### PR TITLE
feat(core): send prHeadCommit at build creation

### DIFF
--- a/packages/core/src/api-client.ts
+++ b/packages/core/src/api-client.ts
@@ -14,6 +14,7 @@ export interface CreateBuildInput {
   parallel?: boolean | null;
   parallelNonce?: string | null;
   prNumber?: number | null;
+  prHeadCommit?: string | null;
 }
 
 export interface CreateBuildOutput {

--- a/packages/core/src/ci-environment/env-ci.ts
+++ b/packages/core/src/ci-environment/env-ci.ts
@@ -18,8 +18,19 @@ export const getCiEnvironmentFromEnvCi = (
   const jobId = ciContext.job ?? null;
   const runId = null;
   const prNumber = null;
+  const prHeadCommit = null;
 
   return commit
-    ? { name, commit, branch, owner, repository, jobId, runId, prNumber }
+    ? {
+        name,
+        commit,
+        branch,
+        owner,
+        repository,
+        jobId,
+        runId,
+        prNumber,
+        prHeadCommit,
+      }
     : null;
 };

--- a/packages/core/src/ci-environment/services/buildkite.ts
+++ b/packages/core/src/ci-environment/services/buildkite.ts
@@ -16,6 +16,7 @@ const service: Service = {
       prNumber: env.BUILDKITE_PULL_REQUEST
         ? Number(env.BUILDKITE_PULL_REQUEST)
         : null,
+      prHeadCommit: null,
     };
   },
 };

--- a/packages/core/src/ci-environment/services/circleci.ts
+++ b/packages/core/src/ci-environment/services/circleci.ts
@@ -22,6 +22,7 @@ const service: Service = {
       jobId: null,
       runId: null,
       prNumber: getPrNumber({ env }),
+      prHeadCommit: null,
     };
   },
 };

--- a/packages/core/src/ci-environment/services/github-actions.ts
+++ b/packages/core/src/ci-environment/services/github-actions.ts
@@ -42,13 +42,14 @@ const service: Service = {
   config: ({ env }) => {
     const payload = readEventPayload({ env });
     return {
-      commit: payload?.pull_request?.head.sha || process.env.GITHUB_SHA || null,
+      commit: process.env.GITHUB_SHA || null,
       branch: payload?.pull_request?.head.ref || getBranch({ env }) || null,
       owner: env.GITHUB_REPOSITORY_OWNER || null,
       repository: getRepository({ env }),
       jobId: env.GITHUB_JOB || null,
       runId: env.GITHUB_RUN_ID || null,
       prNumber: payload?.pull_request?.number || null,
+      prHeadCommit: payload?.pull_request?.head.sha ?? null,
     };
   },
 };

--- a/packages/core/src/ci-environment/services/heroku.ts
+++ b/packages/core/src/ci-environment/services/heroku.ts
@@ -11,6 +11,7 @@ const service: Service = {
     jobId: null,
     runId: null,
     prNumber: null,
+    prHeadCommit: null,
   }),
 };
 

--- a/packages/core/src/ci-environment/services/travis.ts
+++ b/packages/core/src/ci-environment/services/travis.ts
@@ -29,6 +29,7 @@ const service: Service = {
       jobId: null,
       runId: null,
       prNumber: getPrNumber(ctx),
+      prHeadCommit: null,
     };
   },
 };

--- a/packages/core/src/ci-environment/types.ts
+++ b/packages/core/src/ci-environment/types.ts
@@ -15,6 +15,7 @@ export interface CiEnvironment {
   jobId: string | null;
   runId: string | null;
   prNumber: number | null;
+  prHeadCommit: string | null;
 }
 
 export interface Service {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -60,6 +60,12 @@ const schema = {
     default: null,
     nullable: true,
   },
+  prHeadCommit: {
+    env: "ARGOS_PR_HEAD_COMMIT",
+    format: String,
+    default: null,
+    nullable: true,
+  },
   parallel: {
     env: "ARGOS_PARALLEL",
     default: false,
@@ -118,6 +124,7 @@ export interface Config {
   jobId: string | null;
   runId: string | null;
   prNumber: number | null;
+  prHeadCommit: string | null;
 }
 
 export const createConfig = () => {

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -56,6 +56,7 @@ const getConfigFromOptions = (options: UploadParameters) => {
     buildName: config.get("buildName") ?? options.buildName ?? null,
     prNumber:
       config.get("prNumber") ?? options.prNumber ?? ciEnv?.prNumber ?? null,
+    prHeadCommit: config.get("prHeadCommit") ?? ciEnv?.prHeadCommit ?? null,
     ciService: ciEnv?.name ?? null,
     owner: ciEnv?.owner ?? null,
     repository: ciEnv?.repository ?? null,
@@ -121,6 +122,7 @@ export const upload = async (params: UploadParameters) => {
       new Set(screenshots.map((screenshot) => screenshot.hash))
     ),
     prNumber: config.prNumber,
+    prHeadCommit: config.prHeadCommit,
   });
 
   debug("Got screenshots", result);


### PR DESCRIPTION
In this PR, we add a `prHeadCommit` sends from GitHub Actions.

Now `commit` is `$GITHUB_SHA` and we also send the `prHeadCommit` to be displayed in UI. 

https://github.com/argos-ci/argos/pull/944 must be merged first.

Closes #50
