### PR TITLE
feat(gitlab): support gitlab ci

### DIFF
--- a/packages/core/src/ci-environment/index.ts
+++ b/packages/core/src/ci-environment/index.ts
@@ -3,13 +3,14 @@ import heroku from "./services/heroku";
 import githubActions from "./services/github-actions";
 import circleci from "./services/circleci";
 import travis from "./services/travis";
+import gitlab from "./services/gitlab";
 import type { CiEnvironment, Options } from "./types";
 import { debug } from "../debug";
 import { getCiEnvironmentFromEnvCi } from "./env-ci";
 
 export { CiEnvironment };
 
-const services = [heroku, githubActions, circleci, travis, buildkite];
+const services = [heroku, githubActions, circleci, travis, buildkite, gitlab];
 
 export const getCiEnvironment = ({
   env = process.env,

--- a/packages/core/src/ci-environment/services/gitlab.ts
+++ b/packages/core/src/ci-environment/services/gitlab.ts
@@ -1,0 +1,20 @@
+import type { Service } from "../types";
+
+const service: Service = {
+  name: "GitLab",
+  detect: ({ env }) => env.GITLAB_CI === "true",
+  config: ({ env }) => {
+    return {
+      commit: env.CI_COMMIT_SHA || null,
+      branch: env.CI_COMMIT_REF_NAME || null,
+      owner: null,
+      repository: null,
+      jobId: null,
+      runId: null,
+      prNumber: null,
+      prHeadCommit: null,
+    };
+  },
+};
+
+export default service;


### PR DESCRIPTION
We were using env-ci package for GitLab, however, the information is not accurate. In a PR it does not give the branch but the PR target branch.

[`env-ci`](https://github.com/semantic-release/env-ci/blob/7fb0980197ad55ce274370de0ee9440da0ec86f2/services/gitlab.js#L20-L22)

I fixed it by adding a custom service. Also on GitLab we don't have to set repo, pr, etc... all of that is for GitHub. To support that, it is part of supporting tokenless.
