### PR TITLE
Fix Cypress `require.resolve` issue

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -31,7 +31,7 @@ declare global {
 
 function injectArgos() {
   const fileName =
-    typeof require?.resolve === "function"
+    typeof require.resolve === "function"
       ? require.resolve("@argos-ci/browser/global.js")
       : "node_modules/@argos-ci/browser/dist/global.js";
   cy.readFile<string>(fileName).then((source) =>
@@ -43,7 +43,7 @@ function injectArgos() {
 
 function readArgosCypressVersion() {
   const fileName =
-    typeof require?.resolve === "function"
+    typeof require.resolve === "function"
       ? require.resolve("@argos-ci/cypress/package.json")
       : "node_modules/@argos-ci/cypress/package.json";
   return cy.readFile(fileName).then((source) => {

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -42,7 +42,10 @@ function injectArgos() {
 }
 
 function readArgosCypressVersion() {
-  const fileName = require.resolve("@argos-ci/cypress/package.json");
+  const fileName =
+    typeof require?.resolve === "function"
+      ? require.resolve("@argos-ci/cypress/package.json")
+      : "node_modules/@argos-ci/cypress/package.json";
   return cy.readFile(fileName).then((source) => {
     return source.version;
   });


### PR DESCRIPTION
## Description

Screenshot command fails when trying to read `package.json`. If bundler is loading via type `module` then `require.resolve` will fail and should fallback to hard-coded string path to `node_modules` like in `injectArgos`.

## Type of changes

`bug`

## Checklist

Valid all before asking for a code review to `argos-ci/code` :

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [n/a] I have added tests if needed

Optional checks:

- [n/a] My changes requires a change to the documentation
- [n/a] I have updated the documentation accordingly

