### PR TITLE
docs: precise `fullPage` behaviour

### DIFF
--- a/packages/playwright/docs/index.mdx
+++ b/packages/playwright/docs/index.mdx
@@ -42,6 +42,8 @@ Please refer to our [Quickstart guide](/quickstart/playwright) to get started wi
 - `options.viewports`: Define specific viewports for capturing screenshots. More on [viewports configuration](/viewports).
 - `options.argosCSS`: Specific CSS applied during the screenshot process. More on [injecting CSS](/injecting-css)
 
+Unlike [Playwright's `screenshot` method](https://playwright.dev/docs/api/class-page#page-screenshot), set `fullPage` option to `true` by default. Feel free to override this option if you prefer partial screenshots of your pages.
+
 ### Argos Reporter
 
 The Argos reporter offers extensive configuration options. Specifically, all [upload parameters](https://js-sdk-reference.argos-ci.com/interfaces/uploadparameters) are available for customizing the reporter.

--- a/packages/puppeteer/docs/index.mdx
+++ b/packages/puppeteer/docs/index.mdx
@@ -57,6 +57,8 @@ Screenshots are stored in `screenshots/argos` folder, relative to current direct
 - `options.viewports` - Specifies the viewports for which to capture screenshots. See [viewports configuration](/viewports).
 - `options.argosCSS`: Specific CSS applied during the screenshot process. More on [injecting CSS](/injecting-css)
 
+Unlike [Puppeteer's `screenshot` method](https://playwright.dev/docs/api/class-page#page-screenshot), `argosScreenshot` set `fullPage` option to `true` by default. Feel free to override this option if you prefer partial screenshots of your pages.
+
 ## Helper Attributes for Visual Testing
 
 For tailored visual testing, the `data-visual-test` attributes provide control over how elements appear in Argos screenshots. This can be especially useful for obscuring or modifying elements with dynamic content, like dates.


### PR DESCRIPTION
The default value of `fullPage` is surcharged by `argosScreenshot`. It's important to make it explicit for users coming from `screenshot` or `toHaveScreenshot`.