### PR TITLE
feat: enable traces for non-failure screenshots

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -45,16 +45,16 @@
   "devDependencies": {
     "@argos-ci/cli": "workspace:*",
     "@types/mocha": "^10.0.6",
-    "@wdio/cli": "^8.35.1",
-    "@wdio/globals": "^8.35.1",
-    "@wdio/local-runner": "^8.35.1",
-    "@wdio/mocha-framework": "^8.35.0",
+    "@wdio/cli": "^8.38.2",
+    "@wdio/globals": "^8.38.2",
+    "@wdio/local-runner": "^8.38.2",
+    "@wdio/mocha-framework": "^8.38.2",
     "@wdio/spec-reporter": "^8.32.4",
     "@wdio/types": "^8.32.4",
-    "chromedriver": "^123.0.1",
+    "chromedriver": "^125.0.3",
     "ts-node": "^10.9.2",
     "wdio-chromedriver-service": "^8.1.1",
-    "webdriverio": "^8.35.1"
+    "webdriverio": "^8.38.2"
   },
   "scripts": {
     "prebuild": "rm -rf dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,17 +271,17 @@ importers:
         specifier: ^10.0.6
         version: 10.0.6
       '@wdio/cli':
-        specifier: ^8.35.1
-        version: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+        specifier: ^8.38.2
+        version: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
       '@wdio/globals':
-        specifier: ^8.35.1
-        version: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+        specifier: ^8.38.2
+        version: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
       '@wdio/local-runner':
-        specifier: ^8.35.1
-        version: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+        specifier: ^8.38.2
+        version: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
       '@wdio/mocha-framework':
-        specifier: ^8.35.0
-        version: 8.35.0
+        specifier: ^8.38.2
+        version: 8.38.2
       '@wdio/spec-reporter':
         specifier: ^8.32.4
         version: 8.32.4
@@ -289,17 +289,17 @@ importers:
         specifier: ^8.32.4
         version: 8.32.4
       chromedriver:
-        specifier: ^123.0.1
-        version: 123.0.1
+        specifier: ^125.0.3
+        version: 125.0.3
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.17)(@types/node@20.12.8)(typescript@5.4.5)
       wdio-chromedriver-service:
         specifier: ^8.1.1
-        version: 8.1.1(@wdio/types@8.32.4)(chromedriver@123.0.1)(webdriverio@8.35.1(encoding@0.1.13)(typescript@5.4.5))
+        version: 8.1.1(@wdio/types@8.32.4)(chromedriver@125.0.3)(webdriverio@8.38.2(encoding@0.1.13)(typescript@5.4.5))
       webdriverio:
-        specifier: ^8.35.1
-        version: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+        specifier: ^8.38.2
+        version: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
 
 packages:
 
@@ -1825,9 +1825,6 @@ packages:
   '@vitest/runner@1.6.0':
     resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
 
-  '@vitest/snapshot@1.4.0':
-    resolution: {integrity: sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==}
-
   '@vitest/snapshot@1.6.0':
     resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
 
@@ -1837,21 +1834,21 @@ packages:
   '@vitest/utils@1.6.0':
     resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
 
-  '@wdio/cli@8.35.1':
-    resolution: {integrity: sha512-cdFmd6P/eQJdP2lChQ+Fa9b1c2p0bDIPmetVHGCuHiW8ZPkanrvBFtHMUhMu44a1koni9LvN/hu7vIJ/aAC+Rg==}
+  '@wdio/cli@8.38.2':
+    resolution: {integrity: sha512-p9y6jxmpmw53OoB9v/uTLwMetmz7Q0K7NewdVONgmeTY/ERpkU15qL3fMw1rXb+E+vrV8dlce4srnXroec6SFA==}
     engines: {node: ^16.13 || >=18}
     hasBin: true
 
-  '@wdio/config@8.35.0':
-    resolution: {integrity: sha512-I36sBPMl/+LCyQ3Pwb8gGQM6KxwmUfhOPp16TxN21Qo/Bc0fZfyGIg6KevmRu4DuqpGUm5MMVSfyPhLUkMk3Cg==}
+  '@wdio/config@8.38.2':
+    resolution: {integrity: sha512-xlnapTr1vOA0h5HsHTIqj47729FbG3WjxmgHweDEQvcT4C1g9l+WKf+N3FM7DNNoIsAqxKi6rOHG02rJADQJtw==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/globals@8.35.1':
-    resolution: {integrity: sha512-T3IUFcKXRU9WWleAV72DGFWUiXSSr8SBvpc2cUJrvZ5Je9R2gEsrts5eHCY7amXtfeylfMgy5EayGMajgcna6A==}
+  '@wdio/globals@8.38.2':
+    resolution: {integrity: sha512-iIrUF1EODfHLh3V/CSNCqbNNxUTe3ND+c86zDjzJcPFjawLX1plvAApsU/eDmtsFShcOS2KHbfSjiydFoqQG1Q==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/local-runner@8.35.1':
-    resolution: {integrity: sha512-PG+bADoY5VoWPmAfRi030rtxbFj68MVPlcwEN0dN1lDdYKz1ATzzGUK12sqCgGz1ktcC7sQzmJZVBklzbvn3mQ==}
+  '@wdio/local-runner@8.38.2':
+    resolution: {integrity: sha512-syW+R5VUHJ3GBkQGFcNYe6MYwWRgklc9W7A83xQDTvKWFNHCetLvc8AtKZ54vs8MItBejjU+Oh94ZNbNX1pBcg==}
     engines: {node: ^16.13 || >=18}
 
   '@wdio/logger@8.24.12':
@@ -1862,12 +1859,16 @@ packages:
     resolution: {integrity: sha512-/s6zNCqwy1hoc+K4SJypis0Ud0dlJ+urOelJFO1x0G0rwDRWyFiUP6ijTaCcFxAm29jYEcEPWijl2xkVIHwOyA==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/mocha-framework@8.35.0':
-    resolution: {integrity: sha512-riO3aMgvGdFFRMpyMk5m480V+mi5EcKk6cjT1TB9L5XEN7Mo/8qthBw9CLgFCZkr4KlR40hgPKSZFHE0rH2GpQ==}
+  '@wdio/logger@8.38.0':
+    resolution: {integrity: sha512-kcHL86RmNbcQP+Gq/vQUGlArfU6IIcbbnNp32rRIraitomZow+iEoc519rdQmSVusDozMS5DZthkgDdxK+vz6Q==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/protocols@8.32.0':
-    resolution: {integrity: sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q==}
+  '@wdio/mocha-framework@8.38.2':
+    resolution: {integrity: sha512-qJmRL5E6/ypjCUACH4hvCAAmTdU4YUrUlp9o/IKvTIAHMnZPE0/HgUFixCeu8Mop+rdzTPVBrbqxpRDdSnraYA==}
+    engines: {node: ^16.13 || >=18}
+
+  '@wdio/protocols@8.38.0':
+    resolution: {integrity: sha512-7BPi7aXwUtnXZPeWJRmnCNFjyDvGrXlBmN9D4Pi58nILkyjVRQKEY9/qv/pcdyB0cvmIvw++Kl/1Lg+RxG++UA==}
 
   '@wdio/repl@8.24.12':
     resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
@@ -1877,8 +1878,8 @@ packages:
     resolution: {integrity: sha512-kZXbyNuZSSpk4kBavDb+ac25ODu9NVZED6WwZafrlMSnBHcDkoMt26Q0Jp3RKUj+FTyuKH0HvfeLrwVkk6QKDw==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/runner@8.35.1':
-    resolution: {integrity: sha512-5F6cbOYeZjF34Vsnycp5JPnDljI52fmyxsV2O/L3h6F2+83YXpbsqBplw/2G24JtIUudV7VOY/38bUicn1OyXg==}
+  '@wdio/runner@8.38.2':
+    resolution: {integrity: sha512-5lPnKSX2BBLI2AbYW+hoGPiEUAJXj8F8I6NC2LaBVzf1CLN+w2HWZ7lUiqS14XT0b5/hlSUX6+JYwUXlDbpuuw==}
     engines: {node: ^16.13 || >=18}
 
   '@wdio/spec-reporter@8.32.4':
@@ -1889,8 +1890,12 @@ packages:
     resolution: {integrity: sha512-pDPGcCvq0MQF8u0sjw9m4aMI2gAKn6vphyBB2+1IxYriL777gbbxd7WQ+PygMBvYVprCYIkLPvhUFwF85WakmA==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/utils@8.35.0':
-    resolution: {integrity: sha512-9KCyn4aS+9tWfthnUkNFVe52AM6QrLGAeIxgGxNlzTAcQGl7jjwdDM7aSK0RjLkWI3a/88DRH21mN/t2LGDmPQ==}
+  '@wdio/types@8.38.2':
+    resolution: {integrity: sha512-+wj1c1OSLdnN4WO5b44Ih4263dTl/eSwMGSI4/pCgIyXIuYQH38JQ+6WRa+c8vJEskUzboq2cSgEQumVZ39ozQ==}
+    engines: {node: ^16.13 || >=18}
+
+  '@wdio/utils@8.38.2':
+    resolution: {integrity: sha512-y5AnBwsGcu/XuCBGCgKmlvKdwEIFyzLA+Cr+denySxY3jbWDONtPUcGaVdFALwsIa5jcIjcATqGmZcCPGnkd7g==}
     engines: {node: ^16.13 || >=18}
 
   '@wessberg/stringutil@1.0.19':
@@ -1903,6 +1908,10 @@ packages:
   '@yarnpkg/parsers@3.0.0-rc.46':
     resolution: {integrity: sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==}
     engines: {node: '>=14.15.0'}
+
+  '@zip.js/zip.js@2.7.45':
+    resolution: {integrity: sha512-Mm2EXF33DJQ/3GWWEWeP1UCqzpQ5+fiMvT3QWspsXY05DyqqxWu7a9awSzU4/spHMHVFrTjani1PR0vprgZpow==}
+    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=16.5.0'}
 
   '@zkochan/js-yaml@0.0.6':
     resolution: {integrity: sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==}
@@ -2357,8 +2366,8 @@ packages:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
 
-  chromedriver@123.0.1:
-    resolution: {integrity: sha512-YQUIP/zdlzDIRCZNCv6rEVDSY4RAxo/tDL0OiGPPuai+z8unRNqJr/9V6XTBypVFyDheXNalKt9QxEqdMPuLAQ==}
+  chromedriver@125.0.3:
+    resolution: {integrity: sha512-Qzuk5Wian2o3EVGjtbz6V/jv+pT/AV9246HbG6kUljZXXjsKZLZxqJC+kHR3qEh/wdv4EJD0YwAOWV72v9hogw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2810,8 +2819,8 @@ packages:
   devtools-protocol@0.0.1262051:
     resolution: {integrity: sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g==}
 
-  devtools-protocol@0.0.1273771:
-    resolution: {integrity: sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og==}
+  devtools-protocol@0.0.1302984:
+    resolution: {integrity: sha512-Rgh2Sk5fUSCtEx4QGH9iwTyECdFPySG2nlz5J8guGh2Wlha6uzSOCq/DCEC8faHlLaMPZJMuZ4ovgcX4LvOkKA==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -2893,17 +2902,12 @@ packages:
     resolution: {integrity: sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==}
     engines: {node: '>=14.0.0'}
 
-  edgedriver@5.3.10:
-    resolution: {integrity: sha512-RFSHYMNtcF1PjaGZCA2rdQQ8hSTLPZgcYgeY1V6dC+tR4NhZXwFAku+8hCbRYh7ZlwKKrTbVu9FwknjFddIuuw==}
+  edgedriver@5.6.0:
+    resolution: {integrity: sha512-IeJXEczG+DNYBIa9gFgVYTqrawlxmc9SUqUsWU2E98jOsO/amA7wzabKOS8Bwgr/3xWoyXCJ6yGFrbFKrilyyQ==}
     hasBin: true
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-
-  ejs@3.1.9:
-    resolution: {integrity: sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
 
@@ -3325,6 +3329,7 @@ packages:
   fstream@1.0.12:
     resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
     engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3445,6 +3450,7 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -3581,10 +3587,6 @@ packages:
     resolution: {integrity: sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  hosted-git-info@7.0.1:
-    resolution: {integrity: sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -3659,6 +3661,9 @@ packages:
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -3912,11 +3917,6 @@ packages:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
 
-  jake@10.8.7:
-    resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   jake@10.9.1:
     resolution: {integrity: sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==}
     engines: {node: '>=10'}
@@ -4168,10 +4168,6 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-parse-even-better-errors@3.0.1:
-    resolution: {integrity: sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -4209,6 +4205,9 @@ packages:
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4257,6 +4256,9 @@ packages:
   libnpmpublish@7.3.0:
     resolution: {integrity: sha512-fHUxw5VJhZCNSls0KLNEG0mCD2PN1i14gH5elGOgiVnU3VgTcRahagYP2LKI1m0tFCJ+XrAm0zVYyF5RCbXzcg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -4395,10 +4397,6 @@ packages:
 
   magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
-    engines: {node: '>=12'}
-
-  magic-string@0.30.9:
-    resolution: {integrity: sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==}
     engines: {node: '>=12'}
 
   make-dir@2.1.0:
@@ -4704,10 +4702,6 @@ packages:
     resolution: {integrity: sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  normalize-package-data@6.0.0:
-    resolution: {integrity: sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
   normalize-package-data@6.0.1:
     resolution: {integrity: sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4953,6 +4947,9 @@ packages:
     resolution: {integrity: sha512-sgvnoUMlkv9xHwDUKjKQFXVyUi8dtJGKp3vg6sYy+TxbDic5RjZCHF3ygv0EJgNRZ2GfRONjlKPUfokJ9lDpwQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5414,6 +5411,7 @@ packages:
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
@@ -6210,12 +6208,12 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  webdriver@8.35.0:
-    resolution: {integrity: sha512-D13EroddIXDqdq3jgO8j6sorgTWqTwEiTqwlDoJizpRIgHGBy+UjkNM7XW1yVcvt8gsD2Dei2LQth2tJEnu5Ng==}
+  webdriver@8.38.2:
+    resolution: {integrity: sha512-NGfjW0BDYwFgOIzeojOcWGn3tYloQdvHr+Y2xKKYVqa9Rs0x1mzlTjU1kWtC4DaV8DltskwaPa7o+s8hTNpuyA==}
     engines: {node: ^16.13 || >=18}
 
-  webdriverio@8.35.1:
-    resolution: {integrity: sha512-YAuKR4JERGiMqCJmm5fEVZ160iiFPyupwALqfXfzrYVcEmKltKPFY/oUCArmi6Uzqd+Sa2Kp9WZtz2Eu1R76JA==}
+  webdriverio@8.38.2:
+    resolution: {integrity: sha512-r09y5UfivyYh5JOzT2SpJJ1zDmQl/R4OTH12opUqkjvp21BibCQm/uu1mrxGy4lzSHljrvqSVrrcGI+6UA1O8w==}
     engines: {node: ^16.13 || >=18}
     peerDependencies:
       devtools: ^8.14.0
@@ -8311,12 +8309,6 @@ snapshots:
       p-limit: 5.0.0
       pathe: 1.1.2
 
-  '@vitest/snapshot@1.4.0':
-    dependencies:
-      magic-string: 0.30.9
-      pathe: 1.1.2
-      pretty-format: 29.7.0
-
   '@vitest/snapshot@1.6.0':
     dependencies:
       magic-string: 0.30.10
@@ -8334,22 +8326,22 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@wdio/cli@8.35.1(encoding@0.1.13)(typescript@5.4.5)':
+  '@wdio/cli@8.38.2(encoding@0.1.13)(typescript@5.4.5)':
     dependencies:
-      '@types/node': 20.12.4
-      '@vitest/snapshot': 1.4.0
-      '@wdio/config': 8.35.0
-      '@wdio/globals': 8.35.1(encoding@0.1.13)(typescript@5.4.5)
-      '@wdio/logger': 8.28.0
-      '@wdio/protocols': 8.32.0
-      '@wdio/types': 8.32.4
-      '@wdio/utils': 8.35.0
+      '@types/node': 20.12.8
+      '@vitest/snapshot': 1.6.0
+      '@wdio/config': 8.38.2
+      '@wdio/globals': 8.38.2(encoding@0.1.13)(typescript@5.4.5)
+      '@wdio/logger': 8.38.0
+      '@wdio/protocols': 8.38.0
+      '@wdio/types': 8.38.2
+      '@wdio/utils': 8.38.2
       async-exit-hook: 2.0.1
       chalk: 5.3.0
       chokidar: 3.6.0
       cli-spinners: 2.9.2
       dotenv: 16.4.5
-      ejs: 3.1.9
+      ejs: 3.1.10
       execa: 8.0.1
       import-meta-resolve: 4.0.0
       inquirer: 9.2.12
@@ -8358,7 +8350,7 @@ snapshots:
       lodash.union: 4.6.0
       read-pkg-up: 10.0.0
       recursive-readdir: 2.2.3
-      webdriverio: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+      webdriverio: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -8368,11 +8360,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@wdio/config@8.35.0':
+  '@wdio/config@8.38.2':
     dependencies:
-      '@wdio/logger': 8.28.0
-      '@wdio/types': 8.32.4
-      '@wdio/utils': 8.35.0
+      '@wdio/logger': 8.38.0
+      '@wdio/types': 8.38.2
+      '@wdio/utils': 8.38.2
       decamelize: 6.0.0
       deepmerge-ts: 5.1.0
       glob: 10.3.12
@@ -8380,10 +8372,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wdio/globals@8.35.1(encoding@0.1.13)(typescript@5.4.5)':
+  '@wdio/globals@8.38.2(encoding@0.1.13)(typescript@5.4.5)':
     optionalDependencies:
       expect-webdriverio: 4.12.2(encoding@0.1.13)(typescript@5.4.5)
-      webdriverio: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+      webdriverio: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
     transitivePeerDependencies:
       - bufferutil
       - devtools
@@ -8392,13 +8384,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@wdio/local-runner@8.35.1(encoding@0.1.13)(typescript@5.4.5)':
+  '@wdio/local-runner@8.38.2(encoding@0.1.13)(typescript@5.4.5)':
     dependencies:
-      '@types/node': 20.12.4
-      '@wdio/logger': 8.28.0
+      '@types/node': 20.12.8
+      '@wdio/logger': 8.38.0
       '@wdio/repl': 8.24.12
-      '@wdio/runner': 8.35.1(encoding@0.1.13)(typescript@5.4.5)
-      '@wdio/types': 8.32.4
+      '@wdio/runner': 8.38.2(encoding@0.1.13)(typescript@5.4.5)
+      '@wdio/types': 8.38.2
       async-exit-hook: 2.0.1
       split2: 4.2.0
       stream-buffers: 3.0.2
@@ -8424,22 +8416,29 @@ snapshots:
       loglevel-plugin-prefix: 0.8.4
       strip-ansi: 7.1.0
 
-  '@wdio/mocha-framework@8.35.0':
+  '@wdio/logger@8.38.0':
+    dependencies:
+      chalk: 5.3.0
+      loglevel: 1.9.1
+      loglevel-plugin-prefix: 0.8.4
+      strip-ansi: 7.1.0
+
+  '@wdio/mocha-framework@8.38.2':
     dependencies:
       '@types/mocha': 10.0.6
-      '@types/node': 20.12.4
-      '@wdio/logger': 8.28.0
-      '@wdio/types': 8.32.4
-      '@wdio/utils': 8.35.0
+      '@types/node': 20.12.8
+      '@wdio/logger': 8.38.0
+      '@wdio/types': 8.38.2
+      '@wdio/utils': 8.38.2
       mocha: 10.4.0
     transitivePeerDependencies:
       - supports-color
 
-  '@wdio/protocols@8.32.0': {}
+  '@wdio/protocols@8.38.0': {}
 
   '@wdio/repl@8.24.12':
     dependencies:
-      '@types/node': 20.12.4
+      '@types/node': 20.12.8
 
   '@wdio/reporter@8.32.4':
     dependencies:
@@ -8449,19 +8448,19 @@ snapshots:
       diff: 5.2.0
       object-inspect: 1.13.1
 
-  '@wdio/runner@8.35.1(encoding@0.1.13)(typescript@5.4.5)':
+  '@wdio/runner@8.38.2(encoding@0.1.13)(typescript@5.4.5)':
     dependencies:
-      '@types/node': 20.12.4
-      '@wdio/config': 8.35.0
-      '@wdio/globals': 8.35.1(encoding@0.1.13)(typescript@5.4.5)
-      '@wdio/logger': 8.28.0
-      '@wdio/types': 8.32.4
-      '@wdio/utils': 8.35.0
+      '@types/node': 20.12.8
+      '@wdio/config': 8.38.2
+      '@wdio/globals': 8.38.2(encoding@0.1.13)(typescript@5.4.5)
+      '@wdio/logger': 8.38.0
+      '@wdio/types': 8.38.2
+      '@wdio/utils': 8.38.2
       deepmerge-ts: 5.1.0
       expect-webdriverio: 4.12.2(encoding@0.1.13)(typescript@5.4.5)
       gaze: 1.1.3
-      webdriver: 8.35.0
-      webdriverio: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+      webdriver: 8.38.2
+      webdriverio: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
     transitivePeerDependencies:
       - bufferutil
       - devtools
@@ -8482,14 +8481,18 @@ snapshots:
     dependencies:
       '@types/node': 20.12.4
 
-  '@wdio/utils@8.35.0':
+  '@wdio/types@8.38.2':
+    dependencies:
+      '@types/node': 20.12.8
+
+  '@wdio/utils@8.38.2':
     dependencies:
       '@puppeteer/browsers': 1.9.1
-      '@wdio/logger': 8.28.0
-      '@wdio/types': 8.32.4
+      '@wdio/logger': 8.38.0
+      '@wdio/types': 8.38.2
       decamelize: 6.0.0
       deepmerge-ts: 5.1.0
-      edgedriver: 5.3.10
+      edgedriver: 5.6.0
       geckodriver: 4.3.3
       get-port: 7.1.0
       import-meta-resolve: 4.0.0
@@ -8508,6 +8511,8 @@ snapshots:
     dependencies:
       js-yaml: 3.14.1
       tslib: 2.6.2
+
+  '@zip.js/zip.js@2.7.45': {}
 
   '@zkochan/js-yaml@0.0.6':
     dependencies:
@@ -9046,7 +9051,7 @@ snapshots:
 
   chownr@2.0.0: {}
 
-  chromedriver@123.0.1:
+  chromedriver@125.0.3:
     dependencies:
       '@testim/chrome-version': 1.1.4
       axios: 1.6.8(debug@4.3.4)
@@ -9517,7 +9522,7 @@ snapshots:
 
   devtools-protocol@0.0.1262051: {}
 
-  devtools-protocol@0.0.1273771: {}
+  devtools-protocol@0.0.1302984: {}
 
   diff-sequences@29.6.3: {}
 
@@ -9593,22 +9598,18 @@ snapshots:
       '@types/which': 2.0.2
       which: 2.0.2
 
-  edgedriver@5.3.10:
+  edgedriver@5.6.0:
     dependencies:
-      '@wdio/logger': 8.28.0
+      '@wdio/logger': 8.38.0
+      '@zip.js/zip.js': 2.7.45
       decamelize: 6.0.0
       edge-paths: 3.0.5
       node-fetch: 3.3.2
-      unzipper: 0.10.14
       which: 4.0.0
 
   ejs@3.1.10:
     dependencies:
       jake: 10.9.1
-
-  ejs@3.1.9:
-    dependencies:
-      jake: 10.8.7
 
   electron-to-chromium@1.4.551: {}
 
@@ -9913,14 +9914,14 @@ snapshots:
 
   expect-webdriverio@4.12.2(encoding@0.1.13)(typescript@5.4.5):
     dependencies:
-      '@vitest/snapshot': 1.4.0
+      '@vitest/snapshot': 1.6.0
       expect: 29.7.0
       jest-matcher-utils: 29.7.0
       lodash.isequal: 4.5.0
     optionalDependencies:
-      '@wdio/globals': 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+      '@wdio/globals': 8.38.2(encoding@0.1.13)(typescript@5.4.5)
       '@wdio/logger': 8.28.0
-      webdriverio: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+      webdriverio: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
     transitivePeerDependencies:
       - bufferutil
       - devtools
@@ -10182,7 +10183,7 @@ snapshots:
 
   geckodriver@4.3.3:
     dependencies:
-      '@wdio/logger': 8.28.0
+      '@wdio/logger': 8.38.0
       decamelize: 6.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.4
@@ -10303,7 +10304,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.8
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -10455,10 +10456,6 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
-  hosted-git-info@7.0.1:
-    dependencies:
-      lru-cache: 10.2.0
-
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.2.2
@@ -10544,6 +10541,8 @@ snapshots:
       minimatch: 9.0.4
 
   ignore@5.3.1: {}
+
+  immediate@3.0.6: {}
 
   import-fresh@3.3.0:
     dependencies:
@@ -10794,13 +10793,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jake@10.8.7:
-    dependencies:
-      async: 3.2.5
-      chalk: 4.1.2
-      filelist: 1.0.4
-      minimatch: 3.1.2
 
   jake@10.9.1:
     dependencies:
@@ -11379,8 +11371,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-parse-even-better-errors@3.0.1: {}
-
   json-parse-even-better-errors@3.0.2: {}
 
   json-schema-traverse@0.4.1: {}
@@ -11411,6 +11401,13 @@ snapshots:
       extsprintf: 1.3.0
       json-schema: 0.4.0
       verror: 1.10.0
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
 
   keyv@4.5.4:
     dependencies:
@@ -11543,6 +11540,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
   lines-and-columns@1.2.4: {}
 
   lines-and-columns@2.0.4: {}
@@ -11674,10 +11675,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.4.15
 
   magic-string@0.30.5:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-
-  magic-string@0.30.9:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
@@ -12026,13 +12023,6 @@ snapshots:
   normalize-package-data@5.0.0:
     dependencies:
       hosted-git-info: 6.1.1
-      is-core-module: 2.13.1
-      semver: 7.6.0
-      validate-npm-package-license: 3.0.4
-
-  normalize-package-data@6.0.0:
-    dependencies:
-      hosted-git-info: 7.0.1
       is-core-module: 2.13.1
       semver: 7.6.0
       validate-npm-package-license: 3.0.4
@@ -12398,6 +12388,8 @@ snapshots:
       - bluebird
       - supports-color
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -12418,7 +12410,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.24.2
       error-ex: 1.3.2
-      json-parse-even-better-errors: 3.0.1
+      json-parse-even-better-errors: 3.0.2
       lines-and-columns: 2.0.4
       type-fest: 3.13.1
 
@@ -12752,7 +12744,7 @@ snapshots:
   read-pkg@8.1.0:
     dependencies:
       '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 6.0.0
+      normalize-package-data: 6.0.1
       parse-json: 7.1.1
       type-fest: 4.15.0
 
@@ -13732,30 +13724,30 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  wdio-chromedriver-service@8.1.1(@wdio/types@8.32.4)(chromedriver@123.0.1)(webdriverio@8.35.1(encoding@0.1.13)(typescript@5.4.5)):
+  wdio-chromedriver-service@8.1.1(@wdio/types@8.32.4)(chromedriver@125.0.3)(webdriverio@8.38.2(encoding@0.1.13)(typescript@5.4.5)):
     dependencies:
       '@wdio/logger': 8.24.12
       fs-extra: 11.1.1
       split2: 4.2.0
       tcp-port-used: 1.0.2
-      webdriverio: 8.35.1(encoding@0.1.13)(typescript@5.4.5)
+      webdriverio: 8.38.2(encoding@0.1.13)(typescript@5.4.5)
     optionalDependencies:
       '@wdio/types': 8.32.4
-      chromedriver: 123.0.1
+      chromedriver: 125.0.3
     transitivePeerDependencies:
       - supports-color
 
   web-streams-polyfill@3.3.3: {}
 
-  webdriver@8.35.0:
+  webdriver@8.38.2:
     dependencies:
-      '@types/node': 20.12.4
+      '@types/node': 20.12.8
       '@types/ws': 8.5.10
-      '@wdio/config': 8.35.0
-      '@wdio/logger': 8.28.0
-      '@wdio/protocols': 8.32.0
-      '@wdio/types': 8.32.4
-      '@wdio/utils': 8.35.0
+      '@wdio/config': 8.38.2
+      '@wdio/logger': 8.38.0
+      '@wdio/protocols': 8.38.0
+      '@wdio/types': 8.38.2
+      '@wdio/utils': 8.38.2
       deepmerge-ts: 5.1.0
       got: 12.6.1
       ky: 0.33.3
@@ -13765,23 +13757,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@8.35.1(encoding@0.1.13)(typescript@5.4.5):
+  webdriverio@8.38.2(encoding@0.1.13)(typescript@5.4.5):
     dependencies:
-      '@types/node': 20.12.4
-      '@wdio/config': 8.35.0
-      '@wdio/logger': 8.28.0
-      '@wdio/protocols': 8.32.0
+      '@types/node': 20.12.8
+      '@wdio/config': 8.38.2
+      '@wdio/logger': 8.38.0
+      '@wdio/protocols': 8.38.0
       '@wdio/repl': 8.24.12
-      '@wdio/types': 8.32.4
-      '@wdio/utils': 8.35.0
+      '@wdio/types': 8.38.2
+      '@wdio/utils': 8.38.2
       archiver: 7.0.1
       aria-query: 5.3.0
       css-shorthand-properties: 1.1.1
       css-value: 0.0.1
-      devtools-protocol: 0.0.1273771
+      devtools-protocol: 0.0.1302984
       grapheme-splitter: 1.0.4
       import-meta-resolve: 4.0.0
       is-plain-obj: 4.1.0
+      jszip: 3.10.1
       lodash.clonedeep: 4.5.0
       lodash.zip: 4.2.0
       minimatch: 9.0.4
@@ -13790,7 +13783,7 @@ snapshots:
       resq: 1.11.0
       rgb2hex: 0.2.5
       serialize-error: 11.0.3
-      webdriver: 8.35.0
+      webdriver: 8.38.2
     transitivePeerDependencies:
       - bufferutil
       - encoding


### PR DESCRIPTION
Traces are now attached to all screenshots not only failure screenshots.

It allows to have enhanced visual testing debugging for visual
differences.
