### PR TITLE
feat(playwright): wait for viewport resize

### DIFF
--- a/packages/browser/src/viewport.ts
+++ b/packages/browser/src/viewport.ts
@@ -1,6 +1,6 @@
 export type ViewportOrientation = "portrait" | "landscape";
 
-type ViewportSize = {
+export type ViewportSize = {
   width: number;
   height: number;
 };

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -9,6 +9,7 @@ import type {
   ElementHandle,
   TestInfo,
   Locator,
+  ViewportSize,
 } from "@playwright/test";
 import {
   ViewportOption,
@@ -95,6 +96,19 @@ function getViewportSize(page: Page) {
     throw new Error("Can't take screenshots without a viewport.");
   }
   return viewportSize;
+}
+
+/**
+ * Sets the viewport size and waits for the visual viewport to match the specified dimensions.
+ * @returns A promise that resolves when the viewport size has been successfully set and matched.
+ */
+async function setViewportSize(page: Page, viewportSize: ViewportSize) {
+  await page.setViewportSize(viewportSize);
+  await page.waitForFunction(
+    ({ width, height }) =>
+      window.innerWidth === width && window.innerHeight === height,
+    { width: viewportSize.width, height: viewportSize.height },
+  );
 }
 
 /**
@@ -299,14 +313,14 @@ export async function argosScreenshot(
     // Take screenshots for each viewport
     for (const viewport of viewports) {
       const viewportSize = resolveViewport(viewport);
-      await page.setViewportSize(viewportSize);
+      await setViewportSize(page, viewportSize);
       await stabilizeAndScreenshot(
         getScreenshotName(name, { viewportWidth: viewportSize.width }),
       );
     }
 
     // Restore the original viewport size
-    await page.setViewportSize(originalViewportSize);
+    await setViewportSize(page, originalViewportSize);
   } else {
     await stabilizeAndScreenshot(name);
   }

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -7,6 +7,7 @@ import {
   resolveViewport,
   ArgosGlobal,
   getGlobalScript,
+  ViewportSize,
 } from "@argos-ci/browser";
 import {
   ScreenshotMetadata,
@@ -97,6 +98,20 @@ function checkIsFullPage(options: ArgosScreenshotOptions) {
   return options.fullPage !== undefined
     ? options.fullPage
     : options.element === undefined;
+}
+
+/**
+ * Sets the viewport size and waits for the visual viewport to match the specified dimensions.
+ * @returns A promise that resolves when the viewport size has been successfully set and matched.
+ */
+async function setViewportSize(page: Page, viewportSize: ViewportSize) {
+  await page.setViewport(viewportSize);
+  await page.waitForFunction(
+    ({ width, height }) =>
+      window.innerWidth === width && window.innerHeight === height,
+    {},
+    { width: viewportSize.width, height: viewportSize.height },
+  );
 }
 
 /**
@@ -267,13 +282,13 @@ export async function argosScreenshot(
     // Take screenshots for each viewport
     for (const viewport of viewports) {
       const viewportSize = resolveViewport(viewport);
-      await page.setViewport(viewportSize);
+      await setViewportSize(page, viewportSize);
       await stabilizeAndScreenshot(
         getScreenshotName(name, { viewportWidth: viewportSize.width }),
       );
     }
     // Restore the original viewport
-    await page.setViewport(originalViewport);
+    await setViewportSize(page, originalViewport);
   } else {
     await stabilizeAndScreenshot(name);
   }


### PR DESCRIPTION
**Bug Description**  
The `viewports` option in the Playwright integration caused flaky screenshots because Argos was capturing them before the viewport fully resized. This led to [flaky tests](https://app.argos-ci.com/defacto/front-onboarding/builds/3807/110435367).

**Expected Behavior**  
The viewport should resize to the specified dimensions before any screenshot is taken.

**Fix Explanation**  
The Playwright integration has been updated to wait for the viewport to fully resize before capturing screenshots, resolving the issue of flaky tests.