### PR TITLE
fix: don't modify IFRAME to avoid reloads

### DIFF
--- a/packages/browser/src/global/stabilization.ts
+++ b/packages/browser/src/global/stabilization.ts
@@ -128,7 +128,7 @@ function stabilizeElementPositions(document: Document) {
   const elements = Array.from(document.querySelectorAll("*"));
   elements.forEach((element) => {
     if (!checkIsHTMLElement(element)) return;
-    if (element.tagName === 'IFRAME') return;
+    if (element.tagName === "IFRAME") return;
     const style = window.getComputedStyle(element);
     const position = style.position;
     if (position === "fixed") {

--- a/packages/browser/src/global/stabilization.ts
+++ b/packages/browser/src/global/stabilization.ts
@@ -128,6 +128,7 @@ function stabilizeElementPositions(document: Document) {
   const elements = Array.from(document.querySelectorAll("*"));
   elements.forEach((element) => {
     if (!checkIsHTMLElement(element)) return;
+    if (element.tagName === 'IFRAME') return;
     const style = window.getComputedStyle(element);
     const position = style.position;
     if (position === "fixed") {


### PR DESCRIPTION
## Description

Altering IFRAME element causes playwright to re-render contents while taking screenshot which may result in unstable screenshots.

## Type of changes

bug

## Checklist

Valid all before asking for a code review to `argos-ci/code` :

- [ ] I have read the CONTRIBUTING doc - **I believe the doc is not present in this repo ;)**
- [ ] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [ ] Lint and unit tests pass locally
- [ ] I have added tests if needed

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

*Optional* : Feel free to explain your motivation, share useful information or a feature screenshot.
