### PR TITLE
feat: stabilize image sizes

### DIFF
--- a/packages/cypress/docs/index.mdx
+++ b/packages/cypress/docs/index.mdx
@@ -59,6 +59,7 @@ module.exports = defineConfig({
 - `options.stabilize.ariaBusy`: Wait for the `aria-busy` attribute to be removed from the document. Default to `true`.
 - `options.stabilize.fonts`: Wait for fonts to be loaded. Default to `true`.
 - `options.stabilize.images`: Wait for images to be loaded. Default to `true`.
+- `options.stabilize.imageSizes`: Stabilize all image sizes to avoid glitches. Default to `true`.
 
 ## Helper Attributes for Visual Testing
 

--- a/packages/playwright/docs/index.mdx
+++ b/packages/playwright/docs/index.mdx
@@ -239,6 +239,7 @@ export default defineConfig({
 - `options.stabilize.ariaBusy`: Wait for the `aria-busy` attribute to be removed from the document. Default to `true`.
 - `options.stabilize.fonts`: Wait for fonts to be loaded. Default to `true`.
 - `options.stabilize.images`: Wait for images to be loaded. Default to `true`.
+- `options.stabilize.imageSizes`: Stabilize all image sizes to avoid glitches. Default to `true`.
 - `options.beforeScreenshot`: Run a function before taking the screenshot. When using viewports, this function will run before taking sreenshots on each viewport.
 - `options.afterScreenshot`: Run a function after taking the screenshot. When using viewports, this function will run after taking sreenshots on each viewport.
 

--- a/packages/puppeteer/docs/index.mdx
+++ b/packages/puppeteer/docs/index.mdx
@@ -62,6 +62,7 @@ Screenshots are stored in `screenshots/argos` folder, relative to current direct
 - `options.stabilize.ariaBusy`: Wait for the `aria-busy` attribute to be removed from the document. Default to `true`.
 - `options.stabilize.fonts`: Wait for fonts to be loaded. Default to `true`.
 - `options.stabilize.images`: Wait for images to be loaded. Default to `true`.
+- `options.stabilize.imageSizes`: Stabilize all image sizes to avoid glitches. Default to `true`.
 
 Unlike [Puppeteer's `screenshot` method](https://playwright.dev/docs/api/class-page#page-screenshot), `argosScreenshot` set `fullPage` option to `true` by default. Feel free to override this option if you prefer partial screenshots of your pages.
 


### PR DESCRIPTION
When the viewport is changed, the browser fails to re-calculate the
proper image size. With that new stabilization we ensure images are
stable with `viewports` option.
