### PR TITLE
fix(stabilization): override image busting hash

### DIFF
--- a/packages/browser/src/global/stabilization/plugins/loadImageSrcset.ts
+++ b/packages/browser/src/global/stabilization/plugins/loadImageSrcset.ts
@@ -10,7 +10,7 @@ export const plugin = {
   beforeAll() {
     function addCacheBusterToSrc(src: string) {
       const url = new URL(src, window.location.href);
-      if (!url.hash) {
+      if (!url.hash || url.hash.match(/^#argosBust=\d+$/)) {
         url.hash = `argosBust=${String(Date.now())}`;
       } else {
         url.searchParams.set("argosBust", String(Date.now()));


### PR DESCRIPTION
Override previously set URL hashes for busting images in srcsets.

Follow-up to #202 and fixes #201.