### PR TITLE
Disable `loadImageSrcset` stabilization plugin if the user is not using the `viewports` option

### DIFF
--- a/packages/browser/src/global/stabilization/index.ts
+++ b/packages/browser/src/global/stabilization/index.ts
@@ -1,3 +1,4 @@
+import type { ViewportOption } from "../../viewport";
 import { corePlugins, plugins, type PluginName } from "./plugins";
 
 type Cleanup = () => void;
@@ -35,6 +36,11 @@ export interface RuntimeContext {
    * Is the test running in full page mode?
    */
   fullPage?: boolean;
+
+  /**
+   * Viewports to use for the test.
+   */
+  viewports?: ViewportOption[];
 
   /**
    * Custom CSS to apply to the page before taking a screenshot.

--- a/packages/browser/src/global/stabilization/plugins/loadImageSrcset.ts
+++ b/packages/browser/src/global/stabilization/plugins/loadImageSrcset.ts
@@ -7,7 +7,12 @@ import type { Plugin } from "..";
  */
 export const plugin = {
   name: "loadImageSrcset" as const,
-  beforeAll() {
+  beforeAll(options) {
+    // If the user is not using viewports, do nothing.
+    if (!options.viewports || options.viewports.length === 0) {
+      return undefined;
+    }
+
     function addCacheBusterToSrc(src: string) {
       const url = new URL(src, window.location.href);
       if (!url.hash || url.hash.match(/^#argosBust=\d+$/)) {

--- a/packages/browser/src/global/stabilization/plugins/loadImageSrcset.ts
+++ b/packages/browser/src/global/stabilization/plugins/loadImageSrcset.ts
@@ -7,7 +7,7 @@ import type { Plugin } from "..";
  */
 export const plugin = {
   name: "loadImageSrcset" as const,
-  beforeAll(options) {
+  beforeEach(options) {
     // If the user is not using viewports, do nothing.
     if (!options.viewports || options.viewports.length === 0) {
       return undefined;
@@ -45,14 +45,6 @@ export const plugin = {
       img.setAttribute("srcset", bustSrcset(srcset));
     }
 
-    function handleResize() {
-      Array.from(document.images).forEach(forceSrcsetReload);
-    }
-
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
+    Array.from(document.images).forEach(forceSrcsetReload);
   },
 } satisfies Plugin;

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -87,12 +87,13 @@ function injectArgos() {
 function getStabilizationContext(
   options: ArgosScreenshotOptions,
 ): StabilizationContext {
-  const { argosCSS } = options;
+  const { argosCSS, viewports } = options;
   const fullPage = !options.capture || options.capture === "fullPage";
 
   return {
     fullPage,
     argosCSS,
+    viewports,
     options: options.stabilize,
   };
 }

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -182,8 +182,8 @@ Cypress.Commands.add(
 
     function stabilizeAndScreenshot(name: string) {
       waitForReadiness(options);
-
       const afterEach = beforeEach(options);
+      waitForReadiness(options);
 
       const ref: any = {};
 

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -157,10 +157,11 @@ async function setViewportSize(page: Page, viewportSize: ViewportSize) {
 function getStabilizationContext(
   options: ArgosScreenshotOptions,
 ): StabilizationContext {
-  const { fullPage, argosCSS, stabilize } = options;
+  const { fullPage, argosCSS, stabilize, viewports } = options;
   return {
     fullPage,
     argosCSS,
+    viewports,
     options: stabilize,
   };
 }

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -418,6 +418,7 @@ export async function argosScreenshot(
 
     await waitForReadiness(page, options);
     const afterEach = await beforeEach(page, options);
+    await waitForReadiness(page, options);
 
     await Promise.all([
       handle.screenshot({

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -320,8 +320,8 @@ export async function argosScreenshot(
 
   async function stabilizeAndScreenshot(name: string) {
     await waitForReadiness(page, options);
-
     const afterEach = await beforeEach(page, options);
+    await waitForReadiness(page, options);
 
     const [screenshotPath, metadata] = await Promise.all([
       getScreenshotPath(name),

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -138,12 +138,13 @@ async function setViewportSize(page: Page, viewportSize: ViewportSize) {
 function getStabilizationContext(
   options: ArgosScreenshotOptions,
 ): StabilizationContext {
-  const { argosCSS } = options;
+  const { argosCSS, viewports } = options;
   const fullPage = checkIsFullPage(options);
 
   return {
     fullPage,
     argosCSS,
+    viewports,
     options: options.stabilize,
   };
 }


### PR DESCRIPTION
`loadImageSrcset` plugin is only useful if the user has viewports. If not it's better to disable it because when Playwright takes a fullpage screenshot it triggers a resize event.