### PR TITLE
fix(storybook): fix `fitToContent` behaviour

### DIFF
--- a/packages/storybook/src/vitest-plugin.ts
+++ b/packages/storybook/src/vitest-plugin.ts
@@ -140,9 +140,9 @@ function applyFitToContent(
   const { padding, zoom } = fitToContent;
   return {
     ...options,
-    element: "body > div:nth-child(5)",
+    element: "body",
     argosCSS:
-      `body > div:nth-child(5) { padding: ${padding}px; width: fit-content; height: fit-content; zoom: ${zoom}; }` +
+      `body { padding: ${padding}px; width: fit-content; height: fit-content; min-height: initial; zoom: ${zoom}; }` +
       (options?.argosCSS ?? ""),
   };
 }


### PR DESCRIPTION
Now use `body` instead of a custom element to be more reliable
