### PR TITLE
support argos parallel config in playwright

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -87,9 +87,9 @@ async function getParallelFromConfig(
     );
   }
   return {
-    total: config.shard.total,
+    total: argosConfig.parallelTotal || config.shard.total,
     nonce: argosConfig.parallelNonce,
-    index: config.shard.current,
+    index: argosConfig.parallelIndex ||config.shard.current,
   };
 }
 


### PR DESCRIPTION
## Description

The Argos playwright reporter automatically detects the sharding strategy and sets up an expected number of upload calls based on the playwright sharding config. However, this does not work if we are breaking up e2e tests further by project. For example, this CI workflow:

```
jobs:
  run-tests:
    strategy:
      matrix:
        projectName: ["chrome", "msedge"]
        shard: [1, 2, 3, 4]
        shardTotal: [4]
      steps:
      ...
      - name: Run end to end tests
        run: >
          xvfb-run playwright test
          --project=${{ matrix.projectName }}
          --shard=${{ matrix.shard }}/${{ matrix.shardTotal }}
```

This results in not 4, but 4 times the number of projects. This is convenient since this ensures  different projects aren't mixed up in the same shard, so that dependent auth setup projects are only run once per shard.

This however makes Argos reporter fail because it thinks that there will only be 4 uploads and finalizes the uploads prematurely, causing errors when the other project shards complete:
```
APIError: Build already finalized
    at throwAPIError (file:///home/runner/work/pixiebrix-source/pixiebrix-source/node_modules/@argos-ci/api-client/dist/index.js:30:9)
```

This commit allows teams to configure the Argos env variables in CI directly for the playwright reporter to fix the issue:
```
...
jobs:
  run-tests:
    strategy:
      matrix:
        project: ${{ fromJson(inputs.projects) }}
        projectTotal: [2]
        shard: [1, 2, 3, 4]
        shardTotal: [4]
...
      steps:
...
      - name: Calculate ARGOS variables
        id: argos-env-vars
        run: |
          echo "total=$(( ${{ matrix.shardTotal }} * ${{ matrix.projectTotal }} ))" >> $GITHUB_OUTPUT
          echo "index=$(( ${{ matrix.shard }} + (${{ matrix.project.index }} * ${{ matrix.projectTotal }}) ))" >> $GITHUB_OUTPUT
      - name: Run end to end tests
        env:
          ARGOS_PARALLEL_TOTAL: ${{ steps.argos-env-vars.outputs.total }}
          ARGOS_PARALLEL_INDEX: ${{ steps.argos-env-vars.outputs.index }}
        run: >
          xvfb-run playwright test
          --project=${{ matrix.project.name }}
          --shard=${{ matrix.shard }}/${{matrix.projectTotal}}
```

## Type of changes

`enhancement`

## Checklist

- [X] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [X] Lint and unit tests pass locally
- [ ] I have added tests if needed
  - I don't see a good place to add tests? The playwright test suite passes, but that doesn't seem appropriate to test these changes.

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

For more context see this thread in discord here:
https://discord.com/channels/1001395848489484288/1402298867860377721/1402298867860377721
