### PR TITLE
Allow other playwright reporters to log to console

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -294,6 +294,10 @@ class ArgosReporter implements Reporter {
     }
     return;
   }
+
+  printsToStdio() {
+    return false;
+  }
 }
 
 export default ArgosReporter;


### PR DESCRIPTION
## Description

The Argos playwright reporter was preventing all other playwright reporters from logging to the console. This change fixes the issue (while still letting the reporter log to the console)

Before:
<img width="1144" height="404" alt="Screenshot 2025-08-07 at 10 49 31 AM" src="https://github.com/user-attachments/assets/bac9391d-9fd6-42ef-9ddb-96896419601c" />

After:
<img width="1189" height="1084" alt="Screenshot 2025-08-07 at 10 51 14 AM" src="https://github.com/user-attachments/assets/57ab1254-626e-4d9d-b95c-27e7670195ce" />

## Type of changes

`bug`

## Checklist

Valid all before asking for a code review to `argos-ci/code` :

- [X] I have read the CONTRIBUTING doc
- [X] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [X] Lint and unit tests pass locally
- [ ] I have added tests if needed

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

For context see this thread and this comment specifically:
https://github.com/microsoft/playwright/issues/18945#issuecomment-1322734486

I tried to implement [onStdOut](https://playwright.dev/docs/api/class-reporter#reporter-on-std-out)/[onStdErr](https://playwright.dev/docs/api/class-reporter#reporter-on-std-err) instead, but could not get it to work properly (the output from the other reporters were still not being shown). It seems like the logs are still output to the terminal even with `printsToStdio` set to false, which is interesting

