### PR TITLE
feat: separate skip command

### DIFF
--- a/packages/cli/e2e/skip.js
+++ b/packages/cli/e2e/skip.js
@@ -1,0 +1,14 @@
+import { exec } from "node:child_process";
+
+exec(
+  `node bin/argos-cli.js skip --build-name "argos-cli-e2e-skipped-node-${process.env.NODE_VERSION}-${process.env.OS}"`,
+  (err, stdout, stderr) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+
+    console.log(stdout);
+    console.error(stderr);
+  },
+);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "e2e": "node e2e/upload.js",
+    "e2e": "node e2e/upload.js && node e2e/skip.js",
     "check-types": "tsc",
     "check-format": "prettier --check --ignore-unknown --ignore-path=../../.gitignore --ignore-path=../../.prettierignore .",
     "lint": "eslint ."

--- a/packages/cli/src/commands/finalize.ts
+++ b/packages/cli/src/commands/finalize.ts
@@ -1,20 +1,22 @@
 import ora from "ora";
 import type { Command } from "commander";
 import { finalize } from "@argos-ci/core";
-import { parallelNonce } from "../options";
+import { parallelNonceOption, type ParallelNonceOption } from "../options";
+
+type FinalizeOptions = ParallelNonceOption;
 
 export function finalizeCommand(program: Command) {
   program
     .command("finalize")
     .description("Finalize pending parallel builds")
-    .addOption(parallelNonce)
-    .action(async (options) => {
+    .addOption(parallelNonceOption)
+    .action(async (options: FinalizeOptions) => {
       const spinner = ora("Finalizing builds").start();
       try {
         const result = await finalize({
-          parallel: {
-            nonce: options.parallelNonce,
-          },
+          parallel: options.parallelNonce
+            ? { nonce: options.parallelNonce }
+            : undefined,
         });
         spinner.succeed(
           result.builds.length === 0

--- a/packages/cli/src/commands/skip.ts
+++ b/packages/cli/src/commands/skip.ts
@@ -1,0 +1,35 @@
+import type { Command } from "commander";
+import { skip } from "@argos-ci/core";
+import ora from "ora";
+import {
+  buildNameOption,
+  tokenOption,
+  type BuildNameOption,
+  type TokenOption,
+} from "../options";
+
+type SkipOptions = TokenOption & BuildNameOption;
+
+export function skipCommand(program: Command) {
+  program
+    .command("skip")
+    .description("Mark a build as skipped")
+    .addOption(tokenOption)
+    .addOption(buildNameOption)
+    .action(async (options: SkipOptions) => {
+      const spinner = ora("Creating skipped build").start();
+      try {
+        const result = await skip({
+          token: options.token,
+          buildName: options.buildName,
+        });
+        spinner.succeed(`Build created: ${result.build.url}`);
+      } catch (error) {
+        if (error instanceof Error) {
+          spinner.fail(`Build failed: ${error.message}`);
+          console.error(error.stack);
+        }
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { program } from "commander";
 import { uploadCommand } from "./commands/upload";
 import { finalizeCommand } from "./commands/finalize";
+import { skipCommand } from "./commands/skip";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -18,6 +19,7 @@ program
   .version(pkg.version);
 
 uploadCommand(program);
+skipCommand(program);
 finalizeCommand(program);
 
 if (!process.argv.slice(2).length) {

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -1,6 +1,19 @@
 import { Option } from "commander";
 
-export const parallelNonce = new Option(
+export type ParallelNonceOption = { parallelNonce?: string | undefined };
+export const parallelNonceOption = new Option(
   "--parallel-nonce <string>",
   "A unique ID for this parallel build",
 ).env("ARGOS_PARALLEL_NONCE");
+
+export type TokenOption = { token?: string | undefined };
+export const tokenOption = new Option(
+  "--token <token>",
+  "Repository token",
+).env("ARGOS_TOKEN");
+
+export type BuildNameOption = { buildName?: string | undefined };
+export const buildNameOption = new Option(
+  "--build-name <string>",
+  "Name of the build, in case you want to run multiple Argos builds in a single CI job",
+).env("ARGOS_BUILD_NAME");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./config";
 export * from "./finalize";
 export * from "./upload";
+export * from "./skip";

--- a/packages/core/src/skip.test.ts
+++ b/packages/core/src/skip.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { setupMockServer } from "../mocks/server";
+import { skip } from "./skip";
+
+setupMockServer();
+
+describe("#skip", () => {
+  it("marks the build as skipped", async () => {
+    const result = await skip({
+      branch: "main",
+      apiBaseUrl: "https://api.argos-ci.dev",
+      commit: "f16f980bd17cccfa93a1ae7766727e67950773d0",
+      token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
+    });
+
+    expect(result).toEqual({
+      build: { id: "123", url: "https://app.argos-ci.dev/builds/123" },
+    });
+  });
+});

--- a/packages/core/src/skip.ts
+++ b/packages/core/src/skip.ts
@@ -1,0 +1,63 @@
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { createClient, throwAPIError } from "@argos-ci/api-client";
+import { getConfigFromOptions } from "./config";
+import { getAuthToken } from "./auth";
+import { getArgosCoreSDKIdentifier } from "./version";
+import type { UploadParameters } from "./upload";
+
+type SkipParameters = Pick<
+  UploadParameters,
+  | "apiBaseUrl"
+  | "commit"
+  | "branch"
+  | "token"
+  | "prNumber"
+  | "buildName"
+  | "metadata"
+>;
+
+/**
+ * Mark a build as skipped.
+ */
+export async function skip(
+  params: SkipParameters,
+): Promise<{ build: ArgosAPISchema.components["schemas"]["Build"] }> {
+  const [config, argosSdk] = await Promise.all([
+    getConfigFromOptions(params),
+    getArgosCoreSDKIdentifier(),
+  ]);
+
+  const authToken = getAuthToken(config);
+
+  const apiClient = createClient({
+    baseUrl: config.apiBaseUrl,
+    authToken,
+  });
+
+  const createBuildResponse = await apiClient.POST("/builds", {
+    body: {
+      commit: config.commit,
+      branch: config.branch,
+      name: config.buildName,
+      mode: config.mode,
+      prNumber: config.prNumber,
+      prHeadCommit: config.prHeadCommit,
+      referenceBranch: config.referenceBranch,
+      referenceCommit: config.referenceCommit,
+      argosSdk,
+      ciProvider: config.ciProvider,
+      runId: config.runId,
+      runAttempt: config.runAttempt,
+      skipped: true,
+      screenshotKeys: [],
+      pwTraceKeys: [],
+      parentCommits: [],
+    },
+  });
+
+  if (createBuildResponse.error) {
+    throwAPIError(createBuildResponse.error);
+  }
+
+  return { build: createBuildResponse.data.build };
+}

--- a/packages/core/src/upload.test.ts
+++ b/packages/core/src/upload.test.ts
@@ -85,22 +85,6 @@ describe("#upload", () => {
     });
   });
 
-  it("allows to skip", async () => {
-    const result = await upload({
-      branch: "main",
-      apiBaseUrl: "https://api.argos-ci.dev",
-      root: join(__dirname, "../../../__fixtures__/screenshots"),
-      commit: "f16f980bd17cccfa93a1ae7766727e67950773d0",
-      token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
-      skipped: true,
-    });
-
-    expect(result).toEqual({
-      build: { id: "123", url: "https://app.argos-ci.dev/builds/123" },
-      screenshots: [],
-    });
-  });
-
   it("retries", () => {
     return server.boundary(async () => {
       let reqCount = 0;


### PR DESCRIPTION
BREAKING CHANGE:

- `@argos-ci/cli`: `argos upload --skipped` is now `argos skip`
- `@argos-ci/core`: `upload` no longer accepts `skipped` option, a new
  `skip` method has been added instead
