### PR TITLE
fix(cypress): correct ESM `/task` import

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -34,7 +34,7 @@
     },
     "./task": {
       "types": "./dist/task.d.mts",
-      "import": "./dist/task.js",
+      "import": "./dist/task.mjs",
       "require": "./dist/task.cjs",
       "default": "./dist/task.cjs"
     },


### PR DESCRIPTION
## Description

There is no longer a `./dist/task.js` file.

It has been renamed to `./dist/task.mjs` when we upgraded to using `tsdown` in e02526732e6092ea7ae16effe73fbada84049227.

This causes an error when trying to `import('@argos-ci/cypress/task')`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/node/node_modules/@argos-ci/cypress/dist/task.js' imported from /home/node/repl
Did you mean to import @argos-ci/cypress/dist/task.cjs?
    at new NodeError (node:internal/errors:405:5)
    at finalizeResolution (node:internal/modules/esm/resolve:327:11)
    at moduleResolve (node:internal/modules/esm/resolve:980:10)
    at defaultResolve (node:internal/modules/esm/resolve:1193:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:403:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:372:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:249:38)
    at ModuleLoader.import (node:internal/modules/esm/loader:335:34)
    at importModuleDynamically (node:repl:531:47)
    at importModuleDynamicallyWrapper (node:internal/vm/module:429:21) {
  url: 'file:///home/node/node_modules/@argos-ci/cypress/dist/task.js',
  code: 'ERR_MODULE_NOT_FOUND'
}
```

Fixes: e02526732e6092ea7ae16effe73fbada84049227

## Type of changes

Select the correct labels: `bug`, `enhancement` or `documentation`.

I don't think I have permission to label a PR, but this PR fixes a **Bug** :bug:!

## Checklist

Valid all before asking for a code review to `argos-ci/code` :

- [x] I have read the CONTRIBUTING doc
  - I don't think there is one in this repo, but I did read https://github.com/argos-ci/argos/blob/main/CONTRIBUTING.md
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [ ] Lint and unit tests pass locally
  - I've been a bit lazy and just made this PR using GitHub's UI, but considering it's just a 1 byte change, this shouldn't affect anything! 
- [ ] I have added tests if needed

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

I love @argos-ci and you guys are doing a great job :heart:!

Also, if you want to see which files are included in the package, you can see them at: https://www.npmjs.com/package/@argos-ci/cypress/v/6.3.5?activeTab=code

<img width="1211" height="516" alt="image" src="https://github.com/user-attachments/assets/8cf9febd-9694-4cf4-8ece-39f9fa88fbe6" />