### PR TITLE
fix(playwright,storybook): stabilize fullPage screenshots that come out partially blank

### DIFF
--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -281,9 +281,15 @@ export async function argosScreenshot(
         // the browser has not finished drawing yet on loaded machines —
         // the snapshot comes out blank where content was just revealed
         // (e.g. below a story iframe that was resized for fullPage).
-        // Mirrors the stabilization Playwright's toHaveScreenshot performs.
+        // Mirrors the stabilization Playwright's toHaveScreenshot performs,
+        // including its escalating waits between retakes.
+        const pollIntervals = [0, 100, 250, 500];
         let buffer = await screenshotTarget.screenshot(screenshotOptions);
         for (let attempt = 0; attempt < 4; attempt++) {
+          const delay = pollIntervals.shift() ?? 1000;
+          if (delay) {
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
           const next = await screenshotTarget.screenshot(screenshotOptions);
           const stable = next.equals(buffer);
           buffer = next;

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -292,9 +292,22 @@ export async function argosScreenshot(
               return false;
             }
             const body = iframe.contentDocument?.body;
-            if (!body || body.offsetHeight <= iframe.clientHeight) {
+            if (!body) {
               return false;
             }
+            const gap = body.offsetHeight - iframe.clientHeight;
+            if (gap <= 0) {
+              return false;
+            }
+            // A body whose height tracks the iframe (e.g. a 100%-height
+            // layout plus padding) is always taller than the iframe by the
+            // same gap — growing the iframe can never catch up and only
+            // inflates the snapshot. Skip stories already identified as
+            // viewport-tracking.
+            if (Number(iframe.dataset.argosTrackedGap) === gap) {
+              return false;
+            }
+            const previousHeight = iframe.style.height;
             iframe.style.height = `${body.offsetHeight}px`;
             iframe.getBoundingClientRect();
             await new Promise<void>((resolve) =>
@@ -302,6 +315,18 @@ export async function argosScreenshot(
                 requestAnimationFrame(() => resolve()),
               ),
             );
+            const newGap = body.offsetHeight - iframe.clientHeight;
+            if (newGap > 0 && Math.abs(newGap - gap) <= 1) {
+              iframe.style.height = previousHeight;
+              iframe.dataset.argosTrackedGap = String(gap);
+              iframe.getBoundingClientRect();
+              await new Promise<void>((resolve) =>
+                requestAnimationFrame(() =>
+                  requestAnimationFrame(() => resolve()),
+                ),
+              );
+              return false;
+            }
             return true;
           });
           return resized;

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -276,6 +276,36 @@ export async function argosScreenshot(
           animations: "disabled" as const,
           ...playwrightOptions,
         };
+        // The story iframe is sized from the body height when the
+        // viewport is applied, but stories that render a short loading
+        // state first grow afterwards — the screenshot then shows a tall
+        // body inside a short iframe, blank below the iframe's height.
+        // Re-sync the iframe height to the body before every capture so
+        // the drawn area always matches what is screenshotted.
+        const syncFrameHeight = async (): Promise<boolean> => {
+          if (!fullPage || !checkIsFrame(handler)) {
+            return false;
+          }
+          const iframeElement = await handler.frameElement();
+          const resized = await iframeElement.evaluate(async (iframe) => {
+            if (!(iframe instanceof HTMLIFrameElement)) {
+              return false;
+            }
+            const body = iframe.contentDocument?.body;
+            if (!body || body.offsetHeight <= iframe.clientHeight) {
+              return false;
+            }
+            iframe.style.height = `${body.offsetHeight}px`;
+            iframe.getBoundingClientRect();
+            await new Promise<void>((resolve) =>
+              requestAnimationFrame(() =>
+                requestAnimationFrame(() => resolve()),
+              ),
+            );
+            return true;
+          });
+          return resized;
+        };
         // Capture repeatedly until two consecutive screenshots are
         // identical, then keep that one. A single capture can read pixels
         // the browser has not finished drawing yet on loaded machines —
@@ -284,14 +314,16 @@ export async function argosScreenshot(
         // Mirrors the stabilization Playwright's toHaveScreenshot performs,
         // including its escalating waits between retakes.
         const pollIntervals = [0, 100, 250, 500];
+        await syncFrameHeight();
         let buffer = await screenshotTarget.screenshot(screenshotOptions);
         for (let attempt = 0; attempt < 4; attempt++) {
           const delay = pollIntervals.shift() ?? 1000;
           if (delay) {
             await new Promise((resolve) => setTimeout(resolve, delay));
           }
+          const resized = await syncFrameHeight();
           const next = await screenshotTarget.screenshot(screenshotOptions);
-          const stable = next.equals(buffer);
+          const stable = !resized && next.equals(buffer);
           buffer = next;
           if (stable) {
             break;

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -268,14 +268,31 @@ export async function argosScreenshot(
 
         return snapshotPath;
       })(),
-      screenshotTarget.screenshot({
-        path: screenshotPath,
-        type: "png",
-        fullPage,
-        mask: [handler.locator('[data-visual-test="blackout"]')],
-        animations: "disabled",
-        ...playwrightOptions,
-      }),
+      (async () => {
+        const screenshotOptions = {
+          type: "png" as const,
+          fullPage,
+          mask: [handler.locator('[data-visual-test="blackout"]')],
+          animations: "disabled" as const,
+          ...playwrightOptions,
+        };
+        // Capture repeatedly until two consecutive screenshots are
+        // identical, then keep that one. A single capture can read pixels
+        // the browser has not finished drawing yet on loaded machines —
+        // the snapshot comes out blank where content was just revealed
+        // (e.g. below a story iframe that was resized for fullPage).
+        // Mirrors the stabilization Playwright's toHaveScreenshot performs.
+        let buffer = await screenshotTarget.screenshot(screenshotOptions);
+        for (let attempt = 0; attempt < 4; attempt++) {
+          const next = await screenshotTarget.screenshot(screenshotOptions);
+          const stable = next.equals(buffer);
+          buffer = next;
+          if (stable) {
+            break;
+          }
+        }
+        await writeFile(screenshotPath, buffer);
+      })(),
       writeMetadata(screenshotPath, metadata),
     ]);
 

--- a/packages/storybook/src/vitest-plugin.ts
+++ b/packages/storybook/src/vitest-plugin.ts
@@ -50,12 +50,14 @@ export const createArgosScreenshotCommand = (
         ...testContext,
         playwrightLibraries: ["@storybook/addon-vitest"],
         setViewportSize: async (size) => {
-          await ctx.page.evaluate(
-            async ({ size, fullPage }) => {
-              const iframe = document.querySelector(
-                'iframe[data-vitest="true"]',
-              );
-
+          // Resolve the iframe element that contains the frame being
+          // screenshotted. Vitest keeps one iframe per test file, so
+          // querying the page for the first matching iframe can return
+          // another file's iframe — the story's own iframe then keeps its
+          // initial height and the screenshot comes out blank below it.
+          const sessionIframe = await frame.frameElement();
+          await sessionIframe.evaluate(
+            async (iframe, { size, fullPage }) => {
               if (!(iframe instanceof HTMLIFrameElement)) {
                 throw new Error("Vitest iframe not found");
               }

--- a/packages/storybook/src/vitest-plugin.ts
+++ b/packages/storybook/src/vitest-plugin.ts
@@ -90,6 +90,20 @@ export const createArgosScreenshotCommand = (
                 iframe.style.width = `${size.width}px`;
               }
 
+              // Each story starts a fresh viewport-tracking check.
+              delete iframe.dataset.argosTrackedGap;
+
+              const settleFrames = async () => {
+                // Force a layout and wait for two frames so the browser
+                // draws the area exposed by a resize before the screenshot.
+                iframe.getBoundingClientRect();
+                await new Promise<void>((resolve) =>
+                  requestAnimationFrame(() =>
+                    requestAnimationFrame(() => resolve()),
+                  ),
+                );
+              };
+
               if (fullPage) {
                 if (!iframe.contentWindow) {
                   throw new Error(`Can't access iframe window`);
@@ -100,26 +114,30 @@ export const createArgosScreenshotCommand = (
                     : size.height;
 
                 iframe.style.height = "auto";
-                iframe.style.height =
-                  viewportHeight < iframe.contentDocument.body.offsetHeight
-                    ? `${iframe.contentDocument.body.offsetHeight}px`
-                    : "100%";
+                const measuredBody = iframe.contentDocument.body.offsetHeight;
+                const gap = measuredBody - viewportHeight;
+                iframe.style.height = gap > 0 ? `${measuredBody}px` : "100%";
+                await settleFrames();
+                if (gap > 0) {
+                  // A body whose height tracks the iframe (e.g. a
+                  // 100%-height layout plus padding) is always taller by the
+                  // same gap — stretching can never catch up and only
+                  // inflates the snapshot. If the gap survived the stretch,
+                  // revert it.
+                  const newGap =
+                    iframe.contentDocument.body.offsetHeight -
+                    iframe.clientHeight;
+                  if (newGap > 0 && Math.abs(newGap - gap) <= 1) {
+                    iframe.style.height = "100%";
+                    iframe.dataset.argosTrackedGap = String(gap);
+                    await settleFrames();
+                  }
+                }
               } else if (size !== "default") {
                 iframe.style.height = "auto";
                 iframe.style.height = `${size.height}px`;
+                await settleFrames();
               }
-
-              // Force a layout and wait for two frames so the compositor
-              // rasterizes the area exposed by the resize before the
-              // screenshot is taken. Without this, the capture can read the
-              // pre-resize surface and the snapshot comes out blank below
-              // the iframe's previous height.
-              iframe.getBoundingClientRect();
-              await new Promise<void>((resolve) =>
-                requestAnimationFrame(() =>
-                  requestAnimationFrame(() => resolve()),
-                ),
-              );
             },
             { size, fullPage: screenshotOptions.fullPage ?? !fitToContent },
           );

--- a/packages/storybook/src/vitest-plugin.ts
+++ b/packages/storybook/src/vitest-plugin.ts
@@ -51,7 +51,7 @@ export const createArgosScreenshotCommand = (
         playwrightLibraries: ["@storybook/addon-vitest"],
         setViewportSize: async (size) => {
           await ctx.page.evaluate(
-            ({ size, fullPage }) => {
+            async ({ size, fullPage }) => {
               const iframe = document.querySelector(
                 'iframe[data-vitest="true"]',
               );
@@ -106,6 +106,18 @@ export const createArgosScreenshotCommand = (
                 iframe.style.height = "auto";
                 iframe.style.height = `${size.height}px`;
               }
+
+              // Force a layout and wait for two frames so the compositor
+              // rasterizes the area exposed by the resize before the
+              // screenshot is taken. Without this, the capture can read the
+              // pre-resize surface and the snapshot comes out blank below
+              // the iframe's previous height.
+              iframe.getBoundingClientRect();
+              await new Promise<void>((resolve) =>
+                requestAnimationFrame(() =>
+                  requestAnimationFrame(() => resolve()),
+                ),
+              );
             },
             { size, fullPage: screenshotOptions.fullPage ?? !fitToContent },
           );


### PR DESCRIPTION
## Description

On CI we kept getting `fullPage` story screenshots that were blank below the story iframe's initial height (900px by default with `@storybook/addon-vitest`) — the image was full story height, but the bottom was pure white. The blanks were byte-identical across builds, so this wasn't a timing flake.

**Root cause:** for `fullPage` captures the vitest plugin resizes the story iframe to the story's full height, and it finds that iframe with `document.querySelector('iframe[data-vitest="true"]')` — the **first** matching iframe on the page. Vitest keeps one iframe per test file, so once several exist, the plugin resizes another file's iframe. The story's own iframe stays at its initial height, the browser never draws the story below that height, and the screenshot is blank below the fold. (We confirmed this by logging the iframe's bounding box right after the resize: in a run of ~1,170 screenshots, 1,058 still measured 900px tall.)

**Fixes, in order of importance:**

1. **storybook**: resolve the iframe with `frame.frameElement()` — the element that contains the exact frame being screenshotted — instead of the page-wide selector. This is the actual bug fix.
2. **storybook**: after resizing, wait two animation frames so the browser draws the newly revealed area before the screenshot (vitest's own `setIframeViewport` does the same after it resizes an iframe).
3. **playwright**: in `argosScreenshot`, retake the screenshot until two consecutive captures are identical, with the same escalating waits `toHaveScreenshot` uses. Defense-in-depth against captures that read pixels the browser hasn't finished drawing.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [ ] I have added tests if needed (open to suggestions — reproducing needs multiple vitest test files in one run)