### PR TITLE
feat(core): allow specifying a project for tokenless authentication

### DIFF
--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -5,14 +5,17 @@ import ora from "ora";
 import {
   buildNameOption,
   parallelNonceOption,
+  projectOption,
   tokenOption,
   type BuildNameOption,
   type ParallelNonceOption,
+  type ProjectOption,
   type TokenOption,
 } from "../options";
 
 type UploadOptions = BuildNameOption &
   ParallelNonceOption &
+  ProjectOption &
   TokenOption & {
     files?: string[] | undefined;
     ignore?: string[] | undefined;
@@ -41,6 +44,7 @@ export function uploadCommand(program: Command) {
       'One or more globs matching image file paths to ignore (ex: "**/*.png **/diff.jpg")',
     )
     .addOption(tokenOption)
+    .addOption(projectOption)
     .addOption(buildNameOption)
     .addOption(
       new Option(
@@ -117,6 +121,7 @@ export function uploadCommand(program: Command) {
         })();
         const result = await upload({
           token: options.token,
+          project: options.project,
           root: directory,
           buildName: options.buildName,
           files: options.files,

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -12,6 +12,12 @@ export const tokenOption = new Option(
   "Repository token",
 ).env("ARGOS_TOKEN");
 
+export type ProjectOption = { project?: string | undefined };
+export const projectOption = new Option(
+  "--project <slug>",
+  "Argos project slug (account/project), used to disambiguate tokenless authentication when multiple projects are linked to the same repository",
+).env("ARGOS_PROJECT");
+
 export type BuildNameOption = { buildName?: string | undefined };
 export const buildNameOption = new Option(
   "--build-name <string>",

--- a/packages/core/src/auth.test.ts
+++ b/packages/core/src/auth.test.ts
@@ -17,6 +17,7 @@ const base64Decode = (str: string): unknown =>
 const baseConfig: Config = {
   apiBaseUrl: "https://api.argos-ci.com/v2/",
   token: null,
+  project: null,
   commit: "abc123def456abc123def456abc123def456abc1",
   branch: "main",
   buildName: null,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -126,6 +126,12 @@ const schema = {
     default: null,
     format: mustBeArgosToken,
   },
+  project: {
+    env: "ARGOS_PROJECT",
+    default: null,
+    format: String,
+    nullable: true,
+  },
   buildName: {
     env: "ARGOS_BUILD_NAME",
     default: null,
@@ -278,6 +284,14 @@ export interface Config {
    * Argos repository access token.
    */
   token: string | null;
+
+  /**
+   * Argos project slug used for tokenless authentication.
+   * Useful to disambiguate when multiple Argos projects are linked
+   * to the same repository.
+   * @example "my-org/my-project"
+   */
+  project: string | null;
 
   /**
    * Custom build name.
@@ -433,6 +447,7 @@ export async function readConfig(options: Partial<Config> = {}) {
     commit: options.commit || defaultConfig.commit || ciEnv?.commit || null,
     branch: options.branch || defaultConfig.branch || ciEnv?.branch || null,
     token: options.token || defaultConfig.token || null,
+    project: options.project || defaultConfig.project || null,
     buildName: options.buildName || defaultConfig.buildName || null,
     prNumber:
       options.prNumber || defaultConfig.prNumber || ciEnv?.prNumber || null,

--- a/packages/core/src/github-actions-tokenless.test.ts
+++ b/packages/core/src/github-actions-tokenless.test.ts
@@ -21,6 +21,7 @@ describe("exchangeGitHubActionsTokenlessToken", () => {
     prHeadCommit: null,
     commit: "abc123def456abc123def456abc123def456abc1",
     branch: "main",
+    project: null,
   };
 
   it("builds the tokenless bearer token and exchanges it for an Argos token", async () => {
@@ -106,6 +107,60 @@ describe("exchangeGitHubActionsTokenlessToken", () => {
       runId: "run-42",
       prNumber: 99,
     });
+  });
+
+  it("includes the project slug in the bearer token when set", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    server.use(
+      http.post(
+        "https://api.argos-ci.com/v2/auth/github-actions/tokenless/exchange",
+        async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            token: MOCK_TOKENLESS_ARGOS_TOKEN,
+            expiresAt: MOCK_EXPIRES_AT,
+          });
+        },
+      ),
+    );
+
+    await exchangeGitHubActionsTokenlessToken({
+      apiBaseUrl: "https://api.argos-ci.com/v2/",
+      config: { ...baseConfig, project: "acme/web-app" },
+    });
+
+    const bearer = capturedBody.tokenlessToken as string;
+    const payload = base64Decode(bearer.replace("tokenless-github-", "")) as {
+      project?: string;
+    };
+    expect(payload.project).toBe("acme/web-app");
+  });
+
+  it("omits the project slug from the bearer token when null", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    server.use(
+      http.post(
+        "https://api.argos-ci.com/v2/auth/github-actions/tokenless/exchange",
+        async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            token: MOCK_TOKENLESS_ARGOS_TOKEN,
+            expiresAt: MOCK_EXPIRES_AT,
+          });
+        },
+      ),
+    );
+
+    await exchangeGitHubActionsTokenlessToken({
+      apiBaseUrl: "https://api.argos-ci.com/v2/",
+      config: baseConfig,
+    });
+
+    const bearer = capturedBody.tokenlessToken as string;
+    const payload = base64Decode(bearer.replace("tokenless-github-", "")) as {
+      project?: string;
+    };
+    expect(payload.project).toBeUndefined();
   });
 
   it("omits prNumber from the bearer token when null", async () => {

--- a/packages/core/src/github-actions-tokenless.ts
+++ b/packages/core/src/github-actions-tokenless.ts
@@ -17,9 +17,18 @@ export function isGitHubActionsTokenlessAvailable(
  * Build a tokenless GitHub Actions bearer token from the CI environment.
  */
 function getTokenlessBearerToken(
-  config: Pick<Config, "originalRepository" | "jobId" | "runId" | "prNumber">,
+  config: Pick<
+    Config,
+    "originalRepository" | "jobId" | "runId" | "prNumber" | "project"
+  >,
 ): string {
-  const { originalRepository: repository, jobId, runId, prNumber } = config;
+  const {
+    originalRepository: repository,
+    jobId,
+    runId,
+    prNumber,
+    project,
+  } = config;
 
   if (!repository || !jobId || !runId) {
     throw new Error(
@@ -35,6 +44,7 @@ function getTokenlessBearerToken(
     jobId,
     runId,
     prNumber: prNumber ?? undefined,
+    project: project ?? undefined,
   })}`;
 }
 
@@ -52,6 +62,7 @@ export async function exchangeGitHubActionsTokenlessToken(args: {
     | "branch"
     | "prHeadCommit"
     | "commit"
+    | "project"
   >;
 }): Promise<string> {
   const { apiBaseUrl, config } = args;

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -72,6 +72,13 @@ export interface UploadParameters {
   token?: string;
 
   /**
+   * Argos project slug (`account/project`).
+   * Used to disambiguate tokenless authentication when multiple
+   * Argos projects are linked to the same repository.
+   */
+  project?: string;
+
+  /**
    * Pull request number associated with the build.
    */
   prNumber?: number;


### PR DESCRIPTION
## Summary

Adds support for specifying an Argos **project slug** (`account/project-name`) for tokenless GitHub Actions authentication. This disambiguates which project to use when multiple Argos projects are linked to the same GitHub repository.

This is the client-side counterpart to [argos-ci/argos#2281](https://github.com/argos-ci/argos/pull/2281), which adds the optional `project` field to the tokenless token payload on the backend.

The project can be specified three ways, all resolving to the same config field:

- **SDK option** — `upload({ project: "account/project" })`
- **CLI flag** — `--project <slug>` on the `upload` command
- **Environment variable** — `ARGOS_PROJECT`

Fix ARG-407

## Changes

- `config.ts` — new nullable `project` config field (env `ARGOS_PROJECT`), exposed on the `Config` interface and wired into `readConfig`.
- `github-actions-tokenless.ts` — embeds `project` in the base64 tokenless bearer payload (omitted when null, same as `prNumber`).
- `upload.ts` — `project` added to the public `UploadParameters` SDK interface.
- `cli/options.ts` + `cli/commands/upload.ts` — new `--project` option registered on the `upload` command.
- Tests added for including/omitting the project slug; fixtures updated.

## Test plan

- [x] `pnpm build` (core + cli)
- [x] `pnpm check-types` (core + cli)
- [x] `pnpm test` — 80 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)