### PR TITLE
fix: surface HTTP status and raw body in API errors

### DIFF
--- a/packages/api-client/src/fetch.ts
+++ b/packages/api-client/src/fetch.ts
@@ -19,7 +19,10 @@ export class APIError extends Error {
     message: string,
     options?: { status?: number; data?: unknown; cause?: unknown },
   ) {
-    super(message, options?.cause != null ? { cause: options.cause } : undefined);
+    super(
+      message,
+      options?.cause != null ? { cause: options.cause } : undefined,
+    );
     this.name = "APIError";
     this.status = options?.status;
     this.data = options?.data;

--- a/packages/api-client/src/fetch.ts
+++ b/packages/api-client/src/fetch.ts
@@ -4,8 +4,25 @@ import { debug } from "./debug";
 const DEFAULT_TIMEOUT = 30_000;
 
 export class APIError extends Error {
-  constructor(message: string) {
-    super(message);
+  /**
+   * HTTP status code of the response that triggered the error, when available.
+   */
+  status?: number;
+
+  /**
+   * Raw error payload returned by the API (or the infrastructure in front of
+   * it). Useful when the body does not match the expected error shape.
+   */
+  data?: unknown;
+
+  constructor(
+    message: string,
+    options?: { status?: number; data?: unknown; cause?: unknown },
+  ) {
+    super(message, options?.cause != null ? { cause: options.cause } : undefined);
+    this.name = "APIError";
+    this.status = options?.status;
+    this.data = options?.data;
   }
 }
 

--- a/packages/api-client/src/index.test.ts
+++ b/packages/api-client/src/index.test.ts
@@ -62,15 +62,22 @@ describe("throwAPIError", () => {
       status: 413,
       statusText: "Payload Too Large",
     });
-    try {
-      throwAPIError({}, response);
-      expect.unreachable();
-    } catch (error) {
-      expect(error).toBeInstanceOf(APIError);
-      const apiError = error as APIError;
-      expect(apiError.message).toBe("HTTP 413 Payload Too Large");
-      expect(apiError.status).toBe(413);
-      expect(apiError.data).toEqual({});
-    }
+    const error = getThrownError(() => throwAPIError({}, response));
+    expect(error).toBeInstanceOf(APIError);
+    expect((error as APIError).message).toBe("HTTP 413 Payload Too Large");
+    expect((error as APIError).status).toBe(413);
+    expect((error as APIError).data).toEqual({});
   });
 });
+
+/**
+ * Run `fn` and return the error it throws (fails the test if it doesn't throw).
+ */
+function getThrownError(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected function to throw");
+}

--- a/packages/api-client/src/index.test.ts
+++ b/packages/api-client/src/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { APIError } from "./fetch";
+import { formatAPIError, throwAPIError } from "./index";
+
+describe("formatAPIError", () => {
+  it("formats a structured API error", () => {
+    expect(formatAPIError({ error: "Build not found" })).toBe(
+      "Build not found",
+    );
+  });
+
+  it("appends details when present", () => {
+    expect(
+      formatAPIError({
+        error: "Invalid request",
+        details: [{ message: "commit is required" }],
+      }),
+    ).toBe("Invalid request: commit is required");
+  });
+
+  it("falls back to the HTTP status when the body is empty", () => {
+    const response = new Response(null, {
+      status: 413,
+      statusText: "Payload Too Large",
+    });
+    expect(formatAPIError({}, response)).toBe("HTTP 413 Payload Too Large");
+  });
+
+  it("includes a non-JSON body alongside the status", () => {
+    const response = new Response(null, {
+      status: 502,
+      statusText: "Bad Gateway",
+    });
+    expect(formatAPIError("<html>Bad Gateway</html>", response)).toBe(
+      "HTTP 502 Bad Gateway: <html>Bad Gateway</html>",
+    );
+  });
+
+  it("truncates long raw bodies", () => {
+    const body = "x".repeat(1000);
+    const message = formatAPIError(body);
+    expect(message.endsWith("…")).toBe(true);
+    expect(message.length).toBeLessThan(body.length);
+  });
+
+  it("falls back to a generic message when nothing is available", () => {
+    expect(formatAPIError(undefined)).toBe("Unknown API error");
+    expect(formatAPIError({})).toBe("Unknown API error");
+  });
+
+  it("ignores a malformed error object missing the `error` field", () => {
+    const response = new Response(null, { status: 429 });
+    expect(formatAPIError({ message: "rate limited" }, response)).toBe(
+      'HTTP 429: {"message":"rate limited"}',
+    );
+  });
+});
+
+describe("throwAPIError", () => {
+  it("throws an APIError carrying the status and raw data", () => {
+    const response = new Response(null, {
+      status: 413,
+      statusText: "Payload Too Large",
+    });
+    try {
+      throwAPIError({}, response);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(APIError);
+      const apiError = error as APIError;
+      expect(apiError.message).toBe("HTTP 413 Payload Too Large");
+      expect(apiError.status).toBe(413);
+      expect(apiError.data).toEqual({});
+    }
+  });
+});

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -26,20 +26,103 @@ export function createClient(options?: {
 }
 
 /**
- * Handle API errors.
+ * Maximum length of a raw error body included in the formatted message.
+ * Keeps things readable when the body is an HTML error page or a stack trace.
  */
-export function formatAPIError(error: components["schemas"]["Error"]): string {
-  debug("API error", error);
-  const detailMessage = error.details
-    ?.map((detail) => detail.message)
-    .join(", ");
+const MAX_RAW_BODY_LENGTH = 500;
 
-  return detailMessage ? `${error.error}: ${detailMessage}` : error.error;
+/**
+ * Check whether the value matches the expected API error shape:
+ * `{ error: string, details?: [{ message }] }`.
+ */
+function isStructuredAPIError(
+  error: unknown,
+): error is components["schemas"]["Error"] {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "error" in error &&
+    typeof (error as { error: unknown }).error === "string" &&
+    (error as { error: string }).error.length > 0
+  );
+}
+
+/**
+ * Format the HTTP status of a response, e.g. `HTTP 413 Payload Too Large`.
+ */
+function formatStatus(response: Response | undefined): string | null {
+  if (!response) {
+    return null;
+  }
+  return response.statusText
+    ? `HTTP ${response.status} ${response.statusText}`
+    : `HTTP ${response.status}`;
+}
+
+/**
+ * Format a raw (non-structured) error body so it can be shown to the user.
+ * Returns `null` when there is nothing meaningful to display.
+ */
+function formatRawBody(error: unknown): string | null {
+  if (error == null) {
+    return null;
+  }
+  let text: string;
+  if (typeof error === "string") {
+    text = error;
+  } else {
+    try {
+      text = JSON.stringify(error);
+    } catch {
+      text = String(error);
+    }
+  }
+  const trimmed = text.trim();
+  if (!trimmed || trimmed === "{}") {
+    return null;
+  }
+  return trimmed.length > MAX_RAW_BODY_LENGTH
+    ? `${trimmed.slice(0, MAX_RAW_BODY_LENGTH)}…`
+    : trimmed;
+}
+
+/**
+ * Format an API error into a human-readable message.
+ *
+ * When the body matches the expected `{ error, details }` shape, it is used
+ * directly. Otherwise — empty body, HTML error page, plain text, etc., which
+ * happens when the response comes from infrastructure in front of the API
+ * (proxy, load balancer, CDN, rate limiter) rather than from the API itself —
+ * we fall back to the HTTP status and the raw body so the failure stays
+ * debuggable instead of surfacing an empty message.
+ */
+export function formatAPIError(
+  error: unknown,
+  response?: Response,
+): string {
+  debug("API error", { error, status: response?.status });
+
+  if (isStructuredAPIError(error)) {
+    const detailMessage = error.details
+      ?.map((detail) => detail.message)
+      .join(", ");
+
+    return detailMessage ? `${error.error}: ${detailMessage}` : error.error;
+  }
+
+  const message = [formatStatus(response), formatRawBody(error)]
+    .filter(Boolean)
+    .join(": ");
+
+  return message || "Unknown API error";
 }
 
 /**
  * Handle API errors.
  */
-export function throwAPIError(error: components["schemas"]["Error"]): never {
-  throw new APIError(formatAPIError(error));
+export function throwAPIError(error: unknown, response?: Response): never {
+  throw new APIError(formatAPIError(error, response), {
+    status: response?.status,
+    data: error,
+  });
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -96,10 +96,7 @@ function formatRawBody(error: unknown): string | null {
  * we fall back to the HTTP status and the raw body so the failure stays
  * debuggable instead of surfacing an empty message.
  */
-export function formatAPIError(
-  error: unknown,
-  response?: Response,
-): string {
+export function formatAPIError(error: unknown, response?: Response): string {
   debug("API error", { error, status: response?.status });
 
   if (isStructuredAPIError(error)) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -209,7 +209,7 @@ async function fetchAllDiffs(
       perPage: String(perPage),
       ...(options?.needsReview ? ({ needsReview: true } as const) : {}),
     };
-    const { data, error } = await client.GET(
+    const { data, error, response } = await client.GET(
       "/projects/{owner}/{project}/builds/{buildNumber}/diffs",
       {
         params: {
@@ -225,7 +225,7 @@ async function fetchAllDiffs(
 
     if (error || !data) {
       if (error) {
-        throwAPIError(error);
+        throwAPIError(error, response);
       }
       throw new Error("Unexpected empty response from API.");
     }
@@ -244,10 +244,10 @@ async function fetchAllDiffs(
 async function fetchProject(
   client: ReturnType<typeof createClient>,
 ): Promise<Project> {
-  const { data, error } = await client.GET("/project");
+  const { data, error, response } = await client.GET("/project");
 
   if (error) {
-    throwAPIError(error);
+    throwAPIError(error, response);
   }
 
   if (!data) {
@@ -282,7 +282,7 @@ async function fetchBuildByNumber(
       console.error(`Error: Build number ${errorLabel} not found.`);
       process.exit(1);
     }
-    throwAPIError(error);
+    throwAPIError(error, response);
   }
 
   if (!data) {
@@ -432,7 +432,7 @@ export function buildCommand(program: Command) {
 
         const authToken = await getTokenOrExit(options);
         const client = createClient({ authToken, baseUrl: getAPIBaseURL() });
-        const { data, error } = await client.POST(
+        const { data, error, response } = await client.POST(
           "/projects/{owner}/{project}/builds/{buildNumber}/reviews",
           {
             params: {
@@ -447,7 +447,7 @@ export function buildCommand(program: Command) {
         );
 
         if (error) {
-          const message = formatAPIError(error);
+          const message = formatAPIError(error, response);
           throw new Error(
             [
               `Failed to create review for ${owner}/${project} build #${buildReferenceDetails.buildNumber}: ${message}`,

--- a/packages/core/src/deploy.ts
+++ b/packages/core/src/deploy.ts
@@ -119,7 +119,7 @@ export async function deploy(params: DeployParameters) {
   });
 
   if (createResponse.error) {
-    throwAPIError(createResponse.error);
+    throwAPIError(createResponse.error, createResponse.response);
   }
 
   const { deploymentId, uploadFiles: filesToUpload } = createResponse.data;
@@ -162,7 +162,7 @@ export async function deploy(params: DeployParameters) {
   );
 
   if (finalizeResponse.error) {
-    throwAPIError(finalizeResponse.error);
+    throwAPIError(finalizeResponse.error, finalizeResponse.response);
   }
 
   return finalizeResponse.data;

--- a/packages/core/src/finalize.ts
+++ b/packages/core/src/finalize.ts
@@ -33,7 +33,7 @@ export async function finalize(params: FinalizeParameters) {
   });
 
   if (finalizeBuildsResult.error) {
-    throwAPIError(finalizeBuildsResult.error);
+    throwAPIError(finalizeBuildsResult.error, finalizeBuildsResult.response);
   }
 
   return finalizeBuildsResult.data;

--- a/packages/core/src/github-actions-oidc.ts
+++ b/packages/core/src/github-actions-oidc.ts
@@ -75,7 +75,7 @@ export async function exchangeGitHubActionsOidcToken(args: {
   });
 
   if (result.error) {
-    throwAPIError(result.error);
+    throwAPIError(result.error, result.response);
   }
 
   return result.data.token;

--- a/packages/core/src/github-actions-tokenless.ts
+++ b/packages/core/src/github-actions-tokenless.ts
@@ -84,7 +84,7 @@ export async function exchangeGitHubActionsTokenlessToken(args: {
   );
 
   if (result.error) {
-    throwAPIError(result.error);
+    throwAPIError(result.error, result.response);
   }
 
   return result.data.token;

--- a/packages/core/src/skip.ts
+++ b/packages/core/src/skip.ts
@@ -56,7 +56,7 @@ export async function skip(
   });
 
   if (createBuildResponse.error) {
-    throwAPIError(createBuildResponse.error);
+    throwAPIError(createBuildResponse.error, createBuildResponse.response);
   }
 
   return { build: createBuildResponse.data.build };

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -267,7 +267,7 @@ export async function upload(params: UploadParameters): Promise<{
   debug("Fetch project");
   const projectResponse = await apiClient.GET("/project");
   if (projectResponse.error) {
-    throwAPIError(projectResponse.error);
+    throwAPIError(projectResponse.error, projectResponse.response);
   }
   debug("Project fetched", projectResponse.data);
 
@@ -361,7 +361,7 @@ export async function upload(params: UploadParameters): Promise<{
   });
 
   if (createBuildResponse.error) {
-    throwAPIError(createBuildResponse.error);
+    throwAPIError(createBuildResponse.error, createBuildResponse.response);
   }
 
   const result = createBuildResponse.data;
@@ -425,7 +425,7 @@ export async function upload(params: UploadParameters): Promise<{
   });
 
   if (uploadBuildResponse.error) {
-    throwAPIError(uploadBuildResponse.error);
+    throwAPIError(uploadBuildResponse.error, uploadBuildResponse.response);
   }
 
   return { build: uploadBuildResponse.data.build, screenshots: snapshots };


### PR DESCRIPTION
## Problem

A failed Argos build surfaced an `APIError` with **no message**:

```
❌ Error while creating the Argos build
APIError:
    at throwAPIError (.../@argos-ci/api-client/dist/index.mjs:84:8)
    at upload (.../@argos-ci/core/dist/index.mjs:1542:33)
```

### Root cause

`formatAPIError` returned `error.error`. When the error response body is **not** the expected `{ error: "..." }` JSON shape, `error.error` is `undefined`, so `new APIError(undefined)` produces an empty message.

This happens when the error response does **not** originate from the Argos API itself:
- The API's own `errorHandler` always returns `{ error: message }` with a non-empty message.
- `apiFetch` already turns any 5xx into `"Internal Server Error (status)"`.

So an empty message means a **non-5xx (4xx) response from infrastructure in front of the API** (proxy, load balancer, CDN, rate limiter) returning an empty body or an HTML/plain-text page — e.g. `413 Payload Too Large`, `429`, a WAF `403`, etc. `openapi-fetch` then sets `error` to `{}` or a raw string, neither of which has `.error`.

## Fix

Make the formatter robust so the failure is always debuggable:

- `formatAPIError(error, response?)` keeps the structured `{ error, details }` message when present, otherwise falls back to the **HTTP status** (e.g. `HTTP 413 Payload Too Large`) plus the **raw body** (truncated to 500 chars), and `"Unknown API error"` as a last resort.
- `throwAPIError(error, response?)` now accepts the `response` and attaches `status` + raw `data` to the thrown `APIError`.
- `APIError` carries `status?: number` and `data?: unknown` (and sets `name = "APIError"`).
- Threaded the `response` into every `throwAPIError`/`formatAPIError` call site (core + cli).

The original failure would now read e.g. `APIError: HTTP 413 Payload Too Large` instead of a blank message.

## Tests

Added `packages/api-client/src/index.test.ts` covering structured errors, empty-body status fallback, non-JSON bodies, truncation, and the enriched `APIError`. All api-client tests pass; `check-types` is clean across api-client/core/cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)