### PR TITLE
fix: don't treat empty ARGOS_SUBSET/ARGOS_PARALLEL env as enabled

### DIFF
--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -58,8 +58,8 @@ export function uploadCommand(program: Command) {
     .addOption(
       new Option(
         "--parallel",
-        "Enable parallel mode. Run multiple Argos builds and combine them at the end",
-      ).env("ARGOS_PARALLEL"),
+        "Enable parallel mode. Run multiple Argos builds and combine them at the end.\nCan also be set via the ARGOS_PARALLEL environment variable.",
+      ),
     )
     .addOption(
       new Option(
@@ -95,8 +95,8 @@ export function uploadCommand(program: Command) {
     .addOption(
       new Option(
         "--subset",
-        "Whether this build contains only a subset of screenshots.\nThis is useful when a build is created from an incomplete test suite where some tests are skipped.",
-      ).env("ARGOS_SUBSET"),
+        "Whether this build contains only a subset of screenshots.\nThis is useful when a build is created from an incomplete test suite where some tests are skipped.\nCan also be set via the ARGOS_SUBSET environment variable.",
+      ),
     )
     .action(async (directory: string, options: UploadOptions) => {
       const spinner = ora("Uploading screenshots").start();

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -111,6 +111,24 @@ describe("#readConfig", () => {
     delete process.env.ARGOS_SUBSET;
   });
 
+  it("treats an empty ARGOS_SUBSET as false", async () => {
+    process.env.ARGOS_SUBSET = "";
+    expect((await readDummyConfig()).subset).toBe(false);
+    delete process.env.ARGOS_SUBSET;
+  });
+
+  it("reads parallel from env", async () => {
+    process.env.ARGOS_PARALLEL = "true";
+    expect((await readDummyConfig()).parallel).toBe(true);
+    delete process.env.ARGOS_PARALLEL;
+  });
+
+  it("treats an empty ARGOS_PARALLEL as false", async () => {
+    process.env.ARGOS_PARALLEL = "";
+    expect((await readDummyConfig()).parallel).toBe(false);
+    delete process.env.ARGOS_PARALLEL;
+  });
+
   it("reads merge queue pr numbers from env", async () => {
     process.env.ARGOS_MERGE_QUEUE_PRS = "101,102";
     const config = await readDummyConfig();


### PR DESCRIPTION
## Problem

Non-PR builds were being recorded with `subset: true` in the database even when the workflow set `ARGOS_SUBSET` to an empty string.

The `--subset` and `--parallel` boolean flags used Commander's `.env()`. For a **boolean flag**, Commander v12 only checks whether the env var is *defined* (`'X' in process.env`), ignoring its value — so `ARGOS_SUBSET=""` (which GitHub Actions still sets as an empty-string env var) enabled the flag. Since the parsed CLI option is passed explicitly into the config, it overrode the convict env reading, which *does* coerce `""` → `false` correctly.

## Fix

Drop `.env(...)` from these two boolean flags so the env vars are read solely by the convict config (`format: Boolean`), which correctly coerces `""` / `"false"` → `false`. The CLI flags keep working, and when not passed they fall through to the config's env reading.

Other `.env()` options take a `<value>` and are unaffected (Commander uses the value for those).

## Tests

Added regression tests covering empty-string → `false` and `"true"` → `true` for both `ARGOS_SUBSET` and `ARGOS_PARALLEL`.

> [!NOTE]
> This fixes new builds only — builds already mislabeled `subset: true` won't be retroactively corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)