### PR TITLE
feat(core): split the updateBuild request to avoid PayloadTooLargeError

### DIFF
--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1846,6 +1846,8 @@ export interface operations {
                     parallel?: boolean | null;
                     parallelTotal?: number | null;
                     parallelIndex?: number | null;
+                    /** @description Only used for non-parallel builds. Indicates that this is the last request of the build, so Argos can finalize it. A build whose screenshots are too large to fit in a single request can split them across several sequential requests, leaving `final` falsy on every request but the last. Defaults to `true`. */
+                    final?: boolean | null;
                     metadata?: components["schemas"]["BuildMetadata"];
                 };
             };

--- a/packages/core/src/upload.test.ts
+++ b/packages/core/src/upload.test.ts
@@ -161,6 +161,51 @@ describe("#upload", () => {
     })();
   });
 
+  it("marks the update build request as final and carries the metadata", () => {
+    return server.boundary(async () => {
+      const updateBuildBodies: {
+        final?: boolean | null;
+        metadata?: unknown;
+        screenshots: unknown[];
+      }[] = [];
+
+      server.use(
+        http.put(
+          "https://api.argos-ci.dev/builds/:buildId",
+          async ({ request }) => {
+            updateBuildBodies.push(
+              (await request.json()) as {
+                final?: boolean | null;
+                metadata?: unknown;
+                screenshots: unknown[];
+              },
+            );
+            return HttpResponse.json({
+              build: { id: "123", url: "https://app.argos-ci.dev/builds/123" },
+            });
+          },
+        ),
+      );
+
+      await upload({
+        branch: "main",
+        apiBaseUrl: "https://api.argos-ci.dev",
+        root: join(__dirname, "../../../__fixtures__/screenshots"),
+        commit: "f16f980bd17cccfa93a1ae7766727e67950773d0",
+        token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
+        metadata: {
+          testReport: { status: "passed" },
+        },
+      });
+
+      // The fixtures are small, so everything fits in a single request.
+      expect(updateBuildBodies).toHaveLength(1);
+      const last = updateBuildBodies.at(-1);
+      expect(last?.final).toBe(true);
+      expect(last?.metadata).toEqual({ testReport: { status: "passed" } });
+    })();
+  });
+
   it("retries", () => {
     return server.boundary(async () => {
       let reqCount = 0;

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -7,7 +7,7 @@ import { hashFile } from "./hashing";
 import { resolveArgosToken } from "./auth";
 import { uploadFileWithPresignedPost } from "./s3";
 import { debug, debugTime, debugTimeEnd } from "./debug";
-import { chunk, mapInChunks } from "./util/chunk";
+import { chunk, chunkBySize, mapInChunks } from "./util/chunk";
 import {
   getPlaywrightTracePath,
   readMetadata,
@@ -23,6 +23,13 @@ import { skip } from "./skip";
  * Limits concurrency to avoid memory pressure when handling many screenshots.
  */
 const CHUNK_SIZE = 10;
+
+/**
+ * Maximum serialized size (in bytes) of the screenshots sent in a single
+ * `updateBuild` request. Kept below the API request body size limit (3MB) to
+ * leave room for the rest of the body (build metadata, etc.).
+ */
+const MAX_UPDATE_BUILD_SCREENSHOTS_BYTES = 2 * 1024 * 1024;
 
 const PLAYWRIGHT_TRACE_CONTENT_TYPE = "application/zip";
 
@@ -400,35 +407,66 @@ export async function upload(params: UploadParameters): Promise<{
   // Update build
   debug("Updating build");
 
-  const uploadBuildResponse = await apiClient.PUT("/builds/{buildId}", {
-    params: {
-      path: {
-        buildId: result.build.id,
-      },
-    },
-    body: {
-      screenshots: snapshots.map((snapshot) => ({
-        key: snapshot.hash,
-        name: snapshot.name,
-        metadata: snapshot.metadata,
-        pwTraceKey: snapshot.pwTrace?.hash ?? null,
-        threshold: snapshot.threshold ?? config?.threshold ?? null,
-        baseName: snapshot.baseName,
-        parentName: snapshot.parentName,
-        contentType: snapshot.contentType,
-      })),
-      parallel: config.parallel,
-      parallelTotal: config.parallelTotal,
-      parallelIndex: config.parallelIndex,
-      metadata: params.metadata,
-    },
-  });
+  const screenshotInputs = snapshots.map((snapshot) => ({
+    key: snapshot.hash,
+    name: snapshot.name,
+    metadata: snapshot.metadata,
+    pwTraceKey: snapshot.pwTrace?.hash ?? null,
+    threshold: snapshot.threshold ?? config?.threshold ?? null,
+    baseName: snapshot.baseName,
+    parentName: snapshot.parentName,
+    contentType: snapshot.contentType,
+  }));
 
-  if (uploadBuildResponse.error) {
-    throwAPIError(uploadBuildResponse.error, uploadBuildResponse.response);
+  // Parallel shards must be sent in a single request (each request counts as one
+  // batch). Non-parallel builds split their screenshots across several requests
+  // to stay under the API request body size limit, since the metadata of a
+  // single screenshot can be large.
+  const screenshotChunks = config.parallel
+    ? [screenshotInputs]
+    : chunkBySize(screenshotInputs, MAX_UPDATE_BUILD_SCREENSHOTS_BYTES);
+  // Always send at least one request so a build with no screenshots is
+  // finalized.
+  if (screenshotChunks.length === 0) {
+    screenshotChunks.push([]);
   }
 
-  return { build: uploadBuildResponse.data.build, screenshots: snapshots };
+  let build: ArgosAPISchema.components["schemas"]["Build"] | null = null;
+  for (let index = 0; index < screenshotChunks.length; index++) {
+    const isLast = index === screenshotChunks.length - 1;
+    debug(`Updating build (request ${index + 1}/${screenshotChunks.length})`);
+    const uploadBuildResponse = await apiClient.PUT("/builds/{buildId}", {
+      params: {
+        path: {
+          buildId: result.build.id,
+        },
+      },
+      body: {
+        screenshots: screenshotChunks[index] ?? [],
+        parallel: config.parallel,
+        parallelTotal: config.parallelTotal,
+        parallelIndex: config.parallelIndex,
+        // The build is finalized by the last request, which also carries the
+        // build metadata.
+        final: isLast,
+        metadata: isLast ? params.metadata : undefined,
+      },
+    });
+
+    if (uploadBuildResponse.error) {
+      throwAPIError(uploadBuildResponse.error, uploadBuildResponse.response);
+    }
+
+    if (isLast) {
+      build = uploadBuildResponse.data.build;
+    }
+  }
+
+  if (!build) {
+    throw new Error("Invariant: the build was not updated");
+  }
+
+  return { build, screenshots: snapshots };
 }
 
 async function uploadFilesToS3(files: SecureUploadFileInput[]) {

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -418,18 +418,23 @@ export async function upload(params: UploadParameters): Promise<{
     contentType: snapshot.contentType,
   }));
 
-  // Parallel shards must be sent in a single request (each request counts as one
-  // batch). Non-parallel builds split their screenshots across several requests
-  // to stay under the API request body size limit, since the metadata of a
-  // single screenshot can be large.
-  const screenshotChunks = config.parallel
-    ? [screenshotInputs]
-    : chunkBySize(screenshotInputs, MAX_UPDATE_BUILD_SCREENSHOTS_BYTES);
+  // Split the screenshots across several requests to stay under the API request
+  // body size limit, since the metadata of a single screenshot can be large.
+  const screenshotChunks = chunkBySize(
+    screenshotInputs,
+    MAX_UPDATE_BUILD_SCREENSHOTS_BYTES,
+  );
   // Always send at least one request so a build with no screenshots is
   // finalized.
   if (screenshotChunks.length === 0) {
     screenshotChunks.push([]);
   }
+
+  // A parallel shard with an index groups its requests into a single shard, so
+  // only its last request is `final`. Without an index (manual finalization),
+  // requests can't be grouped, so each is its own complete shard — that's fine
+  // since the build is finalized manually.
+  const groupsRequests = !config.parallel || config.parallelIndex != null;
 
   let build: ArgosAPISchema.components["schemas"]["Build"] | null = null;
   for (let index = 0; index < screenshotChunks.length; index++) {
@@ -446,9 +451,9 @@ export async function upload(params: UploadParameters): Promise<{
         parallel: config.parallel,
         parallelTotal: config.parallelTotal,
         parallelIndex: config.parallelIndex,
-        // The build is finalized by the last request, which also carries the
-        // build metadata.
-        final: isLast,
+        // The build/shard is finalized by its last request, which also carries
+        // the build metadata. Ungrouped requests are each final on their own.
+        final: groupsRequests ? isLast : true,
         metadata: isLast ? params.metadata : undefined,
       },
     });

--- a/packages/core/src/util/chunk.test.ts
+++ b/packages/core/src/util/chunk.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { chunkBySize } from "./chunk";
+
+describe("chunkBySize", () => {
+  it("returns no chunk for an empty array", () => {
+    expect(chunkBySize([], 100)).toEqual([]);
+  });
+
+  it("keeps items in a single chunk when they fit", () => {
+    const items = [{ a: 1 }, { a: 2 }, { a: 3 }];
+    expect(chunkBySize(items, 1000)).toEqual([items]);
+  });
+
+  it("splits items into several chunks when they exceed the size", () => {
+    // Each item serializes to `{"a":"xxxx"}` (11 bytes).
+    const items = Array.from({ length: 5 }, () => ({ a: "xxxx" }));
+    const chunks = chunkBySize(items, 25);
+    // 25 bytes fits 2 items (22 bytes) but not 3 (33 bytes).
+    expect(chunks.map((chunk) => chunk.length)).toEqual([2, 2, 1]);
+    expect(chunks.flat()).toEqual(items);
+  });
+
+  it("gives an oversized item its own chunk", () => {
+    const items = [{ a: "x" }, { a: "x".repeat(100) }, { a: "x" }];
+    const chunks = chunkBySize(items, 20);
+    expect(chunks.map((chunk) => chunk.length)).toEqual([1, 1, 1]);
+    expect(chunks.flat()).toEqual(items);
+  });
+});

--- a/packages/core/src/util/chunk.ts
+++ b/packages/core/src/util/chunk.ts
@@ -16,6 +16,30 @@ export const chunk = <T>(collection: T[], size: number) => {
 };
 
 /**
+ * Split items into chunks whose serialized JSON size stays under `maxBytes`.
+ * An item larger than `maxBytes` on its own gets its own chunk.
+ */
+export const chunkBySize = <T>(items: T[], maxBytes: number): T[][] => {
+  const chunks: T[][] = [];
+  let current: T[] = [];
+  let currentBytes = 0;
+  for (const item of items) {
+    const size = Buffer.byteLength(JSON.stringify(item));
+    if (current.length > 0 && currentBytes + size > maxBytes) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(item);
+    currentBytes += size;
+  }
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+  return chunks;
+};
+
+/**
  * Map over a collection asynchronously, processing at most `size` items
  * concurrently to limit memory pressure.
  */


### PR DESCRIPTION
## Why

A build sent all of its screenshot metadata in one `updateBuild` request. Once a suite grows large, that body can exceed the API's request body size limit and fail with `PayloadTooLargeError`, since per-screenshot metadata (test info, annotations, tags, URLs…) can be sizeable. (See ARG-430.)

## What

Split a build's screenshots across **several sequential `updateBuild` requests**, each byte-budgeted to stay under the limit (`chunkBySize`, < 2MB):

- **Single builds**: chunks target the same build; the last request is `final: true` and carries the build metadata.
- **Parallel, indexed shard**: chunks group into a single shard (same `parallelIndex`), only the last is `final`.
- **Parallel, index-less shard** (manual finalization): can't be grouped, so each chunk is sent as its own complete shard — fine since the build is finalized manually.

Build metadata is sent on the last chunk only in every case. `api-client`'s `schema.ts` is regenerated to expose the new `final` field.

Requires the matching backend change (argos `greg/arg-430-...`), which must ship first.

## Tests

`chunkBySize` unit tests (size splitting, oversized item, empty) and an integration test asserting the update request is marked `final` and carries the metadata. Types + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)