### PR TITLE
feat(core): resolve baseline from commits when no Git provider

### DIFF
--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -124,6 +124,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/baseline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Find an eligible baseline from a list of commits
+         * @description Find the build eligible to be used as a baseline among a list of commits. Useful when no Git provider is connected: the CLI can send the candidate ancestor commits and let Argos pick the closest one that has an eligible (complete, valid, approved and not rejected) baseline build.
+         */
+        post: operations["findBaseline"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/cli/token": {
         parameters: {
             query?: never;
@@ -1552,6 +1572,74 @@ export interface operations {
             };
             /** @description Conflict */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    findBaseline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description The commits to look for an eligible baseline, ordered from the closest to the furthest ancestor. The first commit with an eligible baseline wins. */
+                    commits: components["schemas"]["Sha1Hash"][];
+                    /**
+                     * @description The name of the build to find a baseline for.
+                     * @default default
+                     */
+                    name?: string;
+                    /**
+                     * @description The mode of the build to find a baseline for.
+                     * @default ci
+                     * @enum {string}
+                     */
+                    mode?: "ci" | "monitoring";
+                };
+            };
+        };
+        responses: {
+            /** @description The eligible baseline build, or null when none is found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The eligible baseline build found among the commits, or null when none is found. */
+                        baseline: components["schemas"]["Build"] | null;
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/core/src/ci-environment/git.test.ts
+++ b/packages/core/src/ci-environment/git.test.ts
@@ -3,7 +3,13 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { branch, getMergeBaseCommitSha, getRepositoryURL, head } from "./git";
+import {
+  branch,
+  getMergeBaseCommitSha,
+  getRepositoryURL,
+  head,
+  listAncestorCommits,
+} from "./git";
 
 describe("#head", () => {
   it("returns the current commit", () => {
@@ -71,6 +77,65 @@ describe("#getMergeBaseCommitSha (command injection)", () => {
     }
 
     expect(existsSync(markerFile)).toBe(false);
+  });
+});
+
+describe("#listAncestorCommits", () => {
+  let cwd: string;
+  let root: string;
+  let repoDir: string;
+  // Commit SHAs ordered from the oldest (first) to the newest (head).
+  let shas: string[];
+  let firstSha: string;
+  let headSha: string;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    root = mkdtempSync(join(tmpdir(), "argos-git-ancestors-test-"));
+    repoDir = join(root, "repo");
+
+    const bareDir = join(root, "origin.git");
+    execFileSync("git", ["init", "--bare", bareDir]);
+    execFileSync("git", ["init", repoDir]);
+    const git = (...args: string[]) =>
+      execFileSync("git", ["-C", repoDir, ...args]);
+    git("remote", "add", "origin", bareDir);
+    git("config", "user.email", "test@argos-ci.com");
+    git("config", "user.name", "Argos Test");
+
+    // Create a linear history of 5 commits.
+    shas = [];
+    for (let i = 0; i < 5; i++) {
+      git("commit", "--allow-empty", "-m", `commit ${i}`);
+      shas.push(git("rev-parse", "HEAD").toString().trim());
+    }
+    firstSha = shas[0] as string;
+    headSha = shas[shas.length - 1] as string;
+    git("branch", "-M", "main");
+    git("push", "origin", "main");
+
+    process.chdir(repoDir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("lists ancestors closest first, excluding the commit itself", async () => {
+    const ancestors = await listAncestorCommits({ sha: headSha, limit: 10 });
+    // All commits but the head, ordered from the closest to the furthest.
+    expect(ancestors).toEqual([...shas].reverse().slice(1));
+  });
+
+  it("limits the number of ancestors returned", async () => {
+    const ancestors = await listAncestorCommits({ sha: headSha, limit: 2 });
+    expect(ancestors).toEqual([...shas].reverse().slice(1, 3));
+  });
+
+  it("returns an empty array when the commit has no ancestor", async () => {
+    const ancestors = await listAncestorCommits({ sha: firstSha, limit: 10 });
+    expect(ancestors).toEqual([]);
   });
 });
 

--- a/packages/core/src/ci-environment/git.ts
+++ b/packages/core/src/ci-environment/git.ts
@@ -216,16 +216,33 @@ function listShas(path: string, maxCount?: number): string[] {
   return shas;
 }
 
-export async function listParentCommits(input: {
+/**
+ * List the ancestor commits of a commit, ordered from the closest to the
+ * furthest ancestor, up to `limit` commits. The commit itself is excluded.
+ *
+ * The history is deepened with a shallow fetch so this works on the shallow
+ * clones typically used in CI. When the commit is not on the remote (e.g. not
+ * pushed yet) or the fetch fails, we fall back to whatever local history is
+ * available; when the commit is unknown locally too, we return an empty list.
+ */
+export async function listAncestorCommits(input: {
   sha: string;
-}): Promise<string[] | null> {
-  const limit = 200;
+  limit: number;
+}): Promise<string[]> {
+  // Fetch one extra commit since the commit itself is excluded from the result.
+  const depth = input.limit + 1;
   try {
-    await runGitFetch([`--depth=${limit}`, "origin", input.sha]);
+    await runGitFetch([`--depth=${depth}`, "origin", input.sha]);
   } catch (error) {
-    if (getGitErrorOutput(error).includes("not our ref")) {
-      return [];
-    }
+    debug(
+      `Failed to deepen history for ${input.sha}, using local history`,
+      getGitErrorOutput(error),
+    );
   }
-  return listShas(input.sha, limit);
+  try {
+    return listShas(input.sha, depth).slice(1);
+  } catch (error) {
+    debug(`Failed to list ancestors of ${input.sha}`, getGitErrorOutput(error));
+    return [];
+  }
 }

--- a/packages/core/src/ci-environment/index.ts
+++ b/packages/core/src/ci-environment/index.ts
@@ -54,17 +54,18 @@ export function getMergeBaseCommitSha(input: {
 }
 
 /**
- * Get the merge base commit.
+ * List the ancestor commits of a commit, closest first, up to `limit` commits.
  */
-export function listParentCommits(input: {
+export function listAncestorCommits(input: {
   sha: string;
-}): Promise<string[] | null> {
+  limit: number;
+}): Promise<string[]> {
   const context = createContext();
   const service = getCiService(context);
   if (!service) {
-    return Promise.resolve(null);
+    return Promise.resolve([]);
   }
-  return service.listParentCommits(input, context);
+  return service.listAncestorCommits(input, context);
 }
 /**
  * Get the CI environment.

--- a/packages/core/src/ci-environment/services/bitrise.ts
+++ b/packages/core/src/ci-environment/services/bitrise.ts
@@ -1,4 +1,4 @@
-import { getMergeBaseCommitSha, listParentCommits } from "../git";
+import { getMergeBaseCommitSha, listAncestorCommits } from "../git";
 import type { Service, Context } from "../types";
 
 function getPrNumber(context: Context) {
@@ -36,7 +36,7 @@ const service: Service = {
     };
   },
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/services/buildkite.ts
+++ b/packages/core/src/ci-environment/services/buildkite.ts
@@ -1,5 +1,10 @@
 import type { Context, Service } from "../types";
-import { head, branch, getMergeBaseCommitSha, listParentCommits } from "../git";
+import {
+  head,
+  branch,
+  getMergeBaseCommitSha,
+  listAncestorCommits,
+} from "../git";
 import { getRepositoryNameFromURL } from "../../util/url";
 
 function getRepository(context: Context): string | null {
@@ -35,7 +40,7 @@ const service: Service = {
     };
   },
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/services/circleci.ts
+++ b/packages/core/src/ci-environment/services/circleci.ts
@@ -1,4 +1,4 @@
-import { getMergeBaseCommitSha, listParentCommits } from "../git";
+import { getMergeBaseCommitSha, listAncestorCommits } from "../git";
 import type { Service, Context } from "../types";
 
 function getPrNumber(context: Context) {
@@ -48,7 +48,7 @@ const service: Service = {
     };
   },
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/services/git.ts
+++ b/packages/core/src/ci-environment/services/git.ts
@@ -4,7 +4,7 @@ import {
   branch,
   checkIsGitRepository,
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
   getRepositoryURL,
 } from "../git";
 import { getRepositoryNameFromURL } from "../../util/url";
@@ -38,7 +38,7 @@ const service: Service = {
     };
   },
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/services/github-actions.ts
+++ b/packages/core/src/ci-environment/services/github-actions.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { Service, Context } from "../types";
-import { getMergeBaseCommitSha, listParentCommits } from "../git";
+import { getMergeBaseCommitSha, listAncestorCommits } from "../git";
 import type * as webhooks from "@octokit/webhooks";
 import type { RepositoryDispatchContext } from "@vercel/repository-dispatch/context";
 import {
@@ -338,7 +338,7 @@ const service: Service = {
     };
   },
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/services/gitlab.ts
+++ b/packages/core/src/ci-environment/services/gitlab.ts
@@ -1,4 +1,4 @@
-import { getMergeBaseCommitSha, listParentCommits } from "../git";
+import { getMergeBaseCommitSha, listAncestorCommits } from "../git";
 import type { Context, Service } from "../types";
 
 function getRepository(context: Context): string | null {
@@ -38,7 +38,7 @@ const service: Service = {
     };
   },
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/services/heroku.ts
+++ b/packages/core/src/ci-environment/services/heroku.ts
@@ -1,5 +1,5 @@
 import type { Service } from "../types";
-import { getMergeBaseCommitSha, listParentCommits } from "../git";
+import { getMergeBaseCommitSha, listAncestorCommits } from "../git";
 
 const service: Service = {
   name: "Heroku",
@@ -20,7 +20,7 @@ const service: Service = {
     nonce: env.HEROKU_TEST_RUN_ID || null,
   }),
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/services/travis.ts
+++ b/packages/core/src/ci-environment/services/travis.ts
@@ -1,5 +1,5 @@
 import type { Context, Service } from "../types";
-import { getMergeBaseCommitSha, listParentCommits } from "../git";
+import { getMergeBaseCommitSha, listAncestorCommits } from "../git";
 
 function getRepository(context: Context): string | null {
   const { env } = context;
@@ -47,7 +47,7 @@ const service: Service = {
     };
   },
   getMergeBaseCommitSha,
-  listParentCommits,
+  listAncestorCommits,
 };
 
 export default service;

--- a/packages/core/src/ci-environment/types.ts
+++ b/packages/core/src/ci-environment/types.ts
@@ -94,10 +94,11 @@ export interface Service {
     },
     ctx: Context,
   ): Promise<string | null>;
-  listParentCommits(
+  listAncestorCommits(
     input: {
       sha: string;
+      limit: number;
     },
     ctx: Context,
-  ): Promise<string[] | null>;
+  ): Promise<string[]>;
 }

--- a/packages/core/src/find-reference-commit.test.ts
+++ b/packages/core/src/find-reference-commit.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import {
+  findReferenceCommit,
+  getCumulativeBatchSizes,
+  MAX_COMMITS,
+  PARENT_COMMITS_LIMIT,
+  resolveBaseline,
+} from "./find-reference-commit";
+
+type Build = ArgosAPISchema.components["schemas"]["Build"];
+
+/**
+ * Build a fake baseline build whose head points to the given commit.
+ */
+function createBaseline(sha: string): Build {
+  return { head: { sha, branch: "main" } } as Build;
+}
+
+/**
+ * Create a `listCommits` that returns the closest `limit` commits from a fixed
+ * history, mimicking how Git deepens an ancestor list.
+ */
+function createListCommits(history: string[]) {
+  return vi.fn(async (limit: number) => history.slice(0, limit));
+}
+
+describe("#getCumulativeBatchSizes", () => {
+  it("starts with 100 then grows by 500 up to 5000", () => {
+    expect(getCumulativeBatchSizes()).toEqual([
+      100, 600, 1100, 1600, 2100, 2600, 3100, 3600, 4100, 4600, 5000,
+    ]);
+  });
+
+  it("never exceeds the maximum", () => {
+    const sizes = getCumulativeBatchSizes();
+    expect(sizes.at(-1)).toBe(MAX_COMMITS);
+    expect(Math.max(...sizes)).toBe(MAX_COMMITS);
+  });
+});
+
+describe("#findReferenceCommit", () => {
+  it("returns the baseline commit found in the first batch", async () => {
+    const history = Array.from({ length: 200 }, (_, i) => `commit-${i}`);
+    const listCommits = createListCommits(history);
+    const findBaseline = vi.fn(async () => createBaseline("commit-42"));
+
+    const result = await findReferenceCommit({ listCommits, findBaseline });
+
+    expect(result).toBe("commit-42");
+    // Resolved in the first batch, so a single request is enough.
+    expect(findBaseline).toHaveBeenCalledTimes(1);
+    expect(findBaseline).toHaveBeenCalledWith(history.slice(0, 100));
+  });
+
+  it("only sends the new commits in each subsequent batch", async () => {
+    const history = Array.from({ length: 700 }, (_, i) => `commit-${i}`);
+    const listCommits = createListCommits(history);
+    // No baseline in the first batch, found in the second.
+    const findBaseline = vi
+      .fn<(commits: string[]) => Promise<Build | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(createBaseline("commit-321"));
+
+    const result = await findReferenceCommit({ listCommits, findBaseline });
+
+    expect(result).toBe("commit-321");
+    expect(findBaseline).toHaveBeenCalledTimes(2);
+    // First batch: commits 0..99.
+    expect(findBaseline).toHaveBeenNthCalledWith(1, history.slice(0, 100));
+    // Second batch: only the new commits 100..599.
+    expect(findBaseline).toHaveBeenNthCalledWith(2, history.slice(100, 600));
+  });
+
+  it("returns null when no baseline is found in the whole history", async () => {
+    const history = Array.from({ length: 250 }, (_, i) => `commit-${i}`);
+    const listCommits = createListCommits(history);
+    const findBaseline = vi.fn(async () => null);
+
+    const result = await findReferenceCommit({ listCommits, findBaseline });
+
+    expect(result).toBeNull();
+    // First batch (100) finds nothing, second batch sees the remaining 150 and
+    // the history is then exhausted.
+    expect(findBaseline).toHaveBeenCalledTimes(2);
+    expect(findBaseline).toHaveBeenNthCalledWith(2, history.slice(100, 250));
+  });
+
+  it("stops once the history is exhausted", async () => {
+    const history = Array.from({ length: 50 }, (_, i) => `commit-${i}`);
+    const listCommits = createListCommits(history);
+    const findBaseline = vi.fn(async () => null);
+
+    const result = await findReferenceCommit({ listCommits, findBaseline });
+
+    expect(result).toBeNull();
+    expect(findBaseline).toHaveBeenCalledTimes(1);
+    expect(findBaseline).toHaveBeenCalledWith(history);
+  });
+
+  it("returns null without calling the API when there are no commits", async () => {
+    const listCommits = vi.fn(async () => []);
+    const findBaseline = vi.fn(async () => null);
+
+    const result = await findReferenceCommit({ listCommits, findBaseline });
+
+    expect(result).toBeNull();
+    expect(findBaseline).not.toHaveBeenCalled();
+  });
+
+  it("does not exceed the maximum number of commits", async () => {
+    const history = Array.from(
+      { length: MAX_COMMITS + 1000 },
+      (_, i) => `commit-${i}`,
+    );
+    const listCommits = createListCommits(history);
+    const findBaseline = vi.fn<(commits: string[]) => Promise<Build | null>>(
+      async () => null,
+    );
+
+    const result = await findReferenceCommit({ listCommits, findBaseline });
+
+    expect(result).toBeNull();
+    expect(findBaseline).toHaveBeenCalledTimes(
+      getCumulativeBatchSizes().length,
+    );
+    // The last commit ever inspected is at index MAX_COMMITS - 1.
+    const allInspected = findBaseline.mock.calls.flatMap((call) => call[0]);
+    expect(allInspected).toHaveLength(MAX_COMMITS);
+    expect(allInspected.at(-1)).toBe(`commit-${MAX_COMMITS - 1}`);
+  });
+});
+
+/**
+ * Create a `listCommits(sha, limit)` returning `[sha, ...ancestors]` truncated
+ * to `limit`, mimicking how Git lists a commit followed by its ancestors.
+ */
+function createMergeBaseListCommits(ancestors: string[]) {
+  return vi.fn(async (sha: string, limit: number) =>
+    [sha, ...ancestors].slice(0, limit),
+  );
+}
+
+describe("#resolveBaseline", () => {
+  it("returns nulls and does nothing else when there is no merge base", async () => {
+    const getMergeBase = vi.fn(async () => null);
+    const listCommits =
+      vi.fn<(sha: string, limit: number) => Promise<string[]>>();
+    const findBaseline = vi.fn<(commits: string[]) => Promise<Build | null>>();
+
+    const result = await resolveBaseline({
+      getMergeBase,
+      listCommits,
+      findBaseline,
+    });
+
+    expect(result).toEqual({ referenceCommit: null, parentCommits: null });
+    expect(listCommits).not.toHaveBeenCalled();
+    expect(findBaseline).not.toHaveBeenCalled();
+  });
+
+  it("uses the baseline commit and sends no parent commits when one is found", async () => {
+    const ancestors = Array.from({ length: 200 }, (_, i) => `anc-${i}`);
+    const getMergeBase = vi.fn(async () => "merge-base");
+    const listCommits = createMergeBaseListCommits(ancestors);
+    const findBaseline = vi.fn(async () => createBaseline("anc-3"));
+
+    const result = await resolveBaseline({
+      getMergeBase,
+      listCommits,
+      findBaseline,
+    });
+
+    expect(result).toEqual({ referenceCommit: "anc-3", parentCommits: null });
+  });
+
+  it("offers the merge base itself as the first baseline candidate", async () => {
+    const ancestors = Array.from({ length: 50 }, (_, i) => `anc-${i}`);
+    const getMergeBase = vi.fn(async () => "merge-base");
+    const listCommits = createMergeBaseListCommits(ancestors);
+    const findBaseline = vi.fn<(commits: string[]) => Promise<Build | null>>(
+      async () => createBaseline("merge-base"),
+    );
+
+    const result = await resolveBaseline({
+      getMergeBase,
+      listCommits,
+      findBaseline,
+    });
+
+    expect(result).toEqual({
+      referenceCommit: "merge-base",
+      parentCommits: null,
+    });
+    // The merge base is the first candidate sent to the API.
+    expect(findBaseline.mock.calls[0]?.[0]?.[0]).toBe("merge-base");
+  });
+
+  it("falls back to the merge base with parent commits when no baseline is found", async () => {
+    const ancestors = Array.from({ length: 500 }, (_, i) => `anc-${i}`);
+    const getMergeBase = vi.fn(async () => "merge-base");
+    const listCommits = createMergeBaseListCommits(ancestors);
+    const findBaseline = vi.fn(async () => null);
+
+    const result = await resolveBaseline({
+      getMergeBase,
+      listCommits,
+      findBaseline,
+    });
+
+    expect(result.referenceCommit).toBe("merge-base");
+    // The merge base followed by its ancestors, capped at the parent-commit limit.
+    expect(result.parentCommits).toEqual(
+      ["merge-base", ...ancestors].slice(0, PARENT_COMMITS_LIMIT),
+    );
+    expect(result.parentCommits).toHaveLength(PARENT_COMMITS_LIMIT);
+  });
+});

--- a/packages/core/src/find-reference-commit.ts
+++ b/packages/core/src/find-reference-commit.ts
@@ -1,0 +1,185 @@
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { debug } from "./debug";
+
+type Build = ArgosAPISchema.components["schemas"]["Build"];
+
+/**
+ * Number of commits inspected in the first batch. Kept small so the common case
+ * — the baseline is among the most recent ancestors — resolves with a single
+ * lightweight request.
+ */
+export const FIRST_BATCH_SIZE = 100;
+
+/**
+ * Number of commits inspected in each subsequent batch. Larger than the first
+ * batch to widen the search quickly when the baseline is further back.
+ */
+export const NEXT_BATCH_SIZE = 500;
+
+/**
+ * Maximum number of commits inspected before giving up.
+ */
+export const MAX_COMMITS = 5000;
+
+/**
+ * Cumulative number of commits to inspect after each batch: 100, 600, 1100, …,
+ * up to {@link MAX_COMMITS}.
+ */
+export function getCumulativeBatchSizes(): number[] {
+  const sizes: number[] = [];
+  let total = Math.min(FIRST_BATCH_SIZE, MAX_COMMITS);
+  sizes.push(total);
+  while (total < MAX_COMMITS) {
+    total = Math.min(total + NEXT_BATCH_SIZE, MAX_COMMITS);
+    sizes.push(total);
+  }
+  return sizes;
+}
+
+export interface FindReferenceCommitParams {
+  /**
+   * List the ancestor commits of the build, ordered from the closest to the
+   * furthest ancestor, up to `limit` commits. Returns fewer commits when the
+   * history is shorter.
+   */
+  listCommits: (limit: number) => Promise<string[]>;
+
+  /**
+   * Find an eligible baseline build among the given commits, ordered from the
+   * closest to the furthest ancestor. Returns the baseline build, or `null`
+   * when none is found.
+   */
+  findBaseline: (commits: string[]) => Promise<Build | null>;
+}
+
+/**
+ * Find the reference commit by asking the API to pick the closest commit that
+ * has an eligible baseline build, among a list of candidate commits ordered from
+ * the closest to the furthest ancestor. That build's commit becomes the
+ * reference commit.
+ *
+ * Commits are inspected in growing batches ({@link FIRST_BATCH_SIZE}, then
+ * {@link NEXT_BATCH_SIZE} per request, up to {@link MAX_COMMITS}) so the common
+ * case resolves quickly without fetching and sending the whole history.
+ */
+export async function findReferenceCommit(
+  params: FindReferenceCommitParams,
+): Promise<string | null> {
+  let inspectedCount = 0;
+
+  for (const limit of getCumulativeBatchSizes()) {
+    const commits = await params.listCommits(limit);
+
+    // Only send the commits not already inspected in previous batches. Earlier
+    // commits are closer ancestors and have already been ruled out, so within
+    // each batch the closest commit still wins overall.
+    const batch = commits.slice(inspectedCount);
+
+    // No new commits became available: the history is exhausted.
+    if (batch.length === 0) {
+      break;
+    }
+
+    debug(`Looking for a baseline among ${batch.length} commit(s)`);
+    const baseline = await params.findBaseline(batch);
+    if (baseline) {
+      debug("Found baseline build for reference commit", baseline.head.sha);
+      return baseline.head.sha;
+    }
+
+    inspectedCount = commits.length;
+
+    // Fewer commits than requested: the history is exhausted, so asking for more
+    // would return the same list.
+    if (commits.length < limit) {
+      break;
+    }
+  }
+
+  debug("No eligible baseline found among ancestor commits");
+  return null;
+}
+
+/**
+ * Number of commits (the merge base plus its ancestors) sent as `parentCommits`
+ * when no baseline build is found yet. The baseline build may still be
+ * processing on the server; sending these lets the server resolve the baseline
+ * once it completes, when it processes this build. The server treats the first
+ * commit as the reference commit and searches the rest.
+ */
+export const PARENT_COMMITS_LIMIT = 300;
+
+export interface ResolveBaselineParams {
+  /**
+   * Compute the merge base commit between the build branch and its base branch,
+   * or `null` when none can be found.
+   */
+  getMergeBase: () => Promise<string | null>;
+
+  /**
+   * List a commit followed by its ancestors, ordered from the commit itself to
+   * the furthest ancestor, up to `limit` commits.
+   */
+  listCommits: (sha: string, limit: number) => Promise<string[]>;
+
+  /**
+   * Find an eligible baseline build among the given commits, ordered from the
+   * closest to the furthest ancestor. Returns the baseline build, or `null`
+   * when none is found.
+   */
+  findBaseline: (commits: string[]) => Promise<Build | null>;
+}
+
+export interface BaselineResolution {
+  /** Commit to use as the baseline reference, or `null` when none. */
+  referenceCommit: string | null;
+  /**
+   * Commits sent to the server so it can resolve the baseline itself — the
+   * reference commit followed by its ancestors — or `null` when not needed.
+   */
+  parentCommits: string[] | null;
+}
+
+/**
+ * Resolve the baseline for a build that has no remote content access (no Git
+ * provider connected).
+ *
+ * 1. Find the merge base — the closest common ancestor of the build branch and
+ *    its base branch. This is always the starting point.
+ * 2. From the merge base, ask the API to pick the closest commit (the merge base
+ *    itself or one of its ancestors) that has an eligible baseline build, and use
+ *    it as the reference commit.
+ * 3. If none is found, the baseline build may still be processing on the server.
+ *    Fall back to the merge base as the reference commit and send its parent
+ *    commits so the server can resolve the baseline once that build completes.
+ */
+export async function resolveBaseline(
+  params: ResolveBaselineParams,
+): Promise<BaselineResolution> {
+  const mergeBase = await params.getMergeBase();
+  if (!mergeBase) {
+    debug("No merge base found");
+    return { referenceCommit: null, parentCommits: null };
+  }
+  debug("Found merge base", mergeBase);
+
+  const referenceCommit = await findReferenceCommit({
+    listCommits: (limit) => params.listCommits(mergeBase, limit),
+    findBaseline: params.findBaseline,
+  });
+
+  if (referenceCommit) {
+    debug("Found reference commit from baseline", referenceCommit);
+    return { referenceCommit, parentCommits: null };
+  }
+
+  // No eligible baseline build yet — it may still be processing. Fall back to
+  // the merge base and let the server resolve the baseline from the parent
+  // commits once that build completes.
+  const parentCommits = await params.listCommits(
+    mergeBase,
+    PARENT_COMMITS_LIMIT,
+  );
+  debug("No baseline found, using merge base with parent commits", mergeBase);
+  return { referenceCommit: mergeBase, parentCommits };
+}

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -14,7 +14,8 @@ import {
   type ScreenshotMetadata,
 } from "@argos-ci/util";
 import { getArgosCoreSDKIdentifier } from "./version";
-import { getMergeBaseCommitSha, listParentCommits } from "./ci-environment";
+import { getMergeBaseCommitSha, listAncestorCommits } from "./ci-environment";
+import { resolveBaseline, PARENT_COMMITS_LIMIT } from "./find-reference-commit";
 import { getSnapshotMimeType } from "./mime-type";
 import { skip } from "./skip";
 
@@ -280,50 +281,58 @@ export async function upload(params: UploadParameters): Promise<{
 
   const { defaultBaseBranch, hasRemoteContentAccess } = projectResponse.data;
 
-  const referenceCommit = await (async () => {
+  // List a commit followed by its ancestors, closest first, up to `limit`
+  // commits. This matches the `parentCommits` API contract (the server drops the
+  // first entry and searches the rest) and the candidate list for the baseline
+  // API (where the commit itself can also be the baseline).
+  const listCommits = async (sha: string, limit: number) => {
+    const ancestors = await listAncestorCommits({ sha, limit: limit - 1 });
+    return [sha, ...ancestors];
+  };
+
+  const { referenceCommit, parentCommits } = await (async (): Promise<{
+    referenceCommit: string | null;
+    parentCommits: string[] | null;
+  }> => {
+    // An explicitly configured reference commit wins. Its exact commit may not
+    // have a baseline build, so we also send its parent commits as a fallback.
     if (config.referenceCommit) {
       debug("Found reference commit in config", config.referenceCommit);
-      return config.referenceCommit;
+      return {
+        referenceCommit: config.referenceCommit,
+        parentCommits: await listCommits(
+          config.referenceCommit,
+          PARENT_COMMITS_LIMIT,
+        ),
+      };
     }
 
-    // If we have remote access, we will fetch it from the Git Provider.
+    // With remote content access, the reference commit and parent commits are
+    // resolved server-side from the Git Provider.
     if (hasRemoteContentAccess) {
-      return null;
+      return { referenceCommit: null, parentCommits: null };
     }
 
-    // We use the pull request as base branch if possible
-    // else branch specified by the user or the default branch.
+    // Without remote content access, resolve the baseline from the merge base.
     const base =
       config.referenceBranch || config.prBaseBranch || defaultBaseBranch;
-
-    const sha = await getMergeBaseCommitSha({ base, head: config.branch });
-
-    if (sha) {
-      debug("Found merge base", sha);
-    } else {
-      debug("No merge base found");
-    }
-
-    return sha;
-  })();
-
-  const parentCommits = await (async () => {
-    // If we have remote access, we will fetch them from the Git Provider.
-    if (hasRemoteContentAccess) {
-      return null;
-    }
-
-    if (referenceCommit) {
-      const commits = await listParentCommits({ sha: referenceCommit });
-      if (commits) {
-        debug("Found parent commits", commits);
-      } else {
-        debug("No parent commits found");
-      }
-      return commits;
-    }
-
-    return null;
+    return resolveBaseline({
+      getMergeBase: () => getMergeBaseCommitSha({ base, head: config.branch }),
+      listCommits,
+      findBaseline: async (commits) => {
+        const response = await apiClient.POST("/baseline", {
+          body: {
+            commits,
+            name: config.buildName ?? undefined,
+            mode: config.mode ?? undefined,
+          },
+        });
+        if (response.error) {
+          throwAPIError(response.error, response.response);
+        }
+        return response.data.baseline;
+      },
+    });
   })();
 
   // Create build


### PR DESCRIPTION
## What

When a project has **no remote content access** (no Git provider connected), Argos can't compute the baseline server-side. This adds client-side baseline resolution that leans on the new [`/baseline` API (argos#2322)](https://github.com/argos-ci/argos/pull/2322), which finds an eligible baseline build from a list of candidate commits.

## How

Resolution ([`resolveBaseline`](packages/core/src/find-reference-commit.ts)) runs only when `hasRemoteContentAccess` is `false` and no reference commit is explicitly configured:

1. **Merge base first** — find the merge base between the build branch and its base branch. This is always the starting point.
2. **Resolve the reference commit** — ask `/baseline` over `[mergeBase, ...ancestors]` for the closest commit (the merge base itself or an ancestor) that has an eligible baseline build. Searched in growing batches: **100, then 500 per request, up to 5000**. That build's commit becomes the reference commit.
3. **No baseline yet → the baseline build may still be processing** — fall back to `referenceCommit = mergeBase` and send up to **300 parent commits** so the server resolves the baseline asynchronously once that build completes.

## Notes

- The batched search and the merge-base orchestration are dependency-injected in `find-reference-commit.ts`, so they're unit tested (no real git/network needed).
- `listParentCommits` is merged into `listAncestorCommits` — one git commit-listing primitive. `parentCommits` (which the server slices `[0]` off) is derived as `[refCommit, ...ancestors]`.
- Adds real git-integration tests for `listAncestorCommits`.

## Test plan

- [x] `tsc` clean
- [x] `eslint` / `prettier` clean
- [x] `vitest` — 105 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)