### PR TITLE
fix(storybook): screenshots cut off horizontally in Vitest integration

### DIFF
--- a/packages/storybook/src/vitest-plugin.ts
+++ b/packages/storybook/src/vitest-plugin.ts
@@ -49,36 +49,56 @@ export const createArgosScreenshotCommand = (
     // and we screenshot the iframe's `<body>`. Anything overflowing the iframe box
     // is not painted, so the screenshot gets cut. `setViewportSize` grows the iframe
     // *before* `argosCSS` (which injects `fitToContent`'s `zoom`) is applied, so it
-    // can't account for the final content size. Re-fit the iframe height here, after
+    // can't account for the final content size. Re-fit the iframe here, after
     // stabilization has injected `argosCSS`, so the whole content is painted.
     const userBeforeScreenshot = options?.beforeScreenshot;
     const optionsWithFit: ArgosScreenshotOptions = {
       ...options,
       beforeScreenshot: async (api) => {
         await userBeforeScreenshot?.(api);
-        await ctx.page.evaluate(() => {
-          const iframe = document.querySelector('iframe[data-vitest="true"]');
+        await ctx.page.evaluate(
+          ({ fitWidth }) => {
+            const iframe = document.querySelector('iframe[data-vitest="true"]');
 
-          if (
-            !(iframe instanceof HTMLIFrameElement) ||
-            !iframe.contentDocument
-          ) {
-            return;
-          }
+            if (
+              !(iframe instanceof HTMLIFrameElement) ||
+              !iframe.contentDocument
+            ) {
+              return;
+            }
 
-          const { body, documentElement } = iframe.contentDocument;
-          const contentHeight = Math.max(
-            body.scrollHeight,
-            body.offsetHeight,
-            documentElement.scrollHeight,
-          );
+            const { body, documentElement } = iframe.contentDocument;
+            const contentHeight = Math.max(
+              body.scrollHeight,
+              body.offsetHeight,
+              documentElement.scrollHeight,
+            );
 
-          // Only grow, never shrink: the iframe must contain the full content so
-          // it's painted, but we don't want to collapse an intentionally sized viewport.
-          if (contentHeight > iframe.clientHeight) {
-            iframe.style.height = `${contentHeight}px`;
-          }
-        });
+            // Only grow, never shrink: the iframe must contain the full content
+            // so it's painted, but we don't want to collapse an intentionally
+            // sized viewport.
+            if (contentHeight > iframe.clientHeight) {
+              iframe.style.height = `${contentHeight}px`;
+            }
+
+            // `fitToContent` fits the content in both dimensions, so the iframe
+            // must also grow horizontally to paint content wider than the
+            // viewport. Without `fitToContent` we keep the viewport width to
+            // match Playwright's `fullPage` semantics (full height, viewport
+            // width).
+            if (fitWidth) {
+              const contentWidth = Math.max(
+                body.scrollWidth,
+                body.offsetWidth,
+                documentElement.scrollWidth,
+              );
+              if (contentWidth > iframe.clientWidth) {
+                iframe.style.width = `${contentWidth}px`;
+              }
+            }
+          },
+          { fitWidth: Boolean(fitToContent) },
+        );
       },
     };
 

--- a/packages/storybook/stories/WideContent.stories.ts
+++ b/packages/storybook/stories/WideContent.stories.ts
@@ -1,0 +1,29 @@
+import { WideContent } from "./WideContent";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+/**
+ * Regression story for screenshots being cut off *horizontally* when the
+ * content is wider than the viewport.
+ *
+ * With `fitToContent`, the content is fit in both dimensions, so the iframe
+ * must grow horizontally to paint content wider than the viewport. Otherwise
+ * the screenshot is left with a large blank area on the right.
+ */
+const meta = {
+  title: "Repro/WideContent",
+  component: WideContent,
+  parameters: {
+    layout: "fullscreen",
+    argos: { modes: null },
+  },
+} satisfies Meta<typeof WideContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WideWithFitToContent: Story = {
+  args: { width: 2400 },
+  parameters: {
+    argos: { fitToContent: true, modes: null },
+  },
+};

--- a/packages/storybook/stories/WideContent.tsx
+++ b/packages/storybook/stories/WideContent.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+type WideContentProps = {
+  /** Intrinsic content width in px, wider than the viewport. */
+  width?: number;
+};
+
+/**
+ * Renders fixed-width content wider than the viewport, used to reproduce
+ * screenshots being cut off *horizontally* in the Vitest integration.
+ */
+export const WideContent = ({ width = 2400 }: WideContentProps) => {
+  return (
+    <div style={{ padding: 16, fontFamily: "sans-serif" }}>
+      <div
+        style={{
+          width,
+          padding: "12px 16px",
+          border: "2px solid #c00",
+          borderRadius: 6,
+          background:
+            "repeating-linear-gradient(90deg,#fff 0 200px,#f0f0f0 200px 400px)",
+          whiteSpace: "nowrap",
+          boxSizing: "border-box",
+        }}
+      >
+        LEFT EDGE ← this box is {width}px wide, wider than the viewport, to test
+        horizontal clipping → RIGHT EDGE
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Problem

Follow-up to #335 (which fixed *vertical* clipping). The same iframe-clipping issue also happens **horizontally**.

The story renders inside an `<iframe data-vitest="true">` and Argos screenshots the iframe's `<body>`. With `fitToContent`, the content is fit in both dimensions (`width: fit-content; zoom`), but the iframe was only grown *vertically*. Content wider than the viewport therefore overflows the iframe's width and is left unpainted — the screenshot ends up with a large blank area on the right.

## This PR (step 1 — repro only)

Adds a `Repro/WideContent` story: fixed-width content (2400px) wider than the viewport, with `fitToContent`. On `main` this produces a screenshot whose canvas is the full content width but only the leftmost ~viewport-width is painted (rest blank). The fix is pushed as a follow-up commit so the Argos diff demonstrates the screenshot going from cut → complete.

Note: the non-`fitToContent` (`fullPage`) case intentionally keeps viewport width, matching Playwright's `fullPage` semantics (full height, viewport width), so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)