### PR TITLE
feat(vitest): add standalone @argos-ci/vitest package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,29 @@ jobs:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
           NODE_VERSION: ${{ matrix.node-version }}
           OS: ${{ matrix.os }}
+
+  e2e-vitest:
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [lts/*]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup deps
+        uses: ./.github/actions/setup-deps
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run integration tests
+        run: pnpm exec -- turbo run e2e --filter=@argos-ci/vitest
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+          NODE_VERSION: ${{ matrix.node-version }}
+          OS: ${{ matrix.os }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,8 @@ package.json
 lerna.json
 CHANGELOG.md
 dist
+/packages/*/test-results
+/packages/*/screenshots
 /docs
 __fixtures__/screenshots/invalid.argos.json
 /packages/api-client/src/schema.ts

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "@argos-ci/core": "workspace:*",
     "@argos-ci/playwright": "workspace:*",
-    "@argos-ci/util": "workspace:*"
+    "@argos-ci/util": "workspace:*",
+    "@argos-ci/vitest": "workspace:*"
   },
   "devDependencies": {
     "@argos-ci/cli": "workspace:*",
@@ -62,6 +63,7 @@
     "@storybook/addon-vitest": "^10.4.6",
     "@storybook/react-vite": "^10.4.6",
     "@storybook/test-runner": "^0.24.4",
+    "@types/node": "catalog:",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitest/browser": "^4.1.9",

--- a/packages/storybook/src/vitest-plugin.ts
+++ b/packages/storybook/src/vitest-plugin.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "vitest/config";
-import type { BrowserCommand, BrowserCommandContext } from "vitest/node";
+import type { BrowserCommand } from "vitest/node";
 import {
   storybookArgosScreenshot,
   type ArgosScreenshotOptions,
@@ -10,7 +10,15 @@ import {
   type FitToContent,
 } from "./utils/parameters";
 import type { Frame } from "playwright";
-import { ArgosReporter, type ArgosReporterConfig } from "./vitest-reporter";
+import {
+  ArgosReporter,
+  type ArgosReporterConfig,
+} from "@argos-ci/vitest/plugin";
+import {
+  resetTesterScale,
+  setIframeViewportSize,
+  fitIframeToContent,
+} from "@argos-ci/vitest/internal";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -42,7 +50,7 @@ export const createArgosScreenshotCommand = (
     const fitToContent = getFitToContentFromParameters(
       testContext.story.parameters,
     );
-    const after = await before(ctx);
+    const after = await resetTesterScale(ctx);
 
     const options = applyFitToContent(screenshotOptions, fitToContent);
     // The story renders inside an `<iframe data-vitest="true">` on the host page
@@ -56,49 +64,11 @@ export const createArgosScreenshotCommand = (
       ...options,
       beforeScreenshot: async (api) => {
         await userBeforeScreenshot?.(api);
-        await ctx.page.evaluate(
-          ({ fitWidth }) => {
-            const iframe = document.querySelector('iframe[data-vitest="true"]');
-
-            if (
-              !(iframe instanceof HTMLIFrameElement) ||
-              !iframe.contentDocument
-            ) {
-              return;
-            }
-
-            const { body, documentElement } = iframe.contentDocument;
-            const contentHeight = Math.max(
-              body.scrollHeight,
-              body.offsetHeight,
-              documentElement.scrollHeight,
-            );
-
-            // Only grow, never shrink: the iframe must contain the full content
-            // so it's painted, but we don't want to collapse an intentionally
-            // sized viewport.
-            if (contentHeight > iframe.clientHeight) {
-              iframe.style.height = `${contentHeight}px`;
-            }
-
-            // `fitToContent` fits the content in both dimensions, so the iframe
-            // must also grow horizontally to paint content wider than the
-            // viewport. Without `fitToContent` we keep the viewport width to
-            // match Playwright's `fullPage` semantics (full height, viewport
-            // width).
-            if (fitWidth) {
-              const contentWidth = Math.max(
-                body.scrollWidth,
-                body.offsetWidth,
-                documentElement.scrollWidth,
-              );
-              if (contentWidth > iframe.clientWidth) {
-                iframe.style.width = `${contentWidth}px`;
-              }
-            }
-          },
-          { fitWidth: Boolean(fitToContent) },
-        );
+        // `fitToContent` fits the content in both dimensions, so the iframe must
+        // also grow horizontally to paint content wider than the viewport.
+        // Without `fitToContent` we keep the viewport width to match Playwright's
+        // `fullPage` semantics (full height, viewport width).
+        await fitIframeToContent(ctx, { fitWidth: Boolean(fitToContent) });
       },
     };
 
@@ -108,65 +78,9 @@ export const createArgosScreenshotCommand = (
         ...testContext,
         playwrightLibraries: ["@storybook/addon-vitest"],
         setViewportSize: async (size) => {
-          await ctx.page.evaluate(
-            ({ size, fullPage }) => {
-              const iframe = document.querySelector(
-                'iframe[data-vitest="true"]',
-              );
-
-              if (!(iframe instanceof HTMLIFrameElement)) {
-                throw new Error("Vitest iframe not found");
-              }
-
-              if (!iframe.contentDocument) {
-                throw new Error("Vitest iframe contentDocument not found");
-              }
-
-              if (size === "initial") {
-                if (
-                  iframe.dataset.initialWidth &&
-                  iframe.dataset.initialHeight
-                ) {
-                  iframe.style.width = iframe.dataset.initialWidth;
-                  iframe.style.height = iframe.dataset.initialHeight;
-                }
-                return;
-              }
-
-              // Backup default width/height if not set
-              if (
-                !iframe.dataset.initialWidth &&
-                !iframe.dataset.initialHeight
-              ) {
-                iframe.dataset.initialWidth = iframe.style.width;
-                iframe.dataset.initialHeight = iframe.style.height;
-              }
-
-              if (size !== "default") {
-                iframe.style.width = `${size.width}px`;
-              }
-
-              if (fullPage) {
-                if (!iframe.contentWindow) {
-                  throw new Error(`Can't access iframe window`);
-                }
-                const viewportHeight =
-                  size === "default"
-                    ? iframe.contentWindow.innerHeight
-                    : size.height;
-
-                iframe.style.height = "auto";
-                iframe.style.height =
-                  viewportHeight < iframe.contentDocument.body.offsetHeight
-                    ? `${iframe.contentDocument.body.offsetHeight}px`
-                    : "100%";
-              } else if (size !== "default") {
-                iframe.style.height = "auto";
-                iframe.style.height = `${size.height}px`;
-              }
-            },
-            { size, fullPage: screenshotOptions.fullPage ?? !fitToContent },
-          );
+          await setIframeViewportSize(ctx, size, {
+            fullPage: screenshotOptions.fullPage ?? !fitToContent,
+          });
         },
       },
       optionsWithFit,
@@ -175,45 +89,6 @@ export const createArgosScreenshotCommand = (
     return attachments;
   };
 };
-
-/**
- * Run before taking the screenshots.
- * Remove the scale from vitest "vitest-tester" div
- * to avoid ending up with small screenshots.
- * @returns A function to restore the scale after the test.
- */
-async function before(
-  ctx: BrowserCommandContext,
-): Promise<() => Promise<void>> {
-  await ctx.page.evaluate(() => {
-    const tester = document.getElementById("vitest-tester");
-
-    if (!(tester instanceof HTMLElement)) {
-      return;
-    }
-
-    const scale = tester.getAttribute("data-scale");
-
-    if (!scale) {
-      throw new Error("Vitest iframe data-scale attribute not found");
-    }
-
-    tester.dataset.bckTransform = tester.style.transform;
-    tester.style.transform = `scale(1)`;
-  });
-
-  return async () => {
-    await ctx.page.evaluate(() => {
-      const tester = document.getElementById("vitest-tester");
-
-      if (!(tester instanceof HTMLElement)) {
-        return;
-      }
-
-      tester.style.transform = tester.dataset.bckTransform ?? "";
-    });
-  };
-}
 
 /**
  * Apply fitToContent options to the screenshot options.
@@ -268,7 +143,7 @@ export function argosVitestPlugin(options?: ArgosVitestPluginOptions): Plugin {
         test: {
           browser: {
             commands: {
-              argosScreenshot: createArgosScreenshotCommand({
+              argosStorybookScreenshot: createArgosScreenshotCommand({
                 ...otherOptions,
                 root,
               }),

--- a/packages/storybook/src/vitest.ts
+++ b/packages/storybook/src/vitest.ts
@@ -10,7 +10,7 @@ export type { ArgosScreenshotOptions };
 
 declare module "vitest/browser" {
   interface BrowserCommands {
-    argosScreenshot: (
+    argosStorybookScreenshot: (
       ...args: ArgosScreenshotCommandArgs
     ) => Promise<ArgosAttachment[]>;
   }
@@ -37,7 +37,7 @@ export function setupArgos(api: { afterEach: typeof vitest.afterEach }) {
     (globalThis as any).__ARGOS_STORYBOOK_STORY = story;
 
     // Take the screenshot.
-    await server.commands.argosScreenshot({
+    await server.commands.argosStorybookScreenshot({
       mode: "automatic",
       name: story.id,
       story: {
@@ -82,7 +82,7 @@ export async function argosScreenshot(
 
   // Load vitest/browser using dynamic import to avoid loading it in non-Vitest environments.
   const { server } = await import("vitest/browser");
-  await server.commands.argosScreenshot({
+  await server.commands.argosStorybookScreenshot({
     mode: "manual",
     name: `${story.id}/${name}`,
     story: {

--- a/packages/vitest/.gitignore
+++ b/packages/vitest/.gitignore
@@ -1,0 +1,1 @@
+/screenshots/

--- a/packages/vitest/.npmignore
+++ b/packages/vitest/.npmignore
@@ -1,0 +1,7 @@
+/*
+!dist/index.mjs
+!dist/index.d.mts
+!dist/plugin.mjs
+!dist/plugin.d.mts
+!dist/internal.mjs
+!dist/internal.d.mts

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -1,0 +1,77 @@
+<p align="center">
+  <a href="https://argos-ci.com/?utm_source=github&utm_medium=logo" target="_blank">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/argos-ci/argos/main/resources/logos/github-readme-logo-dark.png">
+    <img alt="Argos" src="https://raw.githubusercontent.com/argos-ci/argos/main/resources/logos/github-readme-logo-light.png" width="360" height="70">
+  </picture>
+  </a>
+</p>
+
+<p align="center"><strong>The open source visual testing platform for modern engineering teams.</strong></p>
+
+# Official Argos Vitest integration
+
+[![npm version](https://img.shields.io/npm/v/@argos-ci/vitest.svg)](https://www.npmjs.com/package/@argos-ci/vitest)
+[![npm dm](https://img.shields.io/npm/dm/@argos-ci/vitest.svg)](https://www.npmjs.com/package/@argos-ci/vitest)
+[![npm dt](https://img.shields.io/npm/dt/@argos-ci/vitest.svg)](https://www.npmjs.com/package/@argos-ci/vitest)
+
+Capture Argos screenshots directly from your [Vitest browser tests](https://vitest.dev/guide/browser/).
+
+Visit [argos-ci.com/docs/vitest](https://argos-ci.com/docs/vitest) for guides, API and more.
+
+## Requirements
+
+`@argos-ci/vitest` runs in [Vitest browser mode](https://vitest.dev/guide/browser/) with the
+[Playwright provider](https://vitest.dev/guide/browser/playwright). Install the following peer
+dependencies alongside it:
+
+```sh
+npm install --save-dev @argos-ci/vitest vitest @vitest/browser @vitest/browser-playwright playwright
+```
+
+## Usage
+
+Register the plugin in your Vitest config:
+
+```ts
+// vitest.config.ts
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import { argosVitestPlugin } from "@argos-ci/vitest/plugin";
+
+export default defineConfig({
+  plugins: [
+    argosVitestPlugin({
+      // Upload the screenshots to Argos at the end of the run.
+      uploadToArgos: process.env.CI === "true",
+    }),
+  ],
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});
+```
+
+Then take screenshots from your browser tests:
+
+```ts
+import { test } from "vitest";
+import { render } from "vitest-browser-react";
+import { argosScreenshot } from "@argos-ci/vitest";
+import { Button } from "./Button";
+
+test("Button", async () => {
+  render(<Button>Click me</Button>);
+  await argosScreenshot("button");
+});
+```
+
+## Links
+
+- [Official SDK Docs](https://argos-ci.com/docs/)
+- [Discord](https://argos-ci.com/discord)

--- a/packages/vitest/docs/index.mdx
+++ b/packages/vitest/docs/index.mdx
@@ -1,0 +1,105 @@
+---
+title: Vitest
+slug: /vitest
+---
+
+# Argos Vitest SDK
+
+Capture and review visual changes straight from your [Vitest browser tests](https://vitest.dev/guide/browser/) with Argos.
+
+The `@argos-ci/vitest` SDK takes screenshots while Vitest runs your tests in a real browser (using the [Playwright provider](https://vitest.dev/guide/browser/playwright)) and uploads them to Argos in your CI.
+
+## Requirements
+
+The SDK runs in [Vitest browser mode](https://vitest.dev/guide/browser/) with the Playwright provider. Install it alongside its peer dependencies:
+
+```sh
+npm install --save-dev @argos-ci/vitest vitest @vitest/browser @vitest/browser-playwright playwright
+```
+
+## Getting Started
+
+### 1. Register the plugin
+
+```ts title="vitest.config.ts"
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import { argosVitestPlugin } from "@argos-ci/vitest/plugin";
+
+export default defineConfig({
+  plugins: [
+    argosVitestPlugin({
+      // Upload the screenshots to Argos at the end of the run.
+      uploadToArgos: process.env.CI === "true",
+    }),
+  ],
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});
+```
+
+### 2. Take screenshots
+
+```ts title="Button.test.tsx"
+import { test } from "vitest";
+import { render } from "vitest-browser-react";
+import { argosScreenshot } from "@argos-ci/vitest";
+import { Button } from "./Button";
+
+test("Button", async () => {
+  render(<Button>Click me</Button>);
+  await argosScreenshot("button");
+});
+```
+
+## API Overview
+
+### `@argos-ci/vitest/plugin`
+
+Exposes the Vitest plugin that registers the `argosScreenshot` browser command and, when
+`uploadToArgos` is enabled, the reporter that uploads the screenshots.
+
+```ts
+import { argosVitestPlugin } from "@argos-ci/vitest/plugin";
+```
+
+- **`uploadToArgos`**: Set to `true` to upload the screenshots to Argos at the end of the run (default: `false`).
+- **`root`**: Folder where the screenshots are written (default: `"./screenshots"`).
+
+It also accepts every option of the [Playwright `argosScreenshot` function](/playwright#argosscreenshotpage-name-options) (used as defaults for every screenshot, including non-serializable options like `beforeScreenshot`) and every [upload parameter](https://js-sdk-reference.argos-ci.com/interfaces/UploadParameters.html) (e.g. `buildName`).
+
+### `@argos-ci/vitest`
+
+Take a screenshot from within a browser test.
+
+```ts
+import { argosScreenshot } from "@argos-ci/vitest";
+
+await argosScreenshot("my-screenshot", {
+  // Take a screenshot of a specific element.
+  element: "#my-element",
+  // Capture several viewports.
+  viewports: [{ width: 320, height: 480 }, "macbook-13"],
+});
+```
+
+- **`name`**: A unique name for the screenshot.
+- **`options`**: Serializable screenshot options. Because they cross the Vitest browser/node boundary, non-serializable options (functions, `Locator` elements) must be set on the plugin instead.
+
+#### Options
+
+- **`element`**: String selector of the element to capture.
+- **`viewports`**: Viewports to capture (a size, a [preset name](/viewports), or `{ preset, orientation }`).
+- **`fullPage`**: Capture the full page instead of fitting the screenshot to the content (default: `false`).
+- **`argosCSS`**: Custom CSS evaluated during the screenshot.
+- **`threshold`**: Sensitivity threshold between `0` and `1` (default: `0.5`).
+- **`tag`**: Tag or array of tags to attach to the screenshot.
+- **`ariaSnapshot`**: Capture an ARIA snapshot along with the screenshot (default: `false`).
+- **`disableHover`**: Disable hover effects before capturing (default: `true`).
+- **`stabilize`**: Wait for the UI to stabilize before capturing (default: `true`).

--- a/packages/vitest/e2e/screenshot.test.ts
+++ b/packages/vitest/e2e/screenshot.test.ts
@@ -112,9 +112,16 @@ test("grows the iframe to capture content wider than the viewport", async () => 
   expect(width).toBeGreaterThan(1500);
 });
 
-test("forwards the ariaSnapshot option across the RPC boundary", async () => {
+test("captures an ARIA snapshot alongside the screenshot", async () => {
   mount(`<button>Click me</button>`);
   const attachments = await argosScreenshot("aria", { ariaSnapshot: true });
   // ariaSnapshot adds the aria + aria/metadata attachments: 2 -> 4.
   expect(attachments.length).toBe(4);
+
+  // The `.aria.yml` snapshot is written and contains the accessibility tree, so
+  // it can be picked up by the reporter's upload glob.
+  const aria = attachments.find((a) => a.path.endsWith(".aria.yml"));
+  expect(aria).toBeDefined();
+  const snapshot = await server.commands.readFile(aria!.path);
+  expect(snapshot).toContain('button "Click me"');
 });

--- a/packages/vitest/e2e/screenshot.test.ts
+++ b/packages/vitest/e2e/screenshot.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, expect, test } from "vitest";
+import { server } from "vitest/browser";
+import { argosScreenshot } from "@argos-ci/vitest";
+import type { ArgosAttachment } from "@argos-ci/playwright";
+
+/**
+ * These tests run in a real browser (Vitest browser mode + Playwright) and
+ * exercise the full screenshot flow: reset the tester scale, resize the iframe,
+ * capture the frame body via `@argos-ci/playwright`, and write the screenshots
+ * to `./screenshots`. When `UPLOAD_TO_ARGOS=true`, the reporter uploads them.
+ *
+ * Files written by the node side are read back through Vitest's built-in
+ * `readFile` browser command so we can assert their content.
+ */
+
+function mount(html: string) {
+  document.body.innerHTML = html;
+}
+
+function findMetadata(attachments: ArgosAttachment[]) {
+  return attachments.find((a) => a.path.endsWith(".png.argos.json"));
+}
+
+async function readMetadata(attachments: ArgosAttachment[]) {
+  const metadata = findMetadata(attachments);
+  if (!metadata) {
+    throw new Error("No screenshot metadata attachment found");
+  }
+  return JSON.parse(await server.commands.readFile(metadata.path));
+}
+
+/** Decode a PNG's pixel width from its IHDR chunk (big-endian uint32 @ byte 16). */
+async function readPngWidth(attachment: ArgosAttachment) {
+  const bin = await server.commands.readFile(attachment.path, "latin1");
+  return (
+    (bin.charCodeAt(16) << 24) |
+    (bin.charCodeAt(17) << 16) |
+    (bin.charCodeAt(18) << 8) |
+    bin.charCodeAt(19)
+  );
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.body.style.margin = "0";
+});
+
+test("captures a rendered element with the Argos Vitest SDK metadata", async () => {
+  mount(
+    `<div style="padding:40px;background:#0ea5e9;color:#fff;font:700 32px sans-serif;">Hello Argos</div>`,
+  );
+  const attachments = await argosScreenshot("hello");
+  // One screenshot + its metadata attachment.
+  expect(attachments.length).toBe(2);
+
+  // The whole point of the package: the screenshot is attributed to this SDK
+  // and to the Playwright provider (proves setMetadataConfig propagated).
+  const metadata = await readMetadata(attachments);
+  expect(metadata.sdk.name).toBe("@argos-ci/vitest");
+  expect(metadata.automationLibrary.name).toBe("@vitest/browser-playwright");
+});
+
+test("captures a specific element via a selector", async () => {
+  mount(
+    `<div id="box" style="width:200px;height:120px;background:tomato"></div><p>ignored</p>`,
+  );
+  const attachments = await argosScreenshot("box", { element: "#box" });
+  expect(attachments.length).toBe(2);
+});
+
+test("captures multiple viewports with per-viewport metadata", async () => {
+  mount(
+    `<div style="width:100%;box-sizing:border-box;padding:24px;background:linear-gradient(#f97316,#7c3aed);color:#fff;font:600 20px sans-serif;">Responsive content</div>`,
+  );
+  const attachments = await argosScreenshot("responsive", {
+    viewports: [{ width: 320, height: 480 }, "macbook-13"],
+  });
+  // One screenshot + metadata per viewport.
+  expect(attachments.length).toBe(4);
+
+  const narrow = attachments.find((a) =>
+    a.path.endsWith("responsive vw-320.png.argos.json"),
+  );
+  expect(narrow).toBeDefined();
+  const narrowMetadata = JSON.parse(
+    await server.commands.readFile(narrow!.path),
+  );
+  expect(narrowMetadata.viewport).toEqual({ width: 320, height: 480 });
+});
+
+test("supports custom CSS and full page", async () => {
+  mount(
+    `<div style="height:1600px;background:repeating-linear-gradient(#111,#111 40px,#222 40px,#222 80px)"></div>`,
+  );
+  const attachments = await argosScreenshot("tall", {
+    fullPage: true,
+    argosCSS: "body { background: white; }",
+  });
+  expect(attachments.length).toBe(2);
+});
+
+test("grows the iframe to capture content wider than the viewport", async () => {
+  mount(
+    `<div style="width:2000px;height:200px;background:linear-gradient(90deg,#22c55e,#3b82f6)"></div>`,
+  );
+  // Default (fullPage: false) fits the content in both dimensions, so the
+  // capture must be wider than the viewport instead of clipping it.
+  const attachments = await argosScreenshot("wide");
+  const screenshot = attachments.find((a) => a.path.endsWith("wide.png"));
+  expect(screenshot).toBeDefined();
+  const width = await readPngWidth(screenshot!);
+  expect(width).toBeGreaterThan(1500);
+});
+
+test("forwards the ariaSnapshot option across the RPC boundary", async () => {
+  mount(`<button>Click me</button>`);
+  const attachments = await argosScreenshot("aria", { ariaSnapshot: true });
+  // ariaSnapshot adds the aria + aria/metadata attachments: 2 -> 4.
+  expect(attachments.length).toBe(4);
+});

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@argos-ci/vitest",
+  "description": "Vitest SDK for visual testing with Argos.",
+  "version": "0.1.0",
+  "author": "Smooth Code",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/argos-ci/argos-javascript.git",
+    "directory": "packages/vitest"
+  },
+  "homepage": "https://argos-ci.com/docs/vitest",
+  "bugs": {
+    "url": "https://github.com/argos-ci/argos-javascript/issues"
+  },
+  "keywords": [
+    "vitest",
+    "vitest-plugin",
+    "vitest-browser",
+    "screenshot",
+    "capture",
+    "testing",
+    "visual testing",
+    "argos",
+    "regression",
+    "visual regression"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.mts",
+      "import": "./dist/plugin.mjs",
+      "default": "./dist/plugin.mjs"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.mts",
+      "import": "./dist/internal.mjs",
+      "default": "./dist/internal.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@argos-ci/browser": "workspace:*",
+    "@argos-ci/core": "workspace:*",
+    "@argos-ci/playwright": "workspace:*",
+    "@argos-ci/util": "workspace:*"
+  },
+  "peerDependencies": {
+    "@vitest/browser": ">=4",
+    "@vitest/browser-playwright": ">=4",
+    "playwright": ">=1",
+    "vitest": ">=4"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@vitest/browser": "^4.1.9",
+    "@vitest/browser-playwright": "^4.1.9",
+    "playwright": "^1.61.0",
+    "vitest": "catalog:"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run --project unit",
+    "test-e2e": "vitest run --project e2e",
+    "install-playwright": "playwright install chromium --with-deps",
+    "build-e2e": "pnpm run install-playwright",
+    "e2e": "cross-env BUILD_NAME=\"argos-vitest-e2e-node-$NODE_VERSION-$OS\" UPLOAD_TO_ARGOS=true pnpm run test-e2e",
+    "check-types": "tsc",
+    "check-format": "prettier --check --ignore-unknown --ignore-path=./.gitignore --ignore-path=../../.gitignore --ignore-path=../../.prettierignore .",
+    "lint": "eslint ."
+  }
+}

--- a/packages/vitest/src/command.test.ts
+++ b/packages/vitest/src/command.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserCommandContext } from "vitest/node";
+
+const { argosScreenshot, setMetadataConfig } = vi.hoisted(() => ({
+  argosScreenshot: vi.fn(),
+  setMetadataConfig: vi.fn(),
+}));
+
+vi.mock("@argos-ci/playwright", () => ({
+  argosScreenshot,
+  DO_NOT_USE_setMetadataConfig: setMetadataConfig,
+}));
+
+vi.mock("./version", () => ({
+  getArgosVitestVersion: vi.fn().mockResolvedValue("0.0.0-test"),
+}));
+
+import { createArgosScreenshotCommand } from "./command";
+
+function createCtx() {
+  const evaluate = vi.fn().mockResolvedValue(undefined);
+  const frame = { __brand: "frame" };
+  const ctx = {
+    page: { evaluate },
+    frame: vi.fn().mockResolvedValue(frame),
+  } as unknown as BrowserCommandContext;
+  return { ctx, evaluate, frame };
+}
+
+describe("createArgosScreenshotCommand", () => {
+  beforeEach(() => {
+    argosScreenshot.mockReset().mockResolvedValue([
+      { name: "argos-screenshot", contentType: "image/png", path: "/x.png" },
+      {
+        name: "argos-screenshot/metadata",
+        contentType: "application/json",
+        path: "/x.json",
+      },
+    ]);
+    setMetadataConfig.mockReset();
+  });
+
+  it("throws when the name is missing", async () => {
+    const command = createArgosScreenshotCommand();
+    const { ctx } = createCtx();
+    await expect(command(ctx, "")).rejects.toThrow("name");
+  });
+
+  it("merges per-call options over plugin defaults and preserves node-only hooks", async () => {
+    const pluginBeforeScreenshot = vi.fn();
+    const command = createArgosScreenshotCommand({
+      element: "#plugin-default",
+      threshold: 0.9,
+      beforeScreenshot: pluginBeforeScreenshot,
+    });
+    const { ctx, frame } = createCtx();
+
+    await command(ctx, "shot", { element: "#per-call" });
+
+    expect(argosScreenshot).toHaveBeenCalledTimes(1);
+    const [passedFrame, name, opts] = argosScreenshot.mock.calls[0]!;
+    expect(passedFrame).toBe(frame);
+    expect(name).toBe("shot");
+    // Per-call option wins over the plugin default.
+    expect(opts.element).toBe("#per-call");
+    // Plugin-only (node-side) option is preserved.
+    expect(opts.threshold).toBe(0.9);
+    // Vitest-specific options are stripped before reaching Playwright.
+    expect(opts.viewports).toBeUndefined();
+    expect(opts.fullPage).toBeUndefined();
+    // The node-only hook is wrapped, not dropped: invoking it runs the plugin hook.
+    expect(typeof opts.beforeScreenshot).toBe("function");
+    await opts.beforeScreenshot({ runStabilization: vi.fn() });
+    expect(pluginBeforeScreenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets the Argos SDK metadata before capturing", async () => {
+    const command = createArgosScreenshotCommand();
+    const { ctx } = createCtx();
+
+    await command(ctx, "shot");
+
+    expect(setMetadataConfig).toHaveBeenCalled();
+    const metadata = setMetadataConfig.mock.calls.at(-1)![0];
+    expect(metadata.sdk).toEqual({
+      name: "@argos-ci/vitest",
+      version: "0.0.0-test",
+    });
+    expect(metadata.playwrightLibraries).toContain(
+      "@vitest/browser-playwright",
+    );
+  });
+
+  it("takes one screenshot per viewport with viewport-suffixed names", async () => {
+    const command = createArgosScreenshotCommand();
+    const { ctx } = createCtx();
+
+    const attachments = await command(ctx, "resp", {
+      viewports: [
+        { width: 320, height: 480 },
+        { width: 1280, height: 800 },
+      ],
+    });
+
+    expect(argosScreenshot).toHaveBeenCalledTimes(2);
+    const names = argosScreenshot.mock.calls.map((call) => call[1]);
+    expect(names).toEqual(["resp vw-320", "resp vw-1280"]);
+    // Each viewport records its size in the metadata.
+    const viewports = setMetadataConfig.mock.calls.map(
+      (call) => call[0].viewport,
+    );
+    expect(viewports).toContainEqual({ width: 320, height: 480 });
+    expect(viewports).toContainEqual({ width: 1280, height: 800 });
+    // Attachments from every viewport are returned.
+    expect(attachments).toHaveLength(4);
+  });
+});

--- a/packages/vitest/src/command.ts
+++ b/packages/vitest/src/command.ts
@@ -1,0 +1,87 @@
+import type { BrowserCommand } from "vitest/node";
+import {
+  DO_NOT_USE_setMetadataConfig,
+  type ArgosAttachment,
+} from "@argos-ci/playwright";
+import { resolveViewport, type ViewportSize } from "@argos-ci/browser";
+import { getScreenshotName } from "@argos-ci/util";
+import type {
+  ArgosVitestPluginOptions,
+  VitestScreenshotOptions,
+} from "./options";
+import { resetTesterScale, setIframeViewportSize } from "./iframe";
+import { screenshotFrame } from "./screenshot";
+import { getArgosVitestVersion } from "./version";
+
+/**
+ * Arguments of the `argosScreenshot` browser command.
+ * Only serializable values cross the browser/node RPC boundary.
+ */
+export type ArgosScreenshotCommandArgs = [
+  name: string,
+  options?: VitestScreenshotOptions,
+];
+
+/**
+ * Create the `argosScreenshot` browser command used to capture Argos
+ * screenshots from Vitest browser tests.
+ *
+ * Non-serializable options (`beforeScreenshot`, `afterScreenshot`, a
+ * `Locator`/`ElementHandle` `element`, …) come from `pluginOptions` (node side)
+ * and are merged with the serializable per-call options (per-call wins).
+ */
+export const createArgosScreenshotCommand = (
+  pluginOptions: ArgosVitestPluginOptions = {},
+): BrowserCommand<ArgosScreenshotCommandArgs> => {
+  return async (ctx, name, options) => {
+    if (!name) {
+      throw new Error("The `name` argument is required.");
+    }
+
+    const merged: ArgosVitestPluginOptions = { ...pluginOptions, ...options };
+    const fullPage = merged.fullPage ?? false;
+    const fitWidth = !fullPage;
+
+    const restore = await resetTesterScale(ctx);
+    try {
+      const version = await getArgosVitestVersion();
+      const setMetadata = (viewport?: ViewportSize) => {
+        DO_NOT_USE_setMetadataConfig({
+          sdk: { name: "@argos-ci/vitest", version },
+          playwrightLibraries: ["@vitest/browser-playwright"],
+          viewport,
+        });
+      };
+
+      const attachments: ArgosAttachment[] = [];
+
+      if (merged.viewports && merged.viewports.length > 0) {
+        // Playwright's `viewports` option throws on a Frame, so we reimplement
+        // it by resizing the Vitest iframe for each viewport.
+        for (const viewport of merged.viewports) {
+          const size = resolveViewport(viewport);
+          await setIframeViewportSize(ctx, size, { fullPage });
+          setMetadata(size);
+          const shot = await screenshotFrame(
+            ctx,
+            getScreenshotName(name, { viewportWidth: size.width }),
+            merged,
+            // Keep the fixed viewport width, only grow the height to fit.
+            { fitWidth: false },
+          );
+          attachments.push(...shot);
+          await setIframeViewportSize(ctx, "initial", { fullPage });
+        }
+      } else {
+        await setIframeViewportSize(ctx, "default", { fullPage });
+        setMetadata();
+        const shot = await screenshotFrame(ctx, name, merged, { fitWidth });
+        attachments.push(...shot);
+      }
+
+      return attachments;
+    } finally {
+      await restore();
+    }
+  };
+};

--- a/packages/vitest/src/iframe.ts
+++ b/packages/vitest/src/iframe.ts
@@ -1,0 +1,175 @@
+import type { BrowserCommandContext } from "vitest/node";
+import type { ViewportSize } from "@argos-ci/browser";
+
+/**
+ * Selector of the iframe Vitest renders the test into on the orchestrator page.
+ */
+export const VITEST_IFRAME_SELECTOR = 'iframe[data-vitest="true"]';
+
+/**
+ * ID of the Vitest "tester" element that wraps the iframe with a `scale(...)`
+ * transform.
+ */
+export const VITEST_TESTER_ID = "vitest-tester";
+
+/**
+ * Remove the scale from the Vitest `#vitest-tester` element before taking a
+ * screenshot to avoid ending up with small screenshots.
+ * @returns A function to restore the scale after the screenshot.
+ */
+export async function resetTesterScale(
+  ctx: BrowserCommandContext,
+): Promise<() => Promise<void>> {
+  await ctx.page.evaluate((testerId) => {
+    const tester = document.getElementById(testerId);
+
+    if (!(tester instanceof HTMLElement)) {
+      return;
+    }
+
+    const scale = tester.getAttribute("data-scale");
+
+    if (!scale) {
+      throw new Error("Vitest iframe data-scale attribute not found");
+    }
+
+    tester.dataset.bckTransform = tester.style.transform;
+    tester.style.transform = `scale(1)`;
+  }, VITEST_TESTER_ID);
+
+  return async () => {
+    await ctx.page.evaluate((testerId) => {
+      const tester = document.getElementById(testerId);
+
+      if (!(tester instanceof HTMLElement)) {
+        return;
+      }
+
+      tester.style.transform = tester.dataset.bckTransform ?? "";
+    }, VITEST_TESTER_ID);
+  };
+}
+
+/**
+ * Resize the Vitest iframe.
+ *
+ * The story/test renders inside an `<iframe data-vitest="true">` on the host
+ * page and we screenshot the iframe's `<body>`. Anything overflowing the iframe
+ * box is not painted, so the iframe must be sized to hold the content.
+ *
+ * @param size - The viewport size, `"default"` to keep the natural size, or
+ *   `"initial"` to restore the size backed up on the first resize.
+ * @param options.fullPage - When `true`, grow the height to fit the content
+ *   while keeping the viewport width (Playwright-style full page).
+ */
+export async function setIframeViewportSize(
+  ctx: BrowserCommandContext,
+  size: ViewportSize | "default" | "initial",
+  options: { fullPage?: boolean } = {},
+): Promise<void> {
+  await ctx.page.evaluate(
+    ({ size, fullPage, selector }) => {
+      const iframe = document.querySelector(selector);
+
+      if (!(iframe instanceof HTMLIFrameElement)) {
+        throw new Error("Vitest iframe not found");
+      }
+
+      if (!iframe.contentDocument) {
+        throw new Error("Vitest iframe contentDocument not found");
+      }
+
+      if (size === "initial") {
+        if (iframe.dataset.initialWidth && iframe.dataset.initialHeight) {
+          iframe.style.width = iframe.dataset.initialWidth;
+          iframe.style.height = iframe.dataset.initialHeight;
+        }
+        return;
+      }
+
+      // Backup default width/height if not set
+      if (!iframe.dataset.initialWidth && !iframe.dataset.initialHeight) {
+        iframe.dataset.initialWidth = iframe.style.width;
+        iframe.dataset.initialHeight = iframe.style.height;
+      }
+
+      if (size !== "default") {
+        iframe.style.width = `${size.width}px`;
+      }
+
+      if (fullPage) {
+        if (!iframe.contentWindow) {
+          throw new Error(`Can't access iframe window`);
+        }
+        const viewportHeight =
+          size === "default" ? iframe.contentWindow.innerHeight : size.height;
+
+        iframe.style.height = "auto";
+        iframe.style.height =
+          viewportHeight < iframe.contentDocument.body.offsetHeight
+            ? `${iframe.contentDocument.body.offsetHeight}px`
+            : "100%";
+      } else if (size !== "default") {
+        iframe.style.height = "auto";
+        iframe.style.height = `${size.height}px`;
+      }
+    },
+    {
+      size,
+      fullPage: options.fullPage ?? false,
+      selector: VITEST_IFRAME_SELECTOR,
+    },
+  );
+}
+
+/**
+ * Grow the Vitest iframe to fit its content so nothing is clipped.
+ *
+ * This must run *after* `argosCSS` (which may inject a `zoom`) is applied,
+ * because `setIframeViewportSize` sizes the iframe *before* the content's final
+ * size is known. It only ever grows the iframe, never shrinks it.
+ *
+ * @param options.fitWidth - Also grow the iframe horizontally to paint content
+ *   wider than the viewport. When `false`, only the height grows (to match
+ *   Playwright's `fullPage` semantics: full height, viewport width).
+ */
+export async function fitIframeToContent(
+  ctx: BrowserCommandContext,
+  options: { fitWidth: boolean },
+): Promise<void> {
+  await ctx.page.evaluate(
+    ({ fitWidth, selector }) => {
+      const iframe = document.querySelector(selector);
+
+      if (!(iframe instanceof HTMLIFrameElement) || !iframe.contentDocument) {
+        return;
+      }
+
+      const { body, documentElement } = iframe.contentDocument;
+      const contentHeight = Math.max(
+        body.scrollHeight,
+        body.offsetHeight,
+        documentElement.scrollHeight,
+      );
+
+      // Only grow, never shrink: the iframe must contain the full content so
+      // it's painted, but we don't want to collapse an intentionally sized
+      // viewport.
+      if (contentHeight > iframe.clientHeight) {
+        iframe.style.height = `${contentHeight}px`;
+      }
+
+      if (fitWidth) {
+        const contentWidth = Math.max(
+          body.scrollWidth,
+          body.offsetWidth,
+          documentElement.scrollWidth,
+        );
+        if (contentWidth > iframe.clientWidth) {
+          iframe.style.width = `${contentWidth}px`;
+        }
+      }
+    },
+    { fitWidth: options.fitWidth, selector: VITEST_IFRAME_SELECTOR },
+  );
+}

--- a/packages/vitest/src/index.test.ts
+++ b/packages/vitest/src/index.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "vitest";
+import { argosScreenshot, checkIsVitestEnv } from "./index";
+
+it("detects the Vitest environment", async () => {
+  await expect(checkIsVitestEnv()).resolves.toBe(true);
+});
+
+it("exports the argosScreenshot function", () => {
+  expect(typeof argosScreenshot).toBe("function");
+});

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,0 +1,62 @@
+import type { ArgosAttachment } from "@argos-ci/playwright";
+import type { VitestScreenshotOptions } from "./options";
+
+export type { VitestScreenshotOptions };
+
+declare module "vitest/browser" {
+  interface BrowserCommands {
+    argosScreenshot: (
+      name: string,
+      options?: VitestScreenshotOptions,
+    ) => Promise<ArgosAttachment[]>;
+  }
+}
+
+/**
+ * Take an Argos screenshot in a Vitest browser test.
+ *
+ * Requires the {@link https://www.npmjs.com/package/@argos-ci/vitest Argos Vitest plugin}
+ * to be registered in your Vitest config.
+ *
+ * @example
+ * ```ts
+ * import { render } from "vitest-browser-react";
+ * import { argosScreenshot } from "@argos-ci/vitest";
+ *
+ * test("Button", async () => {
+ *   render(<Button>Click me</Button>);
+ *   await argosScreenshot("button");
+ * });
+ * ```
+ *
+ * @param name - Unique name of the screenshot.
+ * @param options - Serializable screenshot options.
+ * @returns The attachments captured, or an empty array outside of Vitest.
+ */
+export async function argosScreenshot(
+  name: string,
+  options?: VitestScreenshotOptions,
+): Promise<ArgosAttachment[]> {
+  // Only run in Vitest.
+  const isVitest = await checkIsVitestEnv();
+  if (!isVitest) {
+    return [];
+  }
+
+  // Load vitest/browser using dynamic import to avoid loading it in non-Vitest
+  // environments.
+  const { server } = await import("vitest/browser");
+  return server.commands.argosScreenshot(name, options);
+}
+
+/**
+ * Check if we are running in a Vitest environment.
+ */
+export async function checkIsVitestEnv(): Promise<boolean> {
+  try {
+    await import("vitest");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/vitest/src/internal.ts
+++ b/packages/vitest/src/internal.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal, unstable entry point shared with other Argos SDKs (e.g.
+ * `@argos-ci/storybook`). No semver guarantee — do not import directly.
+ */
+export {
+  resetTesterScale,
+  setIframeViewportSize,
+  fitIframeToContent,
+  VITEST_IFRAME_SELECTOR,
+  VITEST_TESTER_ID,
+} from "./iframe";
+export { screenshotFrame } from "./screenshot";
+export { getArgosVitestVersion } from "./version";

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -1,0 +1,100 @@
+import type { UploadParameters } from "@argos-ci/core";
+import type { ArgosScreenshotOptions as PlaywrightScreenshotOptions } from "@argos-ci/playwright";
+import type {
+  ViewportOption,
+  StabilizationPluginOptions,
+} from "@argos-ci/browser";
+
+/**
+ * Configuration for the Argos Vitest reporter.
+ * @see https://js-sdk-reference.argos-ci.com/interfaces/UploadParameters.html
+ */
+export type ArgosReporterConfig = UploadParameters;
+
+/**
+ * Options passed when calling `argosScreenshot` from a browser test.
+ *
+ * These options cross the Vitest browser/node RPC boundary, so they must be
+ * JSON-serializable. Non-serializable options (`beforeScreenshot`,
+ * `afterScreenshot`, a `Locator`/`ElementHandle` `element`, …) can only be set
+ * on the plugin via {@link ArgosVitestPluginOptions}.
+ */
+export interface VitestScreenshotOptions {
+  /**
+   * String selector of the element to take a screenshot of.
+   * A `Locator`/`ElementHandle` cannot be used here because it can't be
+   * serialized across the browser/node boundary — set it on the plugin instead.
+   */
+  element?: string;
+
+  /**
+   * Viewports to take screenshots of.
+   * Implemented by resizing the Vitest iframe (Playwright's native `viewports`
+   * option does not work on a frame).
+   */
+  viewports?: ViewportOption[];
+
+  /**
+   * Capture the full page instead of fitting the screenshot to the content.
+   * - `false` (default): the iframe grows to fit the content in both
+   *   dimensions, so nothing is clipped.
+   * - `true`: keep the viewport width and grow the height (Playwright-style
+   *   full page).
+   * @default false
+   */
+  fullPage?: boolean;
+
+  /**
+   * Custom CSS evaluated during the screenshot process.
+   */
+  argosCSS?: string;
+
+  /**
+   * Sensitivity threshold between 0 and 1.
+   * The higher the threshold, the less sensitive the diff will be.
+   * @default 0.5
+   */
+  threshold?: number;
+
+  /**
+   * Tag or array of tags to attach to the screenshot.
+   */
+  tag?: string | string[];
+
+  /**
+   * Capture an ARIA snapshot along with the screenshot.
+   * @default false
+   */
+  ariaSnapshot?: boolean;
+
+  /**
+   * Disable hover effects by moving the mouse to the top-left corner.
+   * @default true
+   */
+  disableHover?: boolean;
+
+  /**
+   * Wait for the UI to stabilize before taking the screenshot.
+   * Set to `false` to disable stabilization or pass an object to customize it.
+   * @default true
+   */
+  stabilize?: boolean | StabilizationPluginOptions;
+}
+
+/**
+ * Options for the Argos Vitest plugin.
+ *
+ * Accepts every option supported by the Playwright `argosScreenshot` function
+ * (including non-serializable ones like `beforeScreenshot`), all Argos upload
+ * parameters, plus the plugin-specific options below. These act as defaults for
+ * every screenshot and can be overridden per call with the serializable
+ * {@link VitestScreenshotOptions}.
+ */
+export interface ArgosVitestPluginOptions
+  extends ArgosReporterConfig, PlaywrightScreenshotOptions {
+  /**
+   * Upload the report to Argos at the end of the run.
+   * @default false
+   */
+  uploadToArgos?: boolean;
+}

--- a/packages/vitest/src/plugin.ts
+++ b/packages/vitest/src/plugin.ts
@@ -1,0 +1,73 @@
+import type { Plugin } from "vitest/config";
+import { resolve } from "node:path";
+import { createArgosScreenshotCommand } from "./command";
+import { ArgosReporter } from "./reporter";
+import type { ArgosVitestPluginOptions } from "./options";
+
+export { createArgosScreenshotCommand, ArgosReporter };
+export type { ArgosScreenshotCommandArgs } from "./command";
+export type {
+  ArgosVitestPluginOptions,
+  VitestScreenshotOptions,
+  ArgosReporterConfig,
+} from "./options";
+
+const cwd = process.cwd();
+
+/**
+ * Vitest plugin that registers the `argosScreenshot` browser command and,
+ * optionally, the reporter that uploads the captured screenshots to Argos.
+ *
+ * @example
+ * ```ts
+ * import { defineConfig } from "vitest/config";
+ * import { playwright } from "@vitest/browser-playwright";
+ * import { argosVitestPlugin } from "@argos-ci/vitest/plugin";
+ *
+ * export default defineConfig({
+ *   plugins: [argosVitestPlugin({ uploadToArgos: true })],
+ *   test: {
+ *     browser: {
+ *       enabled: true,
+ *       provider: playwright(),
+ *       instances: [{ browser: "chromium" }],
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function argosVitestPlugin(options?: ArgosVitestPluginOptions): Plugin {
+  const {
+    root: unresolvedRoot = "./screenshots",
+    uploadToArgos,
+    ...otherOptions
+  } = options ?? {};
+  const root = resolve(cwd, unresolvedRoot);
+  return {
+    name: "@argos-ci/vitest",
+    configureVitest({ vitest }) {
+      if (uploadToArgos) {
+        vitest.config.reporters.push(
+          new ArgosReporter({ ...otherOptions, root }),
+        );
+      }
+    },
+    config() {
+      return {
+        optimizeDeps: {
+          include: ["@argos-ci/vitest"],
+        },
+        test: {
+          browser: {
+            commands: {
+              argosScreenshot: createArgosScreenshotCommand({
+                ...otherOptions,
+                root,
+              }),
+            },
+          },
+        },
+      };
+    },
+  };
+}

--- a/packages/vitest/src/reporter.test.ts
+++ b/packages/vitest/src/reporter.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Vitest } from "vitest/node";
+
+const { upload } = vi.hoisted(() => ({ upload: vi.fn() }));
+vi.mock("@argos-ci/core", () => ({ upload }));
+
+import { ArgosReporter } from "./reporter";
+
+function createVitest(watch: boolean): Vitest {
+  return { config: { watch } } as unknown as Vitest;
+}
+
+describe("ArgosReporter", () => {
+  let log: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    upload.mockReset();
+    upload.mockResolvedValue({
+      build: { url: "https://argos-ci.com/build/1" },
+    });
+    log = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uploads at the end of a non-watch run and logs the build URL", async () => {
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest(false));
+    await reporter.onTestRunEnd();
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledWith({ buildName: "test" });
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("https://argos-ci.com/build/1"),
+    );
+  });
+
+  it("propagates upload failures", async () => {
+    upload.mockRejectedValue(new Error("upload failed"));
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest(false));
+    await expect(reporter.onTestRunEnd()).rejects.toThrow("upload failed");
+  });
+
+  it("does not upload in watch mode", async () => {
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest(true));
+    await reporter.onTestRunEnd();
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("onFinished delegates to onTestRunEnd for Vitest v3 compatibility", async () => {
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest(false));
+    await reporter.onFinished();
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/vitest/src/reporter.test.ts
+++ b/packages/vitest/src/reporter.test.ts
@@ -25,15 +25,31 @@ describe("ArgosReporter", () => {
     vi.restoreAllMocks();
   });
 
-  it("uploads at the end of a non-watch run and logs the build URL", async () => {
+  it("uploads screenshots and ARIA snapshots at the end of a non-watch run and logs the build URL", async () => {
     const reporter = new ArgosReporter({ buildName: "test" });
     reporter.onInit(createVitest(false));
     await reporter.onTestRunEnd();
     expect(upload).toHaveBeenCalledTimes(1);
-    expect(upload).toHaveBeenCalledWith({ buildName: "test" });
+    expect(upload).toHaveBeenCalledWith({
+      files: ["**/*.png", "**/*.aria.yml"],
+      buildName: "test",
+    });
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining("https://argos-ci.com/build/1"),
     );
+  });
+
+  it("lets the config override the default files glob", async () => {
+    const reporter = new ArgosReporter({
+      buildName: "test",
+      files: ["custom/**/*.png"],
+    });
+    reporter.onInit(createVitest(false));
+    await reporter.onTestRunEnd();
+    expect(upload).toHaveBeenCalledWith({
+      files: ["custom/**/*.png"],
+      buildName: "test",
+    });
   });
 
   it("propagates upload failures", async () => {

--- a/packages/vitest/src/reporter.ts
+++ b/packages/vitest/src/reporter.ts
@@ -1,9 +1,13 @@
-import { upload, type UploadParameters } from "@argos-ci/core";
+import { upload } from "@argos-ci/core";
 import type { Vitest } from "vitest/node";
 import type { Reporter } from "vitest/reporters";
+import type { ArgosReporterConfig } from "./options";
 
-export type ArgosReporterConfig = UploadParameters;
+export type { ArgosReporterConfig };
 
+/**
+ * Vitest reporter that uploads the screenshots captured during the run to Argos.
+ */
 export class ArgosReporter implements Reporter {
   vitest!: Vitest;
   config: ArgosReporterConfig;

--- a/packages/vitest/src/reporter.ts
+++ b/packages/vitest/src/reporter.ts
@@ -30,7 +30,13 @@ export class ArgosReporter implements Reporter {
     if (this.vitest.config.watch) {
       return;
     }
-    const res = await upload(this.config);
+    const res = await upload({
+      // Default to uploading screenshots and ARIA snapshots. Without this,
+      // `upload` only matches images (`**/*.{png,jpg,jpeg}`) and the
+      // `.aria.yml` files produced by `ariaSnapshot: true` are skipped.
+      files: ["**/*.png", "**/*.aria.yml"],
+      ...this.config,
+    });
     console.log(`✅ Argos build created: ${res.build.url}`);
   }
 }

--- a/packages/vitest/src/screenshot.ts
+++ b/packages/vitest/src/screenshot.ts
@@ -1,0 +1,45 @@
+import {
+  argosScreenshot as argosPlaywrightScreenshot,
+  type ArgosAttachment,
+  type ArgosScreenshotOptions as PlaywrightScreenshotOptions,
+} from "@argos-ci/playwright";
+import type { BrowserCommandContext } from "vitest/node";
+import { fitIframeToContent } from "./iframe";
+
+/**
+ * Take a screenshot of the Vitest iframe body using the Playwright SDK.
+ *
+ * This is the shared primitive both the standalone command and Storybook build
+ * on. It:
+ * - strips the Vitest-specific `viewports`/`fullPage` options (they drive the
+ *   iframe resize, not Playwright);
+ * - wraps `beforeScreenshot` so the content is grown to fit *after* `argosCSS`
+ *   (and any user `beforeScreenshot`) has been applied — otherwise wide/tall
+ *   content would be clipped;
+ * - captures the iframe's `<body>` via `@argos-ci/playwright`.
+ *
+ * @param config.fitWidth - Grow the iframe horizontally as well as vertically
+ *   to fit the content (used when not capturing a fixed viewport width).
+ */
+export async function screenshotFrame(
+  ctx: BrowserCommandContext,
+  name: string,
+  options: PlaywrightScreenshotOptions,
+  config: { fitWidth: boolean },
+): Promise<ArgosAttachment[]> {
+  const { viewports: _viewports, fullPage: _fullPage, ...rest } = options;
+  const userBeforeScreenshot = rest.beforeScreenshot;
+
+  const playwrightOptions: PlaywrightScreenshotOptions = {
+    ...rest,
+    beforeScreenshot: async (api) => {
+      await userBeforeScreenshot?.(api);
+      // Re-fit the iframe here, after stabilization has injected `argosCSS`, so
+      // the whole content is painted and nothing is clipped.
+      await fitIframeToContent(ctx, { fitWidth: config.fitWidth });
+    },
+  };
+
+  const frame = await ctx.frame();
+  return argosPlaywrightScreenshot(frame, name, playwrightOptions);
+}

--- a/packages/vitest/src/version.ts
+++ b/packages/vitest/src/version.ts
@@ -1,0 +1,12 @@
+import { readVersionFromPackage } from "@argos-ci/util";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Get the version of the Argos Vitest SDK.
+ */
+export async function getArgosVitestVersion(): Promise<string> {
+  const pkgPath = require.resolve("@argos-ci/vitest/package.json");
+  return readVersionFromPackage(pkgPath);
+}

--- a/packages/vitest/tsconfig.json
+++ b/packages/vitest/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/vitest/tsdown.config.ts
+++ b/packages/vitest/tsdown.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    dts: true,
+    format: ["esm"],
+    deps: {
+      neverBundle: [/^@argos-ci\//, "playwright", /^vitest/, /^@vitest/],
+    },
+  },
+  {
+    entry: ["src/plugin.ts"],
+    dts: true,
+    format: ["esm"],
+    deps: {
+      neverBundle: [/^@argos-ci\//, "playwright", /^vitest/, /^@vitest/],
+    },
+  },
+  {
+    entry: ["src/internal.ts"],
+    dts: true,
+    format: ["esm"],
+    deps: {
+      neverBundle: [/^@argos-ci\//, "playwright", /^vitest/, /^@vitest/],
+    },
+  },
+]);

--- a/packages/vitest/vitest.config.ts
+++ b/packages/vitest/vitest.config.ts
@@ -1,0 +1,38 @@
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+import { argosVitestPlugin } from "./dist/plugin.mjs";
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        // Node unit tests.
+        test: {
+          name: "unit",
+          include: ["src/**/*.test.ts"],
+          environment: "node",
+        },
+      },
+      {
+        // Browser end-to-end tests exercising the real screenshot flow.
+        plugins: [
+          argosVitestPlugin({
+            uploadToArgos: process.env.UPLOAD_TO_ARGOS === "true",
+            buildName: process.env.BUILD_NAME,
+          }),
+        ],
+        test: {
+          name: "e2e",
+          include: ["e2e/**/*.test.ts"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
+  },
+});

--- a/packages/vitest/vitest.shims.d.ts
+++ b/packages/vitest/vitest.shims.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@vitest/browser-playwright" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,13 +302,16 @@ importers:
       '@argos-ci/util':
         specifier: workspace:*
         version: link:../util
+      '@argos-ci/vitest':
+        specifier: workspace:*
+        version: link:../vitest
     devDependencies:
       '@argos-ci/cli':
         specifier: workspace:*
         version: link:../cli
       '@storybook/addon-docs':
         specifier: ^10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/addon-links':
         specifier: ^10.4.6
         version: 10.4.6(@types/react@19.2.17)(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -320,10 +323,13 @@ importers:
         version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9)(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.9)
       '@storybook/react-vite':
         specifier: ^10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@26.0.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 0.24.4(@types/node@22.19.21)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.21
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -332,10 +338,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitest/browser':
         specifier: ^4.1.9
-        version: 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/browser-playwright':
         specifier: ^4.1.9
-        version: 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(playwright@1.61.0)(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(playwright@1.61.0)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
@@ -365,7 +371,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@22.19.21)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       wait-on:
         specifier: ^9.0.10
         version: 9.0.10
@@ -375,6 +381,37 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.21
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@22.19.21)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/vitest:
+    dependencies:
+      '@argos-ci/browser':
+        specifier: workspace:*
+        version: link:../browser
+      '@argos-ci/core':
+        specifier: workspace:*
+        version: link:../core
+      '@argos-ci/playwright':
+        specifier: workspace:*
+        version: link:../playwright
+      '@argos-ci/util':
+        specifier: workspace:*
+        version: link:../util
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.21
+      '@vitest/browser':
+        specifier: ^4.1.9
+        version: 4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.9
+        version: 4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(playwright@1.61.0)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      playwright:
+        specifier: ^1.61.0
+        version: 1.61.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@22.19.21)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -9273,11 +9310,11 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -10089,10 +10126,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       react: 19.2.7
@@ -10127,33 +10164,33 @@ snapshots:
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(playwright@1.61.0)(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(playwright@1.61.0)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/runner': 4.1.9
-      vitest: 4.1.9(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.21)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.3.0
-      vite: 7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.25.12
       rollup: 4.62.2
-      vite: 7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -10171,11 +10208,11 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -10185,7 +10222,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tsconfig-paths: 4.2.0
-      vite: 7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -10211,7 +10248,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.4(@types/node@26.0.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@storybook/test-runner@0.24.4(@types/node@22.19.21)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -10221,14 +10258,14 @@ snapshots:
       '@swc/core': 1.15.41
       '@swc/jest': 0.2.39(@swc/core@1.15.41)
       expect-playwright: 0.8.0
-      jest: 30.4.2(@types/node@26.0.0)
+      jest: 30.4.2(@types/node@22.19.21)
       jest-circus: 30.4.2
       jest-environment-node: 30.4.1
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.4.2
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.4.2(@types/node@26.0.0))
+      jest-watch-typeahead: 3.0.1(jest@30.4.2(@types/node@22.19.21))
       nyc: 15.1.0
       playwright: 1.61.0
       playwright-core: 1.61.0
@@ -10691,7 +10728,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(playwright@1.61.0)(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
@@ -10705,6 +10741,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/browser@4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
@@ -10722,7 +10759,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@7.3.3(@types/node@26.0.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
@@ -10740,6 +10776,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)':
     dependencies:
@@ -13449,25 +13486,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.4.2(@types/node@26.0.0):
-    dependencies:
-      '@jest/core': 30.4.2
-      '@jest/test-result': 30.4.1
-      '@jest/types': 30.4.1
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@26.0.0)
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      yargs: 17.7.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest-config@30.4.2(@types/node@22.19.21):
     dependencies:
       '@babel/core': 7.29.7
@@ -13893,11 +13911,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.4.1
 
-  jest-watch-typeahead@3.0.1(jest@30.4.2(@types/node@26.0.0)):
+  jest-watch-typeahead@3.0.1(jest@30.4.2(@types/node@22.19.21)):
     dependencies:
       ansi-escapes: 7.3.0
       chalk: 5.6.2
-      jest: 30.4.2(@types/node@26.0.0)
+      jest: 30.4.2(@types/node@22.19.21)
       jest-regex-util: 30.4.0
       jest-watcher: 30.4.1
       slash: 5.1.0
@@ -13929,19 +13947,6 @@ snapshots:
       '@jest/types': 30.4.1
       import-local: 3.2.0
       jest-cli: 30.4.2(@types/node@22.19.21)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.4.2(@types/node@26.0.0):
-    dependencies:
-      '@jest/core': 30.4.2
-      '@jest/types': 30.4.1
-      import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@26.0.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
       "@argos-ci/storybook/vitest-plugin": [
         "./packages/*/src/vitest-plugin.ts"
       ],
+      "@argos-ci/vitest/plugin": ["./packages/vitest/src/plugin.ts"],
+      "@argos-ci/vitest/internal": ["./packages/vitest/src/internal.ts"],
       "@argos-ci/util/browser": ["./packages/util/src/browser.ts"]
     },
     "lib": ["ES2022", "DOM"],


### PR DESCRIPTION
## Summary

Extracts the generic Vitest browser-mode screenshot machinery out of `@argos-ci/storybook` into a new **`@argos-ci/vitest`** package that works **standalone** and is **reused by the storybook package**. The goal: take Argos screenshots while Vitest runs browser tests.

```ts
// vitest.config.ts
import { argosVitestPlugin } from "@argos-ci/vitest/plugin";
plugins: [argosVitestPlugin({ uploadToArgos: process.env.CI === "true" })]

// my.test.tsx (browser mode)
import { argosScreenshot } from "@argos-ci/vitest";
test("Button", async () => {
  render(<Button>Click me</Button>);
  await argosScreenshot("button");
});
```

## What's in the package

- **`.`** (browser): `argosScreenshot(name, options?)` + the `vitest/browser` command augmentation. Node-free (only `import type` + a lazy `import("vitest/browser")`).
- **`./plugin`** (node): `argosVitestPlugin` — registers the browser command and the upload reporter.
- **`./internal`** (node, unstable): shared iframe utils + `screenshotFrame` primitive consumed by storybook.

The `ArgosReporter` and the iframe DOM ops (tester-scale reset, iframe viewport resize, grow-to-fit) were moved **verbatim**; storybook now imports them instead of inlining copies.

## Design notes

- **RPC-safe boundary:** per-call options are JSON-serializable; functions/`Locator`s go on the plugin (node side) and are merged in the command closure.
- **Backward compatible:** every `@argos-ci/storybook` published export is unchanged. Its *internal* browser command key was renamed `argosScreenshot` → `argosStorybookScreenshot` to avoid a `vitest/browser` `BrowserCommands` augmentation clash. The public `argosScreenshot(story, name)` function name is kept.
- **Single vitest peer instance:** storybook declared no `@types/node`, so its `vitest` peer resolved to v26 while the catalog pins v22 — two `vitest/node` instances meant the `@vitest/browser-playwright` `ctx.page`/`frame` augmentation didn't apply cross-package. Aligned storybook to the catalog `@types/node`.

## Tests

- **Unit** (node project): reporter (upload / watch-skip / failure / log), command (merge precedence, node-hook preservation, viewport naming, SDK metadata), env detection.
- **Browser e2e** (real Chromium): reads written files back via `server.commands.readFile` to assert metadata (`sdk`=`@argos-ci/vitest`, `automationLibrary`=`@vitest/browser-playwright`, per-viewport `viewport`), `ariaSnapshot` forwarding, and the horizontal `fitWidth` path via PNG-width decode.
- Added an `e2e-vitest` CI job; `.prettierignore` scoped to `/packages/*/{test-results,screenshots}`.

## Verification

- Whole-repo `turbo run check-types lint check-format test` → **53/53 tasks green**.
- Standalone e2e (6) + storybook Vitest e2e (15) pass; screenshots write to disk with correct metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)