### PR TITLE
feat(vitest): add argosSnapshot for value snapshots anywhere

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./config";
 export * from "./deploy";
 export * from "./finalize";
+export * from "./mime-type";
 export * from "./upload";
 export * from "./skip";

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -71,6 +71,38 @@ test("Button", async () => {
 });
 ```
 
+## Snapshots
+
+`argosSnapshot` captures a snapshot of any value — not just a screenshot — and
+uploads it to Argos to diff across builds, mimicking
+[Vitest snapshots](https://vitest.dev/guide/snapshot). Unlike `argosScreenshot`,
+it does not need a browser and works in **both** browser and Node tests.
+
+```ts
+import { test } from "vitest";
+import { argosSnapshot } from "@argos-ci/vitest";
+
+test("API response", async () => {
+  const user = await fetchUser();
+  // Objects are serialized with `@vitest/pretty-format`, strings are written
+  // verbatim.
+  await argosSnapshot("user", user);
+});
+```
+
+Use the `extension` option to control how Argos renders and diffs the snapshot,
+and `tag` to attach tags:
+
+```ts
+await argosSnapshot("config", JSON.stringify(config, null, 2), {
+  extension: ".json",
+  tag: "config",
+});
+```
+
+Snapshots are written to the same folder as screenshots and uploaded by the
+reporter when `uploadToArgos` is enabled.
+
 ## Links
 
 - [Official SDK Docs](https://argos-ci.com/docs)

--- a/packages/vitest/e2e/screenshot.test.ts
+++ b/packages/vitest/e2e/screenshot.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, test } from "vitest";
 import { server } from "vitest/browser";
-import { argosScreenshot } from "@argos-ci/vitest";
+import { argosScreenshot, argosSnapshot } from "@argos-ci/vitest";
 import type { ArgosAttachment } from "@argos-ci/playwright";
 
 /**
@@ -110,6 +110,39 @@ test("grows the iframe to capture content wider than the viewport", async () => 
   expect(screenshot).toBeDefined();
   const width = await readPngWidth(screenshot!);
   expect(width).toBeGreaterThan(1500);
+});
+
+test("writes a value snapshot that the reporter can upload", async () => {
+  // `argosSnapshot` works without a browser, but here we exercise the browser
+  // RPC path: the value is serialized in the browser, written on the node side.
+  const attachments = await argosSnapshot("payload", {
+    id: 1,
+    name: "Argos",
+    tags: ["a", "b"],
+  });
+  // The snapshot file + its metadata attachment.
+  expect(attachments.length).toBe(2);
+
+  const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.txt"));
+  expect(snapshot).toBeDefined();
+  // The value is serialized with pretty-format, ready for Argos to diff.
+  const content = await server.commands.readFile(snapshot!.path);
+  expect(content).toContain('"name": "Argos"');
+
+  const metadata = attachments.find((a) => a.path.endsWith(".argos.json"));
+  expect(metadata).toBeDefined();
+  const parsed = JSON.parse(await server.commands.readFile(metadata!.path));
+  expect(parsed.sdk.name).toBe("@argos-ci/vitest");
+});
+
+test("writes a snapshot with a custom extension", async () => {
+  const attachments = await argosSnapshot("config", '{"enabled":true}', {
+    extension: ".json",
+  });
+  const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.json"));
+  expect(snapshot).toBeDefined();
+  const content = await server.commands.readFile(snapshot!.path);
+  expect(content).toBe('{"enabled":true}');
 });
 
 test("captures an ARIA snapshot alongside the screenshot", async () => {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@vitest/browser": "^4.1.9",
+    "@vitest/pretty-format": "^4.1.9",
     "@vitest/browser-playwright": "^4.1.9",
     "playwright": "^1.61.0",
     "vitest": "catalog:"

--- a/packages/vitest/src/index.test.ts
+++ b/packages/vitest/src/index.test.ts
@@ -1,10 +1,49 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { expect, it } from "vitest";
-import { argosScreenshot, checkIsVitestEnv } from "./index";
+import {
+  argosScreenshot,
+  argosSnapshot,
+  checkIsBrowserEnv,
+  checkIsVitestEnv,
+} from "./index";
 
 it("detects the Vitest environment", async () => {
   await expect(checkIsVitestEnv()).resolves.toBe(true);
 });
 
+it("is not in browser mode when running as a Node unit test", () => {
+  expect(checkIsBrowserEnv()).toBe(false);
+});
+
 it("exports the argosScreenshot function", () => {
   expect(typeof argosScreenshot).toBe("function");
+});
+
+it("exports the argosSnapshot function", () => {
+  expect(typeof argosSnapshot).toBe("function");
+});
+
+it("requires a name for argosSnapshot", async () => {
+  await expect(argosSnapshot("", "content")).rejects.toThrow("name");
+});
+
+it("writes a snapshot from a Node test", async () => {
+  const root = await mkdtemp(join(tmpdir(), "argos-vitest-index-"));
+  try {
+    const attachments = await argosSnapshot(
+      "node-unit",
+      { hello: "world" },
+      {
+        root,
+      },
+    );
+    // In a Node test it takes the direct-write path and returns the attachments.
+    expect(attachments).toHaveLength(2);
+    const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.txt"));
+    expect(snapshot).toBeDefined();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,13 +1,23 @@
 import type { ArgosAttachment } from "@argos-ci/playwright";
-import type { VitestScreenshotOptions } from "./options";
+import type {
+  SerializableSnapshotOptions,
+  VitestScreenshotOptions,
+  VitestSnapshotOptions,
+} from "./options";
+import { serializeSnapshot } from "./serialize";
 
-export type { VitestScreenshotOptions };
+export type { VitestScreenshotOptions, VitestSnapshotOptions };
 
 declare module "vitest/browser" {
   interface BrowserCommands {
     argosScreenshot: (
       name: string,
       options?: VitestScreenshotOptions,
+    ) => Promise<ArgosAttachment[]>;
+    argosSnapshot: (
+      name: string,
+      content: string,
+      options?: SerializableSnapshotOptions,
     ) => Promise<ArgosAttachment[]>;
   }
 }
@@ -50,6 +60,67 @@ export async function argosScreenshot(
 }
 
 /**
+ * Take an Argos snapshot of any serializable value, mimicking
+ * {@link https://vitest.dev/guide/snapshot Vitest snapshots}.
+ *
+ * Unlike {@link argosScreenshot}, this does not need a browser: it serializes
+ * the value (strings verbatim, everything else via `@vitest/pretty-format`) to a
+ * file that Argos picks up and diffs across builds. It works both in Vitest
+ * browser tests and in plain Node tests.
+ *
+ * @example
+ * ```ts
+ * import { argosSnapshot } from "@argos-ci/vitest";
+ *
+ * test("API response", async () => {
+ *   const data = await fetchUser();
+ *   await argosSnapshot("user", data);
+ * });
+ * ```
+ *
+ * @param name - Unique name of the snapshot.
+ * @param content - The value to snapshot. Strings are written as-is; any other
+ *   value is serialized.
+ * @param options - Snapshot options.
+ * @returns The attachments written, or an empty array outside of Vitest.
+ */
+export async function argosSnapshot(
+  name: string,
+  content: unknown,
+  options: VitestSnapshotOptions = {},
+): Promise<ArgosAttachment[]> {
+  if (!name) {
+    throw new Error("The `name` argument is required.");
+  }
+
+  // Only run in Vitest.
+  const isVitest = await checkIsVitestEnv();
+  if (!isVitest) {
+    return [];
+  }
+
+  // Serialize on the test side (browser or Node), so values that only exist
+  // here (DOM nodes, class instances, …) are serialized before crossing the RPC
+  // boundary.
+  const serialized = serializeSnapshot(content, options);
+
+  // The `serialize` function cannot cross the browser/node RPC boundary and is
+  // no longer needed once the value is serialized.
+  const { serialize: _serialize, ...serializableOptions } = options;
+
+  if (checkIsBrowserEnv()) {
+    // Load vitest/browser using dynamic import to avoid loading it in non-Vitest
+    // environments.
+    const { server } = await import("vitest/browser");
+    return server.commands.argosSnapshot(name, serialized, serializableOptions);
+  }
+
+  // Node: write directly to disk.
+  const { writeSnapshotFile } = await import("./snapshot-file");
+  return writeSnapshotFile(name, serialized, serializableOptions);
+}
+
+/**
  * Check if we are running in a Vitest environment.
  */
 export async function checkIsVitestEnv(): Promise<boolean> {
@@ -59,4 +130,15 @@ export async function checkIsVitestEnv(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Check if we are running in Vitest browser mode.
+ * Vitest sets this global in the browser runner.
+ */
+export function checkIsBrowserEnv(): boolean {
+  return (
+    typeof globalThis !== "undefined" &&
+    (globalThis as { __vitest_browser__?: boolean }).__vitest_browser__ === true
+  );
 }

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -82,6 +82,57 @@ export interface VitestScreenshotOptions {
 }
 
 /**
+ * Options passed when calling `argosSnapshot`.
+ *
+ * `argosSnapshot` serializes any value to a file that Argos picks up and diffs,
+ * mimicking {@link https://vitest.dev/guide/snapshot Vitest snapshots}. Unlike
+ * `argosScreenshot`, it does not need a browser and works both in Vitest browser
+ * tests and in plain Node tests.
+ *
+ * These options must be JSON-serializable so they can cross the Vitest
+ * browser/node RPC boundary — the only exception is `serialize`, which is
+ * applied on the test side *before* the value is sent to Node.
+ */
+export interface VitestSnapshotOptions {
+  /**
+   * Folder where the snapshot is written.
+   *
+   * In Node tests this defaults to `"./screenshots"`. In browser tests it
+   * defaults to the plugin `root` and can be overridden per call.
+   * @default "./screenshots"
+   */
+  root?: string;
+
+  /**
+   * Extension of the snapshot file. It also determines how Argos renders and
+   * diffs the snapshot (e.g. `.txt`, `.json`, `.yml`, `.html`, `.md`).
+   * @default ".txt"
+   */
+  extension?: string;
+
+  /**
+   * Tag or array of tags to attach to the snapshot.
+   */
+  tag?: string | string[];
+
+  /**
+   * Custom serializer used when `content` is not already a string.
+   * Defaults to `@vitest/pretty-format` (the serializer Vitest itself uses).
+   */
+  serialize?: (content: unknown) => string;
+}
+
+/**
+ * Subset of {@link VitestSnapshotOptions} that can cross the Vitest
+ * browser/node RPC boundary (everything but `serialize`, which is applied
+ * before the value is sent to Node).
+ */
+export type SerializableSnapshotOptions = Omit<
+  VitestSnapshotOptions,
+  "serialize"
+>;
+
+/**
  * Options for the Argos Vitest plugin.
  *
  * Accepts every option supported by the Playwright `argosScreenshot` function

--- a/packages/vitest/src/plugin.ts
+++ b/packages/vitest/src/plugin.ts
@@ -1,14 +1,21 @@
 import type { Plugin } from "vitest/config";
 import { resolve } from "node:path";
 import { createArgosScreenshotCommand } from "./command";
+import { createArgosSnapshotCommand } from "./snapshot-command";
 import { ArgosReporter } from "./reporter";
 import type { ArgosVitestPluginOptions } from "./options";
 
-export { createArgosScreenshotCommand, ArgosReporter };
+export {
+  createArgosScreenshotCommand,
+  createArgosSnapshotCommand,
+  ArgosReporter,
+};
 export type { ArgosScreenshotCommandArgs } from "./command";
+export type { ArgosSnapshotCommandArgs } from "./snapshot-command";
 export type {
   ArgosVitestPluginOptions,
   VitestScreenshotOptions,
+  VitestSnapshotOptions,
   ArgosReporterConfig,
 } from "./options";
 
@@ -61,6 +68,10 @@ export function argosVitestPlugin(options?: ArgosVitestPluginOptions): Plugin {
           browser: {
             commands: {
               argosScreenshot: createArgosScreenshotCommand({
+                ...otherOptions,
+                root,
+              }),
+              argosSnapshot: createArgosSnapshotCommand({
                 ...otherOptions,
                 root,
               }),

--- a/packages/vitest/src/reporter.test.ts
+++ b/packages/vitest/src/reporter.test.ts
@@ -25,13 +25,14 @@ describe("ArgosReporter", () => {
     vi.restoreAllMocks();
   });
 
-  it("uploads screenshots and ARIA snapshots at the end of a non-watch run and logs the build URL", async () => {
+  it("uploads screenshots, ARIA and value snapshots at the end of a non-watch run and logs the build URL", async () => {
     const reporter = new ArgosReporter({ buildName: "test" });
     reporter.onInit(createVitest(false));
     await reporter.onTestRunEnd();
     expect(upload).toHaveBeenCalledTimes(1);
     expect(upload).toHaveBeenCalledWith({
-      files: ["**/*.png", "**/*.aria.yml"],
+      files: ["**/*.png", "**/*.aria.yml", "**/*.snapshot.*"],
+      ignore: ["**/*.argos.json"],
       buildName: "test",
     });
     expect(log).toHaveBeenCalledWith(
@@ -48,6 +49,7 @@ describe("ArgosReporter", () => {
     await reporter.onTestRunEnd();
     expect(upload).toHaveBeenCalledWith({
       files: ["custom/**/*.png"],
+      ignore: ["**/*.argos.json"],
       buildName: "test",
     });
   });

--- a/packages/vitest/src/reporter.ts
+++ b/packages/vitest/src/reporter.ts
@@ -31,10 +31,15 @@ export class ArgosReporter implements Reporter {
       return;
     }
     const res = await upload({
-      // Default to uploading screenshots and ARIA snapshots. Without this,
-      // `upload` only matches images (`**/*.{png,jpg,jpeg}`) and the
-      // `.aria.yml` files produced by `ariaSnapshot: true` are skipped.
-      files: ["**/*.png", "**/*.aria.yml"],
+      // Default to uploading screenshots, ARIA snapshots and `argosSnapshot`
+      // files. Without this, `upload` only matches images
+      // (`**/*.{png,jpg,jpeg}`), so the `.aria.yml` files produced by
+      // `ariaSnapshot: true` and the `.snapshot.*` files produced by
+      // `argosSnapshot` would be skipped.
+      files: ["**/*.png", "**/*.aria.yml", "**/*.snapshot.*"],
+      // The `.snapshot.*` glob would otherwise also match the `.argos.json`
+      // metadata sidecars written next to each snapshot.
+      ignore: ["**/*.argos.json"],
       ...this.config,
     });
     console.log(`✅ Argos build created: ${res.build.url}`);

--- a/packages/vitest/src/serialize.test.ts
+++ b/packages/vitest/src/serialize.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { serializeSnapshot } from "./serialize";
+
+describe("serializeSnapshot", () => {
+  it("writes strings verbatim", () => {
+    expect(serializeSnapshot("hello world")).toBe("hello world");
+    // Multi-line strings are preserved as-is (no quoting).
+    expect(serializeSnapshot("line 1\nline 2")).toBe("line 1\nline 2");
+  });
+
+  it("serializes objects with pretty-format", () => {
+    const output = serializeSnapshot({ a: 1, b: [1, 2], c: "x" });
+    expect(output).toBe(
+      [
+        "Object {",
+        '  "a": 1,',
+        '  "b": Array [',
+        "    1,",
+        "    2,",
+        "  ],",
+        '  "c": "x",',
+        "}",
+      ].join("\n"),
+    );
+  });
+
+  it("produces a stable output for equal values", () => {
+    const value = { z: 1, a: { nested: true } };
+    expect(serializeSnapshot(value)).toBe(serializeSnapshot({ ...value }));
+  });
+
+  it("uses a custom serializer when provided", () => {
+    const output = serializeSnapshot(
+      { foo: "bar" },
+      { serialize: (value) => JSON.stringify(value) },
+    );
+    expect(output).toBe('{"foo":"bar"}');
+  });
+
+  it("passes strings through the custom serializer too", () => {
+    const output = serializeSnapshot("hello", {
+      serialize: (value) => `custom:${value}`,
+    });
+    expect(output).toBe("custom:hello");
+  });
+});

--- a/packages/vitest/src/serialize.ts
+++ b/packages/vitest/src/serialize.ts
@@ -1,0 +1,41 @@
+import { format, plugins } from "@vitest/pretty-format";
+import type { VitestSnapshotOptions } from "./options";
+
+/**
+ * Plugins used to serialize snapshots. This mirrors the serializers Vitest
+ * enables by default, so DOM nodes, React elements, errors, etc. are printed
+ * the same way you would see them in a Vitest snapshot.
+ */
+const SNAPSHOT_PLUGINS = [
+  plugins.DOMElement,
+  plugins.DOMCollection,
+  plugins.Immutable,
+  plugins.ReactElement,
+  plugins.ReactTestComponent,
+  plugins.Error,
+  plugins.AsymmetricMatcher,
+];
+
+/**
+ * Serialize a snapshot value to the string that gets written to disk.
+ *
+ * - Strings are written verbatim (like Vitest's `toMatchFileSnapshot`).
+ * - Everything else is serialized with `@vitest/pretty-format` (the same
+ *   serializer Vitest uses for `toMatchSnapshot`), unless a custom `serialize`
+ *   function is provided.
+ *
+ * This runs on the test side (browser or Node), so it can serialize values that
+ * only exist there (e.g. DOM nodes) before the string crosses the RPC boundary.
+ */
+export function serializeSnapshot(
+  content: unknown,
+  options: Pick<VitestSnapshotOptions, "serialize"> = {},
+): string {
+  if (options.serialize) {
+    return options.serialize(content);
+  }
+  if (typeof content === "string") {
+    return content;
+  }
+  return format(content, { plugins: SNAPSHOT_PLUGINS });
+}

--- a/packages/vitest/src/snapshot-command.test.ts
+++ b/packages/vitest/src/snapshot-command.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserCommandContext } from "vitest/node";
+
+const { writeSnapshotFile } = vi.hoisted(() => ({
+  writeSnapshotFile: vi.fn(),
+}));
+
+vi.mock("./snapshot-file", () => ({ writeSnapshotFile }));
+
+import { createArgosSnapshotCommand } from "./snapshot-command";
+
+const ctx = {} as BrowserCommandContext;
+
+describe("createArgosSnapshotCommand", () => {
+  beforeEach(() => {
+    writeSnapshotFile.mockReset().mockResolvedValue([]);
+  });
+
+  it("throws when the name is missing", async () => {
+    const command = createArgosSnapshotCommand();
+    await expect(command(ctx, "", "content")).rejects.toThrow("name");
+  });
+
+  it("writes the serialized content with the plugin root", async () => {
+    const command = createArgosSnapshotCommand({ root: "/abs/screenshots" });
+    await command(ctx, "user", "serialized");
+    expect(writeSnapshotFile).toHaveBeenCalledWith("user", "serialized", {
+      root: "/abs/screenshots",
+    });
+  });
+
+  it("lets per-call options override the plugin root", async () => {
+    const command = createArgosSnapshotCommand({ root: "/abs/screenshots" });
+    await command(ctx, "user", "serialized", {
+      root: "/other",
+      extension: ".json",
+      tag: "a",
+    });
+    expect(writeSnapshotFile).toHaveBeenCalledWith("user", "serialized", {
+      root: "/other",
+      extension: ".json",
+      tag: "a",
+    });
+  });
+});

--- a/packages/vitest/src/snapshot-command.ts
+++ b/packages/vitest/src/snapshot-command.ts
@@ -1,0 +1,38 @@
+import type { BrowserCommand } from "vitest/node";
+import type { ArgosAttachment } from "@argos-ci/playwright";
+import type {
+  ArgosVitestPluginOptions,
+  SerializableSnapshotOptions,
+} from "./options";
+import { writeSnapshotFile } from "./snapshot-file";
+
+/**
+ * Arguments of the `argosSnapshot` browser command.
+ * Only serializable values cross the browser/node RPC boundary — the value is
+ * already serialized to a string on the browser side.
+ */
+export type ArgosSnapshotCommandArgs = [
+  name: string,
+  content: string,
+  options?: SerializableSnapshotOptions,
+];
+
+/**
+ * Create the `argosSnapshot` browser command used to write serialized snapshots
+ * from Vitest browser tests. The serialized string is produced on the browser
+ * side and this command writes it (and its metadata) to disk on the Node side.
+ */
+export const createArgosSnapshotCommand = (
+  pluginOptions: ArgosVitestPluginOptions = {},
+): BrowserCommand<ArgosSnapshotCommandArgs> => {
+  return async (_ctx, name, content, options): Promise<ArgosAttachment[]> => {
+    if (!name) {
+      throw new Error("The `name` argument is required.");
+    }
+    const merged: SerializableSnapshotOptions = {
+      root: pluginOptions.root,
+      ...options,
+    };
+    return writeSnapshotFile(name, content, merged);
+  };
+};

--- a/packages/vitest/src/snapshot-file.test.ts
+++ b/packages/vitest/src/snapshot-file.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeSnapshotFile } from "./snapshot-file";
+
+describe("writeSnapshotFile", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "argos-vitest-snapshot-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("throws when the name is missing", async () => {
+    await expect(writeSnapshotFile("", "content", { root })).rejects.toThrow(
+      "name",
+    );
+  });
+
+  it("writes the snapshot content and metadata to disk", async () => {
+    const attachments = await writeSnapshotFile("user", "serialized", { root });
+
+    // One snapshot + its metadata attachment.
+    expect(attachments).toHaveLength(2);
+
+    const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.txt"));
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.path).toBe(join(root, "user.snapshot.txt"));
+    expect(snapshot!.contentType).toBe("text/plain");
+    expect(await readFile(snapshot!.path, "utf-8")).toBe("serialized");
+
+    // The metadata sidecar attributes the snapshot to this SDK and to Vitest.
+    const metadataAttachment = attachments.find((a) =>
+      a.path.endsWith(".argos.json"),
+    );
+    expect(metadataAttachment).toBeDefined();
+    const metadata = JSON.parse(
+      await readFile(metadataAttachment!.path, "utf-8"),
+    );
+    expect(metadata.sdk.name).toBe("@argos-ci/vitest");
+    expect(metadata.automationLibrary.name).toBe("vitest");
+  });
+
+  it("uses the extension to control the file type", async () => {
+    const attachments = await writeSnapshotFile("data", '{"a":1}', {
+      root,
+      extension: ".json",
+    });
+    const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.json"));
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.contentType).toBe("application/json");
+  });
+
+  it("normalizes an extension without a leading dot", async () => {
+    const [snapshot] = await writeSnapshotFile("data", "a: 1", {
+      root,
+      extension: "yml",
+    });
+    expect(snapshot!.path).toBe(join(root, "data.snapshot.yml"));
+  });
+
+  it("records tags in the metadata", async () => {
+    const attachments = await writeSnapshotFile("tagged", "x", {
+      root,
+      tag: ["a", "b"],
+    });
+    const metadataAttachment = attachments.find((a) =>
+      a.path.endsWith(".argos.json"),
+    )!;
+    const metadata = JSON.parse(
+      await readFile(metadataAttachment.path, "utf-8"),
+    );
+    expect(metadata.tags).toEqual(["a", "b"]);
+  });
+
+  it("sanitizes the name and creates nested directories", async () => {
+    const [snapshot] = await writeSnapshotFile("nested/report:v1", "x", {
+      root,
+    });
+    // The subdirectory is created and the reserved character is sanitized.
+    expect(snapshot!.path).toBe(join(root, "nested", "report-v1.snapshot.txt"));
+    expect(await readFile(snapshot!.path, "utf-8")).toBe("x");
+  });
+});

--- a/packages/vitest/src/snapshot-file.ts
+++ b/packages/vitest/src/snapshot-file.ts
@@ -1,0 +1,97 @@
+import { writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { getSnapshotMimeType } from "@argos-ci/core";
+import {
+  createDirectory,
+  getMetadataPath,
+  getScreenshotName,
+  writeMetadata,
+  type ScreenshotMetadata,
+} from "@argos-ci/util";
+import type { ArgosAttachment } from "@argos-ci/playwright";
+import type { SerializableSnapshotOptions } from "./options";
+import { getArgosVitestVersion, getVitestVersion } from "./version";
+
+/**
+ * Default folder where snapshots are written when no `root` is provided.
+ * Matches the plugin default so Node and browser snapshots land together.
+ */
+export const DEFAULT_SNAPSHOTS_ROOT = "./screenshots";
+
+/**
+ * Default extension of a serialized snapshot file.
+ */
+const DEFAULT_EXTENSION = ".txt";
+
+/**
+ * Marker inserted before the extension so the reporter can reliably pick up
+ * snapshots (`**\/*.snapshot.*`) without matching screenshots or ARIA files.
+ */
+const SNAPSHOT_INFIX = ".snapshot";
+
+/**
+ * Normalize a user-provided extension to a leading-dot form (`.txt`).
+ */
+function normalizeExtension(extension: string): string {
+  return extension.startsWith(".") ? extension : `.${extension}`;
+}
+
+/**
+ * Write a serialized snapshot (and its metadata) to disk and return the
+ * corresponding Argos attachments.
+ *
+ * This is the shared Node-side primitive used by both the browser command (which
+ * receives the already-serialized string over RPC) and the Node code path.
+ */
+export async function writeSnapshotFile(
+  name: string,
+  content: string,
+  options: SerializableSnapshotOptions = {},
+): Promise<ArgosAttachment[]> {
+  if (!name) {
+    throw new Error("The `name` argument is required.");
+  }
+
+  const root = options.root ?? DEFAULT_SNAPSHOTS_ROOT;
+  const extension = normalizeExtension(options.extension ?? DEFAULT_EXTENSION);
+  const filename = `${getScreenshotName(name)}${SNAPSHOT_INFIX}${extension}`;
+  const snapshotPath = resolve(root, filename);
+
+  const [vitestVersion, sdkVersion] = await Promise.all([
+    getVitestVersion(),
+    getArgosVitestVersion(),
+  ]);
+
+  const tags = options.tag
+    ? Array.isArray(options.tag)
+      ? options.tag
+      : [options.tag]
+    : undefined;
+
+  const metadata: ScreenshotMetadata = {
+    // `argosSnapshot` does not rely on a browser, so Vitest itself is the
+    // automation library that produced the snapshot.
+    automationLibrary: { name: "vitest", version: vitestVersion },
+    sdk: { name: "@argos-ci/vitest", version: sdkVersion },
+    ...(tags ? { tags } : {}),
+  };
+
+  await createDirectory(dirname(snapshotPath));
+  await Promise.all([
+    writeFile(snapshotPath, content, "utf-8"),
+    writeMetadata(snapshotPath, metadata),
+  ]);
+
+  return [
+    {
+      name: `argos/snapshot___${name}`,
+      contentType: getSnapshotMimeType(snapshotPath),
+      path: snapshotPath,
+    },
+    {
+      name: `argos/snapshot/metadata___${name}`,
+      contentType: "application/json",
+      path: getMetadataPath(snapshotPath),
+    },
+  ];
+}

--- a/packages/vitest/src/version.ts
+++ b/packages/vitest/src/version.ts
@@ -10,3 +10,12 @@ export async function getArgosVitestVersion(): Promise<string> {
   const pkgPath = require.resolve("@argos-ci/vitest/package.json");
   return readVersionFromPackage(pkgPath);
 }
+
+/**
+ * Get the version of Vitest itself (used as the automation library for
+ * `argosSnapshot`, which does not rely on a browser).
+ */
+export async function getVitestVersion(): Promise<string> {
+  const pkgPath = require.resolve("vitest/package.json");
+  return readVersionFromPackage(pkgPath);
+}

--- a/packages/vitest/tsdown.config.ts
+++ b/packages/vitest/tsdown.config.ts
@@ -6,7 +6,16 @@ export default defineConfig([
     dts: true,
     format: ["esm"],
     deps: {
-      neverBundle: [/^@argos-ci\//, "playwright", /^vitest/, /^@vitest/],
+      // `@vitest/pretty-format` is intentionally bundled: keeping it external
+      // makes its own transitive dep (`tinyrainbow`) unresolvable when Vitest
+      // pre-bundles this package for the browser.
+      neverBundle: [
+        /^@argos-ci\//,
+        "playwright",
+        /^vitest/,
+        "@vitest/browser",
+        "@vitest/browser-playwright",
+      ],
     },
   },
   {
@@ -14,7 +23,16 @@ export default defineConfig([
     dts: true,
     format: ["esm"],
     deps: {
-      neverBundle: [/^@argos-ci\//, "playwright", /^vitest/, /^@vitest/],
+      // `@vitest/pretty-format` is intentionally bundled: keeping it external
+      // makes its own transitive dep (`tinyrainbow`) unresolvable when Vitest
+      // pre-bundles this package for the browser.
+      neverBundle: [
+        /^@argos-ci\//,
+        "playwright",
+        /^vitest/,
+        "@vitest/browser",
+        "@vitest/browser-playwright",
+      ],
     },
   },
   {
@@ -22,7 +40,16 @@ export default defineConfig([
     dts: true,
     format: ["esm"],
     deps: {
-      neverBundle: [/^@argos-ci\//, "playwright", /^vitest/, /^@vitest/],
+      // `@vitest/pretty-format` is intentionally bundled: keeping it external
+      // makes its own transitive dep (`tinyrainbow`) unresolvable when Vitest
+      // pre-bundles this package for the browser.
+      neverBundle: [
+        /^@argos-ci\//,
+        "playwright",
+        /^vitest/,
+        "@vitest/browser",
+        "@vitest/browser-playwright",
+      ],
     },
   },
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.9
         version: 4.1.9(msw@2.14.6(@types/node@22.19.21)(typescript@6.0.3))(playwright@1.61.0)(vite@7.3.3(@types/node@22.19.21)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/pretty-format':
+        specifier: ^4.1.9
+        version: 4.1.9
       playwright:
         specifier: ^1.61.0
         version: 1.61.0


### PR DESCRIPTION
## What

Adds an `argosSnapshot(name, content, options?)` API to `@argos-ci/vitest` that captures a snapshot of **any value** (not just a screenshot) and uploads it to Argos to diff across builds — mimicking [Vitest snapshots](https://vitest.dev/guide/snapshot).

Unlike `argosScreenshot`, it **does not need a browser** and works in both Vitest browser tests and plain Node tests.

```ts
import { test } from "vitest";
import { argosSnapshot } from "@argos-ci/vitest";

test("API response", async () => {
  const user = await fetchUser();
  await argosSnapshot("user", user); // serialized with @vitest/pretty-format
});

// custom extension + tags
await argosSnapshot("config", JSON.stringify(config, null, 2), {
  extension: ".json",
  tag: "config",
});
```

## How it works

- **Serialization** runs on the test side (strings verbatim, everything else via `@vitest/pretty-format`, or a custom `serialize` fn) so browser-only values (DOM nodes, class instances) are serialized *before* crossing the RPC boundary.
- **Dispatch**: browser mode delegates to a new `argosSnapshot` browser command; Node writes directly to disk. Browser mode is detected via the `__vitest_browser__` global.
- Snapshots are written as `<name>.snapshot.<ext>` (+ a `.argos.json` metadata sidecar attributing them to the `@argos-ci/vitest` SDK and `vitest`). Supports `root`, `extension`, and `tag`.

## Reporter

Updated to push snapshots: glob `["**/*.png", "**/*.aria.yml", "**/*.snapshot.*"]` with `ignore: ["**/*.argos.json"]` so metadata sidecars aren't uploaded as snapshots.

## Other changes

- Export `getSnapshotMimeType` from `@argos-ci/core`.
- Bundle `@vitest/pretty-format` into the dist — keeping it external made its transitive `tinyrainbow` dep unresolvable when Vitest pre-bundles the package for the browser.

## Tests

- **Unit** (29 passing): `serialize`, `snapshot-file` (writes real files to a temp dir — effectively a Node integration test), `snapshot-command`, updated `reporter` + `index`.
- **E2E** (8 passing): two new browser tests exercising the full browser→node RPC + real file write for a value snapshot and a custom-extension snapshot.

Build, typecheck, lint, and format all pass. README documents the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)