### PR TITLE
docs(vitest): point SDK docs links to reference and quickstart

### DIFF
--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -17,7 +17,7 @@
 
 Capture Argos screenshots directly from your [Vitest browser tests](https://vitest.dev/guide/browser/).
 
-Visit [argos-ci.com/docs](https://argos-ci.com/docs) for guides, API and more.
+Visit the [Vitest SDK documentation](https://argos-ci.com/docs/sdks-reference/vitest) for guides, API and more.
 
 ## Requirements
 
@@ -105,5 +105,6 @@ reporter when `uploadToArgos` is enabled.
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs)
+- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/vitest)
+- [Quickstart](https://argos-ci.com/docs/quickstart/vitest-quickstart)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -19,14 +19,23 @@ Capture Argos screenshots directly from your [Vitest browser tests](https://vite
 
 Visit the [Vitest SDK documentation](https://argos-ci.com/docs/sdks-reference/vitest) for guides, API and more.
 
-## Requirements
+## Installation
 
-`@argos-ci/vitest` runs in [Vitest browser mode](https://vitest.dev/guide/browser/) with the
-[Playwright provider](https://vitest.dev/guide/browser/playwright). Install the following peer
-dependencies alongside it:
+Install the package:
 
 ```sh
-npm install --save-dev @argos-ci/vitest vitest @vitest/browser @vitest/browser-playwright playwright
+npm install --save-dev @argos-ci/vitest
+```
+
+`argosSnapshot` runs in any Vitest test — browser or Node — and needs nothing else.
+
+To capture screenshots with `argosScreenshot`, run your tests in
+[Vitest browser mode](https://vitest.dev/guide/browser/) with the
+[Playwright provider](https://vitest.dev/guide/browser/playwright) and install the
+following peer dependencies:
+
+```sh
+npm install --save-dev vitest @vitest/browser @vitest/browser-playwright playwright
 ```
 
 ## Usage

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/vitest"
   },
-  "homepage": "https://argos-ci.com/docs",
+  "homepage": "https://argos-ci.com/docs/sdks-reference/vitest",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },


### PR DESCRIPTION
Update the Vitest SDK docs links to match the pattern used by the other SDK packages (playwright, storybook, etc.).

## Changes

- **package.json** — `homepage` now points to the Vitest SDK reference: https://argos-ci.com/docs/sdks-reference/vitest
- **README.md** — intro link and "Official SDK Docs" now point to the reference; added the Quickstart link: https://argos-ci.com/docs/quickstart/vitest-quickstart

🤖 Generated with [Claude Code](https://claude.com/claude-code)