### PR TITLE
feat: add --skip-if-empty option to argos finalize

### DIFF
--- a/packages/cli/src/commands/finalize.ts
+++ b/packages/cli/src/commands/finalize.ts
@@ -1,34 +1,54 @@
-import ora from "ora";
-import type { Command } from "commander";
-import { finalize } from "@argos-ci/core";
-import { parallelNonceOption, type ParallelNonceOption } from "../options";
+import ora from 'ora';
+import { Option, type Command } from 'commander';
+import { finalize } from '@argos-ci/core';
+import {
+    buildNameOption,
+    parallelNonceOption,
+    tokenOption,
+    type BuildNameOption,
+    type ParallelNonceOption,
+    type TokenOption,
+} from '../options';
 
-type FinalizeOptions = ParallelNonceOption;
+type FinalizeOptions = ParallelNonceOption &
+    TokenOption &
+    BuildNameOption & { skipIfEmpty?: boolean | undefined };
+
+const skipIfEmptyOption = new Option(
+    '--skip-if-empty',
+    'Create a skipped build when no parallel build matches the nonce.\nUseful when uploads are conditional (e.g. skipped by a CI cache) and Argos is a required status check: the skipped build reports a success status even though nothing was uploaded.'
+);
 
 export function finalizeCommand(program: Command) {
-  program
-    .command("finalize")
-    .description("Finalize pending parallel builds")
-    .addOption(parallelNonceOption)
-    .action(async (options: FinalizeOptions) => {
-      const spinner = ora("Finalizing builds").start();
-      try {
-        const result = await finalize({
-          parallel: options.parallelNonce
-            ? { nonce: options.parallelNonce }
-            : undefined,
+    program
+        .command('finalize')
+        .description('Finalize pending parallel builds')
+        .addOption(parallelNonceOption)
+        .addOption(tokenOption)
+        .addOption(skipIfEmptyOption)
+        .addOption(buildNameOption)
+        .action(async (options: FinalizeOptions) => {
+            const spinner = ora('Finalizing builds').start();
+            try {
+                const result = await finalize({
+                    token: options.token,
+                    parallel: options.parallelNonce ? { nonce: options.parallelNonce } : undefined,
+                    skipIfEmpty: options.skipIfEmpty,
+                    buildName: options.buildName,
+                });
+                spinner.succeed(
+                    result.skippedBuild
+                        ? `No builds to finalize — skipped build created: ${result.skippedBuild.url}`
+                        : result.builds.length === 0
+                          ? 'No builds to finalize'
+                          : `Builds finalized: ${result.builds.map((b) => b.url).join(', ')}`
+                );
+            } catch (error) {
+                if (error instanceof Error) {
+                    spinner.fail(`Failed to finalize: ${error.message}`);
+                    console.error(error.stack);
+                }
+                process.exit(1);
+            }
         });
-        spinner.succeed(
-          result.builds.length === 0
-            ? "No builds to finalize"
-            : `Builds finalized: ${result.builds.map((b) => b.url).join(", ")}`,
-        );
-      } catch (error) {
-        if (error instanceof Error) {
-          spinner.fail(`Failed to finalize: ${error.message}`);
-          console.error(error.stack);
-        }
-        process.exit(1);
-      }
-    });
 }

--- a/packages/cli/src/commands/finalize.ts
+++ b/packages/cli/src/commands/finalize.ts
@@ -1,54 +1,56 @@
-import ora from 'ora';
-import { Option, type Command } from 'commander';
-import { finalize } from '@argos-ci/core';
+import ora from "ora";
+import { Option, type Command } from "commander";
+import { finalize } from "@argos-ci/core";
 import {
-    buildNameOption,
-    parallelNonceOption,
-    tokenOption,
-    type BuildNameOption,
-    type ParallelNonceOption,
-    type TokenOption,
-} from '../options';
+  buildNameOption,
+  parallelNonceOption,
+  tokenOption,
+  type BuildNameOption,
+  type ParallelNonceOption,
+  type TokenOption,
+} from "../options";
 
 type FinalizeOptions = ParallelNonceOption &
-    TokenOption &
-    BuildNameOption & { skipIfEmpty?: boolean | undefined };
+  TokenOption &
+  BuildNameOption & { skipIfEmpty?: boolean | undefined };
 
 const skipIfEmptyOption = new Option(
-    '--skip-if-empty',
-    'Create a skipped build when no parallel build matches the nonce.\nUseful when uploads are conditional (e.g. skipped by a CI cache) and Argos is a required status check: the skipped build reports a success status even though nothing was uploaded.'
+  "--skip-if-empty",
+  "Create a skipped build when no parallel build matches the nonce.\nUseful when uploads are conditional (e.g. skipped by a CI cache) and Argos is a required status check: the skipped build reports a success status even though nothing was uploaded.",
 );
 
 export function finalizeCommand(program: Command) {
-    program
-        .command('finalize')
-        .description('Finalize pending parallel builds')
-        .addOption(parallelNonceOption)
-        .addOption(tokenOption)
-        .addOption(skipIfEmptyOption)
-        .addOption(buildNameOption)
-        .action(async (options: FinalizeOptions) => {
-            const spinner = ora('Finalizing builds').start();
-            try {
-                const result = await finalize({
-                    token: options.token,
-                    parallel: options.parallelNonce ? { nonce: options.parallelNonce } : undefined,
-                    skipIfEmpty: options.skipIfEmpty,
-                    buildName: options.buildName,
-                });
-                spinner.succeed(
-                    result.skippedBuild
-                        ? `No builds to finalize — skipped build created: ${result.skippedBuild.url}`
-                        : result.builds.length === 0
-                          ? 'No builds to finalize'
-                          : `Builds finalized: ${result.builds.map((b) => b.url).join(', ')}`
-                );
-            } catch (error) {
-                if (error instanceof Error) {
-                    spinner.fail(`Failed to finalize: ${error.message}`);
-                    console.error(error.stack);
-                }
-                process.exit(1);
-            }
+  program
+    .command("finalize")
+    .description("Finalize pending parallel builds")
+    .addOption(parallelNonceOption)
+    .addOption(tokenOption)
+    .addOption(skipIfEmptyOption)
+    .addOption(buildNameOption)
+    .action(async (options: FinalizeOptions) => {
+      const spinner = ora("Finalizing builds").start();
+      try {
+        const result = await finalize({
+          token: options.token,
+          parallel: options.parallelNonce
+            ? { nonce: options.parallelNonce }
+            : undefined,
+          skipIfEmpty: options.skipIfEmpty,
+          buildName: options.buildName,
         });
+        spinner.succeed(
+          result.skippedBuild
+            ? `No builds to finalize — skipped build created: ${result.skippedBuild.url}`
+            : result.builds.length === 0
+              ? "No builds to finalize"
+              : `Builds finalized: ${result.builds.map((b) => b.url).join(", ")}`,
+        );
+      } catch (error) {
+        if (error instanceof Error) {
+          spinner.fail(`Failed to finalize: ${error.message}`);
+          console.error(error.stack);
+        }
+        process.exit(1);
+      }
+    });
 }

--- a/packages/core/mocks/handlers/finalizeBuilds.ts
+++ b/packages/core/mocks/handlers/finalizeBuilds.ts
@@ -1,0 +1,32 @@
+import { http, HttpResponse } from 'msw';
+
+type FinalizeBuildsParams = never;
+type FinalizeBuildsRequestBody = {
+    parallelNonce: string;
+};
+type FinalizeBuildsResponseBody = {
+    builds: {
+        id: string;
+        url: string;
+    }[];
+};
+
+export const finalizeBuilds = http.post<
+    FinalizeBuildsParams,
+    FinalizeBuildsRequestBody,
+    FinalizeBuildsResponseBody
+>('https://api.argos-ci.dev/builds/finalize', async ({ request }) => {
+    const body = await request.json();
+    // The "empty" nonce simulates a run where no parallel build was uploaded.
+    if (body.parallelNonce === 'empty') {
+        return HttpResponse.json({ builds: [] });
+    }
+    return HttpResponse.json({
+        builds: [
+            {
+                id: '456',
+                url: 'https://app.argos-ci.dev/builds/456',
+            },
+        ],
+    });
+});

--- a/packages/core/mocks/handlers/finalizeBuilds.ts
+++ b/packages/core/mocks/handlers/finalizeBuilds.ts
@@ -1,32 +1,32 @@
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse } from "msw";
 
 type FinalizeBuildsParams = never;
 type FinalizeBuildsRequestBody = {
-    parallelNonce: string;
+  parallelNonce: string;
 };
 type FinalizeBuildsResponseBody = {
-    builds: {
-        id: string;
-        url: string;
-    }[];
+  builds: {
+    id: string;
+    url: string;
+  }[];
 };
 
 export const finalizeBuilds = http.post<
-    FinalizeBuildsParams,
-    FinalizeBuildsRequestBody,
-    FinalizeBuildsResponseBody
->('https://api.argos-ci.dev/builds/finalize', async ({ request }) => {
-    const body = await request.json();
-    // The "empty" nonce simulates a run where no parallel build was uploaded.
-    if (body.parallelNonce === 'empty') {
-        return HttpResponse.json({ builds: [] });
-    }
-    return HttpResponse.json({
-        builds: [
-            {
-                id: '456',
-                url: 'https://app.argos-ci.dev/builds/456',
-            },
-        ],
-    });
+  FinalizeBuildsParams,
+  FinalizeBuildsRequestBody,
+  FinalizeBuildsResponseBody
+>("https://api.argos-ci.dev/builds/finalize", async ({ request }) => {
+  const body = await request.json();
+  // The "empty" nonce simulates a run where no parallel build was uploaded.
+  if (body.parallelNonce === "empty") {
+    return HttpResponse.json({ builds: [] });
+  }
+  return HttpResponse.json({
+    builds: [
+      {
+        id: "456",
+        url: "https://app.argos-ci.dev/builds/456",
+      },
+    ],
+  });
 });

--- a/packages/core/mocks/server.ts
+++ b/packages/core/mocks/server.ts
@@ -1,19 +1,21 @@
-import { beforeAll, afterAll, afterEach } from "vitest";
-import { setupServer } from "msw/node";
-import { createBuild } from "./handlers/createBuild";
-import { getProject } from "./handlers/getProject";
-import { updateBuild } from "./handlers/updateBuild";
-import { uploadScreenshot } from "./handlers/uploadScreenshot";
+import { beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { createBuild } from './handlers/createBuild';
+import { finalizeBuilds } from './handlers/finalizeBuilds';
+import { getProject } from './handlers/getProject';
+import { updateBuild } from './handlers/updateBuild';
+import { uploadScreenshot } from './handlers/uploadScreenshot';
 
 export const server = setupServer(
-  createBuild,
-  updateBuild,
-  uploadScreenshot,
-  getProject,
+    createBuild,
+    finalizeBuilds,
+    updateBuild,
+    uploadScreenshot,
+    getProject
 );
 
 export const setupMockServer = () => {
-  beforeAll(() => server.listen());
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
 };

--- a/packages/core/mocks/server.ts
+++ b/packages/core/mocks/server.ts
@@ -1,21 +1,21 @@
-import { beforeAll, afterAll, afterEach } from 'vitest';
-import { setupServer } from 'msw/node';
-import { createBuild } from './handlers/createBuild';
-import { finalizeBuilds } from './handlers/finalizeBuilds';
-import { getProject } from './handlers/getProject';
-import { updateBuild } from './handlers/updateBuild';
-import { uploadScreenshot } from './handlers/uploadScreenshot';
+import { beforeAll, afterAll, afterEach } from "vitest";
+import { setupServer } from "msw/node";
+import { createBuild } from "./handlers/createBuild";
+import { finalizeBuilds } from "./handlers/finalizeBuilds";
+import { getProject } from "./handlers/getProject";
+import { updateBuild } from "./handlers/updateBuild";
+import { uploadScreenshot } from "./handlers/uploadScreenshot";
 
 export const server = setupServer(
-    createBuild,
-    finalizeBuilds,
-    updateBuild,
-    uploadScreenshot,
-    getProject
+  createBuild,
+  finalizeBuilds,
+  updateBuild,
+  uploadScreenshot,
+  getProject,
 );
 
 export const setupMockServer = () => {
-    beforeAll(() => server.listen());
-    afterEach(() => server.resetHandlers());
-    afterAll(() => server.close());
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
 };

--- a/packages/core/src/finalize.test.ts
+++ b/packages/core/src/finalize.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupMockServer } from '../mocks/server';
+import { finalize } from './finalize';
+
+setupMockServer();
+
+describe('#finalize', () => {
+    beforeEach(() => {
+        vi.stubEnv('ARGOS_COMMIT', 'f16f980bd17cccfa93a1ae7766727e67950773d0');
+        vi.stubEnv('ARGOS_BRANCH', 'main');
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('finalizes builds matching the nonce', async () => {
+        const result = await finalize({
+            apiBaseUrl: 'https://api.argos-ci.dev',
+            token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
+            parallel: { nonce: 'nonce-123' },
+        });
+
+        expect(result).toEqual({
+            builds: [{ id: '456', url: 'https://app.argos-ci.dev/builds/456' }],
+            skippedBuild: null,
+        });
+    });
+
+    it('returns no builds when the nonce matches nothing', async () => {
+        const result = await finalize({
+            apiBaseUrl: 'https://api.argos-ci.dev',
+            token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
+            parallel: { nonce: 'empty' },
+        });
+
+        expect(result).toEqual({ builds: [], skippedBuild: null });
+    });
+
+    it('throws without a nonce', async () => {
+        await expect(
+            finalize({
+                apiBaseUrl: 'https://api.argos-ci.dev',
+                token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
+            })
+        ).rejects.toThrow('parallel.nonce is required to finalize the build');
+    });
+
+    describe('with skipIfEmpty', () => {
+        it('creates a skipped build when the nonce matches nothing', async () => {
+            const result = await finalize({
+                apiBaseUrl: 'https://api.argos-ci.dev',
+                token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
+                parallel: { nonce: 'empty' },
+                skipIfEmpty: true,
+                buildName: 'unit',
+            });
+
+            expect(result).toEqual({
+                builds: [],
+                skippedBuild: {
+                    id: '123',
+                    url: 'https://app.argos-ci.dev/builds/123',
+                },
+            });
+        });
+
+        it('does not create a skipped build when builds are finalized', async () => {
+            const result = await finalize({
+                apiBaseUrl: 'https://api.argos-ci.dev',
+                token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
+                parallel: { nonce: 'nonce-123' },
+                skipIfEmpty: true,
+                buildName: 'unit',
+            });
+
+            expect(result).toEqual({
+                builds: [{ id: '456', url: 'https://app.argos-ci.dev/builds/456' }],
+                skippedBuild: null,
+            });
+        });
+    });
+});

--- a/packages/core/src/finalize.test.ts
+++ b/packages/core/src/finalize.test.ts
@@ -1,83 +1,87 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { setupMockServer } from '../mocks/server';
-import { finalize } from './finalize';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setupMockServer } from "../mocks/server";
+import { finalize } from "./finalize";
 
 setupMockServer();
 
-describe('#finalize', () => {
-    beforeEach(() => {
-        vi.stubEnv('ARGOS_COMMIT', 'f16f980bd17cccfa93a1ae7766727e67950773d0');
-        vi.stubEnv('ARGOS_BRANCH', 'main');
+describe("#finalize", () => {
+  beforeEach(() => {
+    // Neutralize CI detection so the tests behave the same locally and on
+    // GitHub Actions, where a nonce would be derived from the run
+    // automatically.
+    vi.stubEnv("GITHUB_ACTIONS", "");
+    vi.stubEnv("ARGOS_COMMIT", "f16f980bd17cccfa93a1ae7766727e67950773d0");
+    vi.stubEnv("ARGOS_BRANCH", "main");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("finalizes builds matching the nonce", async () => {
+    const result = await finalize({
+      apiBaseUrl: "https://api.argos-ci.dev",
+      token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
+      parallel: { nonce: "nonce-123" },
     });
 
-    afterEach(() => {
-        vi.unstubAllEnvs();
+    expect(result).toEqual({
+      builds: [{ id: "456", url: "https://app.argos-ci.dev/builds/456" }],
+      skippedBuild: null,
+    });
+  });
+
+  it("returns no builds when the nonce matches nothing", async () => {
+    const result = await finalize({
+      apiBaseUrl: "https://api.argos-ci.dev",
+      token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
+      parallel: { nonce: "empty" },
     });
 
-    it('finalizes builds matching the nonce', async () => {
-        const result = await finalize({
-            apiBaseUrl: 'https://api.argos-ci.dev',
-            token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
-            parallel: { nonce: 'nonce-123' },
-        });
+    expect(result).toEqual({ builds: [], skippedBuild: null });
+  });
 
-        expect(result).toEqual({
-            builds: [{ id: '456', url: 'https://app.argos-ci.dev/builds/456' }],
-            skippedBuild: null,
-        });
+  it("throws without a nonce", async () => {
+    await expect(
+      finalize({
+        apiBaseUrl: "https://api.argos-ci.dev",
+        token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
+      }),
+    ).rejects.toThrow("parallel.nonce is required to finalize the build");
+  });
+
+  describe("with skipIfEmpty", () => {
+    it("creates a skipped build when the nonce matches nothing", async () => {
+      const result = await finalize({
+        apiBaseUrl: "https://api.argos-ci.dev",
+        token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
+        parallel: { nonce: "empty" },
+        skipIfEmpty: true,
+        buildName: "unit",
+      });
+
+      expect(result).toEqual({
+        builds: [],
+        skippedBuild: {
+          id: "123",
+          url: "https://app.argos-ci.dev/builds/123",
+        },
+      });
     });
 
-    it('returns no builds when the nonce matches nothing', async () => {
-        const result = await finalize({
-            apiBaseUrl: 'https://api.argos-ci.dev',
-            token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
-            parallel: { nonce: 'empty' },
-        });
+    it("does not create a skipped build when builds are finalized", async () => {
+      const result = await finalize({
+        apiBaseUrl: "https://api.argos-ci.dev",
+        token: "92d832e0d22ab113c8979d73a87a11130eaa24a9",
+        parallel: { nonce: "nonce-123" },
+        skipIfEmpty: true,
+        buildName: "unit",
+      });
 
-        expect(result).toEqual({ builds: [], skippedBuild: null });
+      expect(result).toEqual({
+        builds: [{ id: "456", url: "https://app.argos-ci.dev/builds/456" }],
+        skippedBuild: null,
+      });
     });
-
-    it('throws without a nonce', async () => {
-        await expect(
-            finalize({
-                apiBaseUrl: 'https://api.argos-ci.dev',
-                token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
-            })
-        ).rejects.toThrow('parallel.nonce is required to finalize the build');
-    });
-
-    describe('with skipIfEmpty', () => {
-        it('creates a skipped build when the nonce matches nothing', async () => {
-            const result = await finalize({
-                apiBaseUrl: 'https://api.argos-ci.dev',
-                token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
-                parallel: { nonce: 'empty' },
-                skipIfEmpty: true,
-                buildName: 'unit',
-            });
-
-            expect(result).toEqual({
-                builds: [],
-                skippedBuild: {
-                    id: '123',
-                    url: 'https://app.argos-ci.dev/builds/123',
-                },
-            });
-        });
-
-        it('does not create a skipped build when builds are finalized', async () => {
-            const result = await finalize({
-                apiBaseUrl: 'https://api.argos-ci.dev',
-                token: '92d832e0d22ab113c8979d73a87a11130eaa24a9',
-                parallel: { nonce: 'nonce-123' },
-                skipIfEmpty: true,
-                buildName: 'unit',
-            });
-
-            expect(result).toEqual({
-                builds: [{ id: '456', url: 'https://app.argos-ci.dev/builds/456' }],
-                skippedBuild: null,
-            });
-        });
-    });
+  });
 });

--- a/packages/core/src/finalize.ts
+++ b/packages/core/src/finalize.ts
@@ -1,94 +1,96 @@
-import type { ArgosAPISchema } from '@argos-ci/api-client';
-import { createClient, throwAPIError } from '@argos-ci/api-client';
-import { resolveArgosToken } from './auth';
-import { readConfig } from './config';
-import { skip } from './skip';
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { createClient, throwAPIError } from "@argos-ci/api-client";
+import { resolveArgosToken } from "./auth";
+import { readConfig } from "./config";
+import { skip } from "./skip";
 
 export type FinalizeParameters = {
-    /**
-     * Base URL of the Argos API.
-     */
-    apiBaseUrl?: string;
+  /**
+   * Base URL of the Argos API.
+   */
+  apiBaseUrl?: string;
 
-    /**
-     * Argos token.
-     */
-    token?: string;
+  /**
+   * Argos token.
+   */
+  token?: string;
 
-    parallel?: {
-        nonce: string;
-    };
+  parallel?: {
+    nonce: string;
+  };
 
-    /**
-     * Create a skipped build when no parallel build matches the nonce.
-     * Useful when uploads are conditional (e.g. skipped by a CI cache such as
-     * Turborepo or Nx) and Argos is a required status check: the skipped build
-     * reports a success status even though nothing was uploaded.
-     */
-    skipIfEmpty?: boolean;
+  /**
+   * Create a skipped build when no parallel build matches the nonce.
+   * Useful when uploads are conditional (e.g. skipped by a CI cache such as
+   * Turborepo or Nx) and Argos is a required status check: the skipped build
+   * reports a success status even though nothing was uploaded.
+   */
+  skipIfEmpty?: boolean;
 
-    /**
-     * Name of the build, used by the skipped build created when `skipIfEmpty`
-     * is enabled and no build matches the nonce.
-     */
-    buildName?: string;
+  /**
+   * Name of the build, used by the skipped build created when `skipIfEmpty`
+   * is enabled and no build matches the nonce.
+   */
+  buildName?: string;
 };
 
-type Build = ArgosAPISchema.components['schemas']['Build'];
+type Build = ArgosAPISchema.components["schemas"]["Build"];
 
 export type FinalizeResult = {
-    /**
-     * Parallel builds finalized by this call.
-     */
-    builds: Build[];
+  /**
+   * Parallel builds finalized by this call.
+   */
+  builds: Build[];
 
-    /**
-     * Skipped build created when `skipIfEmpty` is enabled and no parallel
-     * build matched the nonce, `null` otherwise.
-     */
-    skippedBuild: Build | null;
+  /**
+   * Skipped build created when `skipIfEmpty` is enabled and no parallel
+   * build matched the nonce, `null` otherwise.
+   */
+  skippedBuild: Build | null;
 };
 
 /**
  * Finalize pending builds.
  */
-export async function finalize(params: FinalizeParameters): Promise<FinalizeResult> {
-    const config = await readConfig({
-        apiBaseUrl: params.apiBaseUrl,
-        token: params.token,
-        parallelNonce: params.parallel?.nonce,
+export async function finalize(
+  params: FinalizeParameters,
+): Promise<FinalizeResult> {
+  const config = await readConfig({
+    apiBaseUrl: params.apiBaseUrl,
+    token: params.token,
+    parallelNonce: params.parallel?.nonce,
+  });
+  const authToken = await resolveArgosToken(config);
+
+  const apiClient = createClient({
+    baseUrl: config.apiBaseUrl,
+    authToken,
+  });
+
+  if (!config.parallelNonce) {
+    throw new Error("parallel.nonce is required to finalize the build");
+  }
+
+  const finalizeBuildsResult = await apiClient.POST("/builds/finalize", {
+    body: {
+      parallelNonce: config.parallelNonce,
+    },
+  });
+
+  if (finalizeBuildsResult.error) {
+    throwAPIError(finalizeBuildsResult.error, finalizeBuildsResult.response);
+  }
+
+  const { builds } = finalizeBuildsResult.data;
+
+  if (builds.length === 0 && params.skipIfEmpty) {
+    const { build } = await skip({
+      apiBaseUrl: params.apiBaseUrl,
+      token: params.token,
+      buildName: params.buildName,
     });
-    const authToken = await resolveArgosToken(config);
+    return { builds, skippedBuild: build };
+  }
 
-    const apiClient = createClient({
-        baseUrl: config.apiBaseUrl,
-        authToken,
-    });
-
-    if (!config.parallelNonce) {
-        throw new Error('parallel.nonce is required to finalize the build');
-    }
-
-    const finalizeBuildsResult = await apiClient.POST('/builds/finalize', {
-        body: {
-            parallelNonce: config.parallelNonce,
-        },
-    });
-
-    if (finalizeBuildsResult.error) {
-        throwAPIError(finalizeBuildsResult.error, finalizeBuildsResult.response);
-    }
-
-    const { builds } = finalizeBuildsResult.data;
-
-    if (builds.length === 0 && params.skipIfEmpty) {
-        const { build } = await skip({
-            apiBaseUrl: params.apiBaseUrl,
-            token: params.token,
-            buildName: params.buildName,
-        });
-        return { builds, skippedBuild: build };
-    }
-
-    return { builds, skippedBuild: null };
+  return { builds, skippedBuild: null };
 }

--- a/packages/core/src/finalize.ts
+++ b/packages/core/src/finalize.ts
@@ -1,40 +1,94 @@
-import { createClient, throwAPIError } from "@argos-ci/api-client";
-import { resolveArgosToken } from "./auth";
-import { readConfig } from "./config";
+import type { ArgosAPISchema } from '@argos-ci/api-client';
+import { createClient, throwAPIError } from '@argos-ci/api-client';
+import { resolveArgosToken } from './auth';
+import { readConfig } from './config';
+import { skip } from './skip';
 
 export type FinalizeParameters = {
-  parallel?: {
-    nonce: string;
-  };
+    /**
+     * Base URL of the Argos API.
+     */
+    apiBaseUrl?: string;
+
+    /**
+     * Argos token.
+     */
+    token?: string;
+
+    parallel?: {
+        nonce: string;
+    };
+
+    /**
+     * Create a skipped build when no parallel build matches the nonce.
+     * Useful when uploads are conditional (e.g. skipped by a CI cache such as
+     * Turborepo or Nx) and Argos is a required status check: the skipped build
+     * reports a success status even though nothing was uploaded.
+     */
+    skipIfEmpty?: boolean;
+
+    /**
+     * Name of the build, used by the skipped build created when `skipIfEmpty`
+     * is enabled and no build matches the nonce.
+     */
+    buildName?: string;
+};
+
+type Build = ArgosAPISchema.components['schemas']['Build'];
+
+export type FinalizeResult = {
+    /**
+     * Parallel builds finalized by this call.
+     */
+    builds: Build[];
+
+    /**
+     * Skipped build created when `skipIfEmpty` is enabled and no parallel
+     * build matched the nonce, `null` otherwise.
+     */
+    skippedBuild: Build | null;
 };
 
 /**
  * Finalize pending builds.
  */
-export async function finalize(params: FinalizeParameters) {
-  const config = await readConfig({
-    parallelNonce: params.parallel?.nonce,
-  });
-  const authToken = await resolveArgosToken(config);
+export async function finalize(params: FinalizeParameters): Promise<FinalizeResult> {
+    const config = await readConfig({
+        apiBaseUrl: params.apiBaseUrl,
+        token: params.token,
+        parallelNonce: params.parallel?.nonce,
+    });
+    const authToken = await resolveArgosToken(config);
 
-  const apiClient = createClient({
-    baseUrl: config.apiBaseUrl,
-    authToken,
-  });
+    const apiClient = createClient({
+        baseUrl: config.apiBaseUrl,
+        authToken,
+    });
 
-  if (!config.parallelNonce) {
-    throw new Error("parallel.nonce is required to finalize the build");
-  }
+    if (!config.parallelNonce) {
+        throw new Error('parallel.nonce is required to finalize the build');
+    }
 
-  const finalizeBuildsResult = await apiClient.POST("/builds/finalize", {
-    body: {
-      parallelNonce: config.parallelNonce,
-    },
-  });
+    const finalizeBuildsResult = await apiClient.POST('/builds/finalize', {
+        body: {
+            parallelNonce: config.parallelNonce,
+        },
+    });
 
-  if (finalizeBuildsResult.error) {
-    throwAPIError(finalizeBuildsResult.error, finalizeBuildsResult.response);
-  }
+    if (finalizeBuildsResult.error) {
+        throwAPIError(finalizeBuildsResult.error, finalizeBuildsResult.response);
+    }
 
-  return finalizeBuildsResult.data;
+    const { builds } = finalizeBuildsResult.data;
+
+    if (builds.length === 0 && params.skipIfEmpty) {
+        const { build } = await skip({
+            apiBaseUrl: params.apiBaseUrl,
+            token: params.token,
+            buildName: params.buildName,
+        });
+        return { builds, skippedBuild: build };
+    }
+
+    return { builds, skippedBuild: null };
 }


### PR DESCRIPTION
## Description

Adds a `--skip-if-empty` option to `argos finalize`: when no parallel build matches the nonce, it creates a **skipped build** instead of doing nothing.

This covers pipelines where every upload step is conditional — typically monorepos where a task cache (Turborepo, Nx) decides which test suites actually run. On a run where all Argos-enabled suites are cache hits, nothing is uploaded, and a required Argos status check would stay missing on the commit. `finalize --skip-if-empty` guarantees the commit always gets an Argos build: a real one when shards were uploaded, a skipped (immediately successful) one otherwise.

```
argos finalize --skip-if-empty --build-name unit
```

Changes:

- `@argos-ci/core`: `finalize()` accepts `skipIfEmpty` and `buildName`, and returns `{ builds, skippedBuild }` (`skippedBuild` is `null` unless the fallback ran). Also adds `apiBaseUrl`/`token` parameters for parity with `upload()`/`skip()`.
- `@argos-ci/cli`: `finalize` gains `--skip-if-empty`, `--build-name` and `--token`.
- Mock handler for `POST /builds/finalize` + unit tests covering both modes.

## Type of changes

`enhancement`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

Optional checks:

- [x] My changes requires a change to the documentation
- [x] I have updated the documentation accordingly

## Further comments

Docs PR in the docs repo documents the new flag (CLI reference + a new "Cached CI pipelines (Turborepo, Nx)" guide). First consumer: GitBook's monorepo, which aggregates vitest prompt-snapshot suites into a single `unit` build under Turborepo caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)