### PR TITLE
fix(cli): raise maxBuffer in e2e run helper

### DIFF
--- a/packages/cli/e2e/utils.ts
+++ b/packages/cli/e2e/utils.ts
@@ -34,6 +34,10 @@ export function run(
   const result = spawnSync("node", [cliPath, ...args], {
     encoding: "utf8",
     env,
+    // The default 1 MB buffer kills the child once its output outgrows it
+    // (status: null). The e2e suite approves the shared build on every run,
+    // so `review list` output grows unboundedly and eventually crossed it.
+    maxBuffer: 128 * 1024 * 1024,
   });
 
   const stdout = result.stdout ?? "";
@@ -42,7 +46,11 @@ export function run(
   if (result.status !== 0) {
     throw new CommandError(
       `Command failed: node ${cliPath} ${args.join(" ")}`,
-      { status: result.status, stdout, stderr },
+      {
+        status: result.status,
+        stdout,
+        stderr,
+      },
     );
   }
 


### PR DESCRIPTION
## Description

`e2e-core` is red on `main` since yesterday (last three CI runs): `e2e/review.test.ts > lists reviews in JSON mode` fails with `CommandError` and `status: null`.

Root cause: `spawnSync` in the e2e `run()` helper uses the default **1 MB `maxBuffer`** — when the child's output exceeds it, Node kills the process (`status: null`). The review e2e suite creates ~3 approved reviews on the shared build (#27748) on every run, across a 9-job matrix, so the `review list --json` output has been growing since April and finally crossed 1 MB.

This raises `maxBuffer` to 128 MB with a comment explaining why.

Worth considering separately: pruning the reviews on build 27748 (or pointing the suite at a fresh build periodically), since the output — and test duration — will keep growing forever otherwise.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)