### PR TITLE
feat(vitest): automatic naming, test metadata, shard detection & `snapshots` output dir

### DIFF
--- a/packages/vitest/.gitignore
+++ b/packages/vitest/.gitignore
@@ -1,3 +1,4 @@
+/snapshots/
 /screenshots/
 /.vitest-attachments/
 /e2e/__screenshots__/

--- a/packages/vitest/.gitignore
+++ b/packages/vitest/.gitignore
@@ -1,1 +1,3 @@
 /screenshots/
+/.vitest-attachments/
+/e2e/__screenshots__/

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -80,12 +80,31 @@ test("Button", async () => {
 });
 ```
 
+### Automatic naming
+
+The name is optional. When omitted, Argos derives one from the current test,
+just like [Vitest snapshots](https://vitest.dev/guide/snapshot)
+(`` `${test.fullName} ${count}` ``). Several unnamed captures in the same test
+get an incrementing counter so they stay unique:
+
+```ts
+test("Button", async () => {
+  render(<Button>Click me</Button>);
+  await argosScreenshot(); // -> "Button 1"
+  await argosScreenshot(); // -> "Button 2"
+});
+```
+
 ## Snapshots
 
 `argosSnapshot` captures a snapshot of any value — not just a screenshot — and
 uploads it to Argos to diff across builds, mimicking
 [Vitest snapshots](https://vitest.dev/guide/snapshot). Unlike `argosScreenshot`,
 it does not need a browser and works in **both** browser and Node tests.
+
+The value comes first; the name is optional. Omit it to auto-name the snapshot
+from the current test (like screenshots above), or pass `options.name` to set it
+explicitly:
 
 ```ts
 import { test } from "vitest";
@@ -95,7 +114,8 @@ test("API response", async () => {
   const user = await fetchUser();
   // Objects are serialized with `@vitest/pretty-format`, strings are written
   // verbatim.
-  await argosSnapshot("user", user);
+  await argosSnapshot(user); // -> "API response 1"
+  await argosSnapshot(user, { name: "user" }); // explicit name
 });
 ```
 
@@ -103,7 +123,8 @@ Use the `extension` option to control how Argos renders and diffs the snapshot,
 and `tag` to attach tags:
 
 ```ts
-await argosSnapshot("config", JSON.stringify(config, null, 2), {
+await argosSnapshot(JSON.stringify(config, null, 2), {
+  name: "config",
   extension: ".json",
   tag: "config",
 });

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -83,17 +83,21 @@ test("Button", async () => {
 ### Automatic naming
 
 The name is optional. When omitted, Argos derives one from the current test,
-just like [Vitest snapshots](https://vitest.dev/guide/snapshot)
-(`` `${test.fullName} ${count}` ``). Several unnamed captures in the same test
-get an incrementing counter so they stay unique:
+mimicking [Vitest snapshots](https://vitest.dev/guide/snapshot). Several unnamed
+captures in the same test get an incrementing counter so they stay unique:
 
 ```ts
 test("Button", async () => {
   render(<Button>Click me</Button>);
-  await argosScreenshot(); // -> "Button 1"
-  await argosScreenshot(); // -> "Button 2"
+  await argosScreenshot(); // -> "src/Button.test.tsx > Button 1"
+  await argosScreenshot(); // -> "src/Button.test.tsx > Button 2"
 });
 ```
+
+Unlike Vitest — which keeps a per-file `.snap`, so its keys only need to be
+unique within a file — Argos names are **global** across the build. The
+generated name therefore includes the test file path, so two tests with the same
+title in different files never collide.
 
 ## Snapshots
 
@@ -114,7 +118,7 @@ test("API response", async () => {
   const user = await fetchUser();
   // Objects are serialized with `@vitest/pretty-format`, strings are written
   // verbatim.
-  await argosSnapshot(user); // -> "API response 1"
+  await argosSnapshot(user); // -> "src/user.test.ts > API response 1"
   await argosSnapshot(user, { name: "user" }); // explicit name
 });
 ```

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -134,8 +134,9 @@ await argosSnapshot(JSON.stringify(config, null, 2), {
 });
 ```
 
-Snapshots are written to the same folder as screenshots and uploaded by the
-reporter when `uploadToArgos` is enabled.
+Screenshots and snapshots are both written to the `./snapshots` directory by
+default (configurable via the plugin `root` option) and uploaded by the reporter
+when `uploadToArgos` is enabled.
 
 ## Links
 

--- a/packages/vitest/e2e/screenshot.test.ts
+++ b/packages/vitest/e2e/screenshot.test.ts
@@ -54,10 +54,11 @@ test("captures a rendered element with the Argos Vitest SDK metadata", async () 
   expect(attachments.length).toBe(2);
 
   // The whole point of the package: the screenshot is attributed to this SDK
-  // and to the Playwright provider (proves setMetadataConfig propagated).
+  // and to Vitest as the automation library (proves setMetadataConfig
+  // propagated).
   const metadata = await readMetadata(attachments);
   expect(metadata.sdk.name).toBe("@argos-ci/vitest");
-  expect(metadata.automationLibrary.name).toBe("@vitest/browser-playwright");
+  expect(metadata.automationLibrary.name).toBe("vitest");
 });
 
 test("attaches the Vitest test metadata to the screenshot", async () => {

--- a/packages/vitest/e2e/screenshot.test.ts
+++ b/packages/vitest/e2e/screenshot.test.ts
@@ -60,6 +60,36 @@ test("captures a rendered element with the Argos Vitest SDK metadata", async () 
   expect(metadata.automationLibrary.name).toBe("@vitest/browser-playwright");
 });
 
+test("attaches the Vitest test metadata to the screenshot", async () => {
+  mount(`<div style="padding:20px">Metadata</div>`);
+  const attachments = await argosScreenshot("with-metadata");
+  const metadata = await readMetadata(attachments);
+
+  // Test metadata (injected from the Vitest test context, since Playwright's
+  // own testInfo is absent in a Vitest run).
+  expect(metadata.test.id).toBeTruthy();
+  expect(metadata.test.title).toBe(
+    "attaches the Vitest test metadata to the screenshot",
+  );
+  expect(metadata.test.titlePath).toEqual([
+    "e2e/screenshot.test.ts",
+    "attaches the Vitest test metadata to the screenshot",
+  ]);
+  // `location.file` is resolved relative to the git repository on the Node side.
+  expect(metadata.test.location.file).toContain(
+    "packages/vitest/e2e/screenshot.test.ts",
+  );
+  // `includeTaskLocation` (enabled by the plugin) provides real line/column.
+  expect(metadata.test.location.line).toBeGreaterThan(0);
+  expect(metadata.test.location.column).toBeGreaterThan(0);
+
+  // Browser-derived metadata comes for free through the Playwright SDK.
+  expect(metadata.browser.name).toBe("chromium");
+  expect(typeof metadata.url).toBe("string");
+  expect(["light", "dark"]).toContain(metadata.colorScheme);
+  expect(metadata.mediaType).toBe("screen");
+});
+
 test("auto-names a screenshot from the current test", async () => {
   mount(
     `<div style="padding:40px;background:#22c55e;color:#fff;font:700 32px sans-serif;">Auto</div>`,
@@ -153,6 +183,32 @@ test("writes a value snapshot that the reporter can upload", async () => {
   expect(metadata).toBeDefined();
   const parsed = JSON.parse(await server.commands.readFile(metadata!.path));
   expect(parsed.sdk.name).toBe("@argos-ci/vitest");
+});
+
+test("attaches the Vitest test metadata to the snapshot", async () => {
+  const attachments = await argosSnapshot(
+    { hello: "world" },
+    { name: "snapshot-metadata" },
+  );
+  const metadata = attachments.find((a) => a.path.endsWith(".argos.json"));
+  expect(metadata).toBeDefined();
+  const parsed = JSON.parse(await server.commands.readFile(metadata!.path));
+
+  // Snapshots have no browser, so Vitest is the automation library, but they
+  // still carry the test metadata.
+  expect(parsed.automationLibrary.name).toBe("vitest");
+  expect(parsed.test.id).toBeTruthy();
+  expect(parsed.test.title).toBe(
+    "attaches the Vitest test metadata to the snapshot",
+  );
+  expect(parsed.test.titlePath).toEqual([
+    "e2e/screenshot.test.ts",
+    "attaches the Vitest test metadata to the snapshot",
+  ]);
+  // `location.file` is resolved relative to the git repository on the Node side.
+  expect(parsed.test.location.file).toContain(
+    "packages/vitest/e2e/screenshot.test.ts",
+  );
 });
 
 test("writes a snapshot with a custom extension", async () => {

--- a/packages/vitest/e2e/screenshot.test.ts
+++ b/packages/vitest/e2e/screenshot.test.ts
@@ -60,6 +60,21 @@ test("captures a rendered element with the Argos Vitest SDK metadata", async () 
   expect(metadata.automationLibrary.name).toBe("@vitest/browser-playwright");
 });
 
+test("auto-names a screenshot from the current test", async () => {
+  mount(
+    `<div style="padding:40px;background:#22c55e;color:#fff;font:700 32px sans-serif;">Auto</div>`,
+  );
+  // No name: it is derived from the current test + a per-test counter, so the
+  // file lands under the test title with a ` 1` suffix.
+  const attachments = await argosScreenshot();
+  expect(attachments.length).toBe(2);
+
+  const screenshot = attachments.find((a) => a.path.endsWith(".png"));
+  expect(screenshot).toBeDefined();
+  expect(screenshot!.path).toContain("auto-names a screenshot");
+  expect(screenshot!.path).toContain(" 1.png");
+});
+
 test("captures a specific element via a selector", async () => {
   mount(
     `<div id="box" style="width:200px;height:120px;background:tomato"></div><p>ignored</p>`,
@@ -115,15 +130,20 @@ test("grows the iframe to capture content wider than the viewport", async () => 
 test("writes a value snapshot that the reporter can upload", async () => {
   // `argosSnapshot` works without a browser, but here we exercise the browser
   // RPC path: the value is serialized in the browser, written on the node side.
-  const attachments = await argosSnapshot("payload", {
-    id: 1,
-    name: "Argos",
-    tags: ["a", "b"],
-  });
+  const attachments = await argosSnapshot(
+    {
+      id: 1,
+      name: "Argos",
+      tags: ["a", "b"],
+    },
+    { name: "payload" },
+  );
   // The snapshot file + its metadata attachment.
   expect(attachments.length).toBe(2);
 
-  const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.txt"));
+  const snapshot = attachments.find((a) =>
+    a.path.endsWith("payload.snapshot.txt"),
+  );
   expect(snapshot).toBeDefined();
   // The value is serialized with pretty-format, ready for Argos to diff.
   const content = await server.commands.readFile(snapshot!.path);
@@ -136,7 +156,8 @@ test("writes a value snapshot that the reporter can upload", async () => {
 });
 
 test("writes a snapshot with a custom extension", async () => {
-  const attachments = await argosSnapshot("config", '{"enabled":true}', {
+  const attachments = await argosSnapshot('{"enabled":true}', {
+    name: "config",
     extension: ".json",
   });
   const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.json"));

--- a/packages/vitest/src/auto-name.test.ts
+++ b/packages/vitest/src/auto-name.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from "vitest";
+import { TestRunner } from "vitest";
+import { resolveAutoName } from "./auto-name";
+
+it("returns an explicit name verbatim", async () => {
+  await expect(resolveAutoName("button")).resolves.toBe("button");
+});
+
+it("generates a name from the current test with a per-test counter", async () => {
+  const testName = TestRunner.getCurrentTest()?.fullName;
+  expect(testName).toBeTruthy();
+
+  // Each auto-named capture in the same test gets an incrementing counter,
+  // mimicking Vitest's `${testName} ${count}` snapshot naming.
+  await expect(resolveAutoName()).resolves.toBe(`${testName} 1`);
+  await expect(resolveAutoName()).resolves.toBe(`${testName} 2`);
+});
+
+it("restarts the counter for each test", async () => {
+  const testName = TestRunner.getCurrentTest()?.fullName;
+  // A different test task, so the counter starts over at 1.
+  await expect(resolveAutoName()).resolves.toBe(`${testName} 1`);
+});

--- a/packages/vitest/src/auto-name.test.ts
+++ b/packages/vitest/src/auto-name.test.ts
@@ -21,3 +21,26 @@ it("restarts the counter for each test", async () => {
   // A different test task, so the counter starts over at 1.
   await expect(resolveAutoName()).resolves.toBe(`${testName} 1`);
 });
+
+it("includes the test file path so names are unique across files", async () => {
+  const file = TestRunner.getCurrentTest()?.file?.name;
+  expect(file).toBe("src/auto-name.test.ts");
+  // Argos names are global across the build (unlike Vitest's per-file `.snap`),
+  // so the file path is part of the auto-generated name.
+  await expect(resolveAutoName()).resolves.toContain(`${file} > `);
+});
+
+// A test title long enough that the auto-generated name would overflow the
+// filesystem's 255-char limit once extensions are appended.
+it(`truncates names that would overflow the filename limit ${"x".repeat(300)}`, async () => {
+  const test = TestRunner.getCurrentTest();
+  const reservedLength = 25;
+  const name = await resolveAutoName(undefined, { reservedLength });
+
+  // The whole filename (name + reserved suffix) fits within the limit.
+  expect(name.length).toBeLessThanOrEqual(255 - reservedLength);
+  // The unique test id is kept so truncated names from different tests never
+  // collide, and the counter is preserved at the end.
+  expect(name).toContain(test!.id);
+  expect(name.endsWith(" 1")).toBe(true);
+});

--- a/packages/vitest/src/auto-name.ts
+++ b/packages/vitest/src/auto-name.ts
@@ -1,0 +1,65 @@
+/** Minimal shape of a Vitest test task that we rely on. */
+type CurrentTest = { fullName: string } | undefined;
+
+/**
+ * Per-test counter used to generate unique automatic names, keyed by the
+ * current test task. A `WeakMap` lets the entries be garbage-collected with the
+ * test tasks, so nothing leaks across files or runs.
+ */
+const counters = new WeakMap<object, number>();
+
+/**
+ * Get the current Vitest test task.
+ *
+ * Vitest >= 4.1 exposes `TestRunner.getCurrentTest()` from the `vitest` entry
+ * point; the `vitest/suite` export is deprecated. We prefer the new API and
+ * fall back to `vitest/suite` for older 4.x. Both are imported dynamically so
+ * importing `@argos-ci/vitest` in a non-Vitest environment does not pull Vitest
+ * in.
+ */
+async function getCurrentTest(): Promise<CurrentTest> {
+  const vitest = (await import("vitest")) as {
+    TestRunner?: { getCurrentTest?: () => CurrentTest };
+  };
+  const runner = vitest.TestRunner;
+  if (runner?.getCurrentTest) {
+    return runner.getCurrentTest();
+  }
+  const suite = (await import("vitest/suite")) as {
+    getCurrentTest: () => CurrentTest;
+  };
+  return suite.getCurrentTest();
+}
+
+/**
+ * Resolve the name of a screenshot or snapshot.
+ *
+ * When an explicit `name` is provided, it is returned as-is. Otherwise a name
+ * is generated automatically from the current Vitest test, mimicking
+ * {@link https://vitest.dev/guide/snapshot Vitest's own snapshot naming}:
+ * `` `${test.fullName} ${count}` ``, where `count` increments per test so
+ * several auto-named captures in the same test stay unique.
+ *
+ * Must only be called once we know we are running inside Vitest (the caller
+ * checks `checkIsVitestEnv` first).
+ *
+ * @param name - Explicit name, or `undefined`/empty to auto-generate one.
+ * @returns The resolved, non-empty name.
+ */
+export async function resolveAutoName(name?: string): Promise<string> {
+  if (name) {
+    return name;
+  }
+
+  const test = await getCurrentTest();
+  if (!test) {
+    throw new Error(
+      "Argos could not generate an automatic name because it is not running " +
+        "inside a Vitest test. Pass an explicit `name` argument.",
+    );
+  }
+
+  const count = (counters.get(test) ?? 0) + 1;
+  counters.set(test, count);
+  return `${test.fullName} ${count}`;
+}

--- a/packages/vitest/src/auto-name.ts
+++ b/packages/vitest/src/auto-name.ts
@@ -1,7 +1,4 @@
-/** Minimal shape of a Vitest test task that we rely on. */
-type CurrentTest =
-  | { id: string; fullName: string; file?: { name?: string } | undefined }
-  | undefined;
+import { getCurrentTest } from "./test-context";
 
 /**
  * Maximum length of a single filename component on common filesystems (ext4,
@@ -24,29 +21,6 @@ function truncate(text: string, length: number): string {
     return text;
   }
   return `${text.slice(0, Math.max(0, length - 1))}…`;
-}
-
-/**
- * Get the current Vitest test task.
- *
- * Vitest >= 4.1 exposes `TestRunner.getCurrentTest()` from the `vitest` entry
- * point; the `vitest/suite` export is deprecated. We prefer the new API and
- * fall back to `vitest/suite` for older 4.x. Both are imported dynamically so
- * importing `@argos-ci/vitest` in a non-Vitest environment does not pull Vitest
- * in.
- */
-async function getCurrentTest(): Promise<CurrentTest> {
-  const vitest = (await import("vitest")) as {
-    TestRunner?: { getCurrentTest?: () => CurrentTest };
-  };
-  const runner = vitest.TestRunner;
-  if (runner?.getCurrentTest) {
-    return runner.getCurrentTest();
-  }
-  const suite = (await import("vitest/suite")) as {
-    getCurrentTest: () => CurrentTest;
-  };
-  return suite.getCurrentTest();
 }
 
 /**

--- a/packages/vitest/src/auto-name.ts
+++ b/packages/vitest/src/auto-name.ts
@@ -1,5 +1,13 @@
 /** Minimal shape of a Vitest test task that we rely on. */
-type CurrentTest = { fullName: string } | undefined;
+type CurrentTest =
+  | { id: string; fullName: string; file?: { name?: string } | undefined }
+  | undefined;
+
+/**
+ * Maximum length of a single filename component on common filesystems (ext4,
+ * APFS, NTFS all cap at 255 bytes/chars).
+ */
+const MAX_FILENAME_LENGTH = 255;
 
 /**
  * Per-test counter used to generate unique automatic names, keyed by the
@@ -7,6 +15,16 @@ type CurrentTest = { fullName: string } | undefined;
  * test tasks, so nothing leaks across files or runs.
  */
 const counters = new WeakMap<object, number>();
+
+/**
+ * Truncate `text` to `length` characters, replacing the tail with an ellipsis.
+ */
+function truncate(text: string, length: number): string {
+  if (text.length <= length) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, length - 1))}…`;
+}
 
 /**
  * Get the current Vitest test task.
@@ -40,13 +58,32 @@ async function getCurrentTest(): Promise<CurrentTest> {
  * `` `${test.fullName} ${count}` ``, where `count` increments per test so
  * several auto-named captures in the same test stay unique.
  *
+ * Unlike Vitest — which stores snapshots in a per-file `.snap`, so its keys only
+ * need to be unique within a file — Argos names are global across the whole
+ * build. The name therefore includes the test file path so two tests with the
+ * same title in different files do not collide. Vitest's `fullName` already
+ * starts with the file path; we prepend it defensively in case that changes.
+ *
+ * The name is kept short enough that the final filename — including the
+ * extension(s) the caller appends (e.g. `.snapshot.txt`, ` vw-800.png`) and the
+ * `.argos.json` metadata sidecar — fits within {@link MAX_FILENAME_LENGTH}.
+ * Mirroring the Playwright SDK, when the readable name would overflow we fall
+ * back to the test id (short and unique) so truncated names never collide, then
+ * keep as much of the readable name as fits.
+ *
  * Must only be called once we know we are running inside Vitest (the caller
  * checks `checkIsVitestEnv` first).
  *
  * @param name - Explicit name, or `undefined`/empty to auto-generate one.
+ * @param options.reservedLength - Number of characters the caller appends after
+ *   the returned name when building the filename (extensions + metadata
+ *   suffix), reserved so the whole filename stays within the limit.
  * @returns The resolved, non-empty name.
  */
-export async function resolveAutoName(name?: string): Promise<string> {
+export async function resolveAutoName(
+  name?: string,
+  options: { reservedLength?: number } = {},
+): Promise<string> {
   if (name) {
     return name;
   }
@@ -61,5 +98,24 @@ export async function resolveAutoName(name?: string): Promise<string> {
 
   const count = (counters.get(test) ?? 0) + 1;
   counters.set(test, count);
-  return `${test.fullName} ${count}`;
+
+  const file = test.file?.name;
+  const fullName =
+    file && !test.fullName.startsWith(file)
+      ? `${file} > ${test.fullName}`
+      : test.fullName;
+
+  // Reserve room for the trailing counter and the caller's suffix, then keep
+  // the whole name within the filesystem limit. The counter always survives
+  // (appended after truncation) so per-test captures stay unique; when the
+  // readable name overflows, the unique test id is prepended so truncated names
+  // from different tests never collide.
+  const suffix = ` ${count}`;
+  const maxBase =
+    MAX_FILENAME_LENGTH - (options.reservedLength ?? 0) - suffix.length;
+  const base =
+    fullName.length > maxBase
+      ? truncate(`${test.id} ${fullName}`, maxBase)
+      : fullName;
+  return `${base}${suffix}`;
 }

--- a/packages/vitest/src/command.test.ts
+++ b/packages/vitest/src/command.test.ts
@@ -86,9 +86,7 @@ describe("createArgosScreenshotCommand", () => {
       name: "@argos-ci/vitest",
       version: "0.0.0-test",
     });
-    expect(metadata.playwrightLibraries).toContain(
-      "@vitest/browser-playwright",
-    );
+    expect(metadata.playwrightLibraries).toContain("vitest");
   });
 
   it("takes one screenshot per viewport with viewport-suffixed names", async () => {

--- a/packages/vitest/src/command.ts
+++ b/packages/vitest/src/command.ts
@@ -50,7 +50,10 @@ export const createArgosScreenshotCommand = (
       const setMetadata = (viewport?: ViewportSize) => {
         DO_NOT_USE_setMetadataConfig({
           sdk: { name: "@argos-ci/vitest", version },
-          playwrightLibraries: ["@vitest/browser-playwright"],
+          // Report Vitest as the automation library (not the underlying
+          // `@vitest/browser-playwright` provider), so screenshots match the
+          // `vitest` automation library used by `argosSnapshot`.
+          playwrightLibraries: ["vitest"],
           viewport,
           // Injected so the Playwright SDK attaches the Vitest test metadata
           // (Playwright's own `testInfo` is absent here). It resolves

--- a/packages/vitest/src/command.ts
+++ b/packages/vitest/src/command.ts
@@ -10,6 +10,7 @@ import type {
   VitestScreenshotOptions,
 } from "./options";
 import { resetTesterScale, setIframeViewportSize } from "./iframe";
+import type { TestMetadata } from "./metadata";
 import { screenshotFrame } from "./screenshot";
 import { getArgosVitestVersion } from "./version";
 
@@ -20,6 +21,7 @@ import { getArgosVitestVersion } from "./version";
 export type ArgosScreenshotCommandArgs = [
   name: string,
   options?: VitestScreenshotOptions,
+  test?: TestMetadata,
 ];
 
 /**
@@ -33,7 +35,7 @@ export type ArgosScreenshotCommandArgs = [
 export const createArgosScreenshotCommand = (
   pluginOptions: ArgosVitestPluginOptions = {},
 ): BrowserCommand<ArgosScreenshotCommandArgs> => {
-  return async (ctx, name, options) => {
+  return async (ctx, name, options, test) => {
     if (!name) {
       throw new Error("The `name` argument is required.");
     }
@@ -50,6 +52,10 @@ export const createArgosScreenshotCommand = (
           sdk: { name: "@argos-ci/vitest", version },
           playwrightLibraries: ["@vitest/browser-playwright"],
           viewport,
+          // Injected so the Playwright SDK attaches the Vitest test metadata
+          // (Playwright's own `testInfo` is absent here). It resolves
+          // `location.file` relative to the git repository.
+          test,
         });
       };
 

--- a/packages/vitest/src/index.test.ts
+++ b/packages/vitest/src/index.test.ts
@@ -1,7 +1,8 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, it } from "vitest";
+import { TestRunner } from "vitest";
 import {
   argosScreenshot,
   argosSnapshot,
@@ -25,23 +26,50 @@ it("exports the argosSnapshot function", () => {
   expect(typeof argosSnapshot).toBe("function");
 });
 
-it("requires a name for argosSnapshot", async () => {
-  await expect(argosSnapshot("", "content")).rejects.toThrow("name");
+it("auto-names a snapshot from the current test when no name is given", async () => {
+  const root = await mkdtemp(join(tmpdir(), "argos-vitest-auto-"));
+  try {
+    // No `name`: it is derived from the current test + a per-test counter.
+    const first = await argosSnapshot({ hello: "world" }, { root });
+    const second = await argosSnapshot({ hello: "again" }, { root });
+
+    const testName = TestRunner.getCurrentTest()?.fullName;
+    expect(testName).toBeTruthy();
+
+    const firstSnapshot = first.find((a) => a.path.endsWith(".snapshot.txt"));
+    const secondSnapshot = second.find((a) => a.path.endsWith(".snapshot.txt"));
+    expect(firstSnapshot).toBeDefined();
+    expect(secondSnapshot).toBeDefined();
+
+    // Both are auto-named after the test, with an incrementing counter, so they
+    // do not collide. The name is derived from the test title (filesystem-unsafe
+    // characters like `>` are sanitized away in the file name).
+    expect(firstSnapshot!.path).toContain("auto-names a snapshot");
+    expect(firstSnapshot!.path).toContain(" 1.snapshot.txt");
+    expect(secondSnapshot!.path).toContain(" 2.snapshot.txt");
+    expect(firstSnapshot!.path).not.toBe(secondSnapshot!.path);
+
+    // The value is serialized and written under the auto-generated name.
+    expect(await readFile(firstSnapshot!.path, "utf-8")).toContain(
+      '"hello": "world"',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 it("writes a snapshot from a Node test", async () => {
   const root = await mkdtemp(join(tmpdir(), "argos-vitest-index-"));
   try {
     const attachments = await argosSnapshot(
-      "node-unit",
       { hello: "world" },
-      {
-        root,
-      },
+      { name: "node-unit", root },
     );
     // In a Node test it takes the direct-write path and returns the attachments.
     expect(attachments).toHaveLength(2);
-    const snapshot = attachments.find((a) => a.path.endsWith(".snapshot.txt"));
+    const snapshot = attachments.find((a) =>
+      a.path.endsWith("node-unit.snapshot.txt"),
+    );
     expect(snapshot).toBeDefined();
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/vitest/src/index.test.ts
+++ b/packages/vitest/src/index.test.ts
@@ -71,6 +71,17 @@ it("writes a snapshot from a Node test", async () => {
       a.path.endsWith("node-unit.snapshot.txt"),
     );
     expect(snapshot).toBeDefined();
+
+    // The metadata sidecar carries the Vitest test metadata.
+    const metadataAttachment = attachments.find((a) =>
+      a.path.endsWith(".argos.json"),
+    );
+    const metadata = JSON.parse(
+      await readFile(metadataAttachment!.path, "utf-8"),
+    );
+    expect(metadata.sdk.name).toBe("@argos-ci/vitest");
+    expect(metadata.test.title).toBe("writes a snapshot from a Node test");
+    expect(metadata.test.location.file).toContain("src/index.test.ts");
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,4 +1,5 @@
 import type { ArgosAttachment } from "@argos-ci/playwright";
+import { resolveAutoName } from "./auto-name";
 import type {
   SerializableSnapshotOptions,
   VitestScreenshotOptions,
@@ -28,6 +29,10 @@ declare module "vitest/browser" {
  * Requires the {@link https://www.npmjs.com/package/@argos-ci/vitest Argos Vitest plugin}
  * to be registered in your Vitest config.
  *
+ * The `name` is optional: when omitted, Argos generates one automatically from
+ * the current test, mimicking {@link https://vitest.dev/guide/snapshot Vitest's
+ * snapshot naming} (`` `${test.fullName} ${count}` ``).
+ *
  * @example
  * ```ts
  * import { render } from "vitest-browser-react";
@@ -35,28 +40,43 @@ declare module "vitest/browser" {
  *
  * test("Button", async () => {
  *   render(<Button>Click me</Button>);
- *   await argosScreenshot("button");
+ *   await argosScreenshot("button"); // explicit name
+ *   await argosScreenshot();         // automatic name
  * });
  * ```
  *
- * @param name - Unique name of the screenshot.
+ * @param name - Unique name of the screenshot. Omit to generate one from the
+ *   current test.
  * @param options - Serializable screenshot options.
  * @returns The attachments captured, or an empty array outside of Vitest.
  */
 export async function argosScreenshot(
   name: string,
   options?: VitestScreenshotOptions,
+): Promise<ArgosAttachment[]>;
+export async function argosScreenshot(
+  options?: VitestScreenshotOptions,
+): Promise<ArgosAttachment[]>;
+export async function argosScreenshot(
+  nameOrOptions?: string | VitestScreenshotOptions,
+  maybeOptions?: VitestScreenshotOptions,
 ): Promise<ArgosAttachment[]> {
+  const name = typeof nameOrOptions === "string" ? nameOrOptions : undefined;
+  const options =
+    typeof nameOrOptions === "string" ? maybeOptions : nameOrOptions;
+
   // Only run in Vitest.
   const isVitest = await checkIsVitestEnv();
   if (!isVitest) {
     return [];
   }
 
+  const resolvedName = await resolveAutoName(name);
+
   // Load vitest/browser using dynamic import to avoid loading it in non-Vitest
   // environments.
   const { server } = await import("vitest/browser");
-  return server.commands.argosScreenshot(name, options);
+  return server.commands.argosScreenshot(resolvedName, options);
 }
 
 /**
@@ -68,56 +88,66 @@ export async function argosScreenshot(
  * file that Argos picks up and diffs across builds. It works both in Vitest
  * browser tests and in plain Node tests.
  *
+ * The name is optional: pass it via `options.name`, or omit it to have Argos
+ * generate one automatically from the current test, mimicking
+ * {@link https://vitest.dev/guide/snapshot Vitest's snapshot naming}
+ * (`` `${test.fullName} ${count}` ``).
+ *
  * @example
  * ```ts
  * import { argosSnapshot } from "@argos-ci/vitest";
  *
  * test("API response", async () => {
  *   const data = await fetchUser();
- *   await argosSnapshot("user", data);
+ *   await argosSnapshot(data);                  // automatic name
+ *   await argosSnapshot(data, { name: "user" }); // explicit name
  * });
  * ```
  *
- * @param name - Unique name of the snapshot.
  * @param content - The value to snapshot. Strings are written as-is; any other
  *   value is serialized.
- * @param options - Snapshot options.
+ * @param options - Snapshot options, including an optional `name`.
  * @returns The attachments written, or an empty array outside of Vitest.
  */
 export async function argosSnapshot(
-  name: string,
   content: unknown,
   options: VitestSnapshotOptions = {},
 ): Promise<ArgosAttachment[]> {
-  if (!name) {
-    throw new Error("The `name` argument is required.");
-  }
-
   // Only run in Vitest.
   const isVitest = await checkIsVitestEnv();
   if (!isVitest) {
     return [];
   }
 
+  const resolvedName = await resolveAutoName(options.name);
+
   // Serialize on the test side (browser or Node), so values that only exist
   // here (DOM nodes, class instances, …) are serialized before crossing the RPC
   // boundary.
   const serialized = serializeSnapshot(content, options);
 
-  // The `serialize` function cannot cross the browser/node RPC boundary and is
-  // no longer needed once the value is serialized.
-  const { serialize: _serialize, ...serializableOptions } = options;
+  // `serialize` cannot cross the browser/node RPC boundary, and `name` is passed
+  // to the Node primitives as a separate argument — strip both.
+  const {
+    serialize: _serialize,
+    name: _name,
+    ...serializableOptions
+  } = options;
 
   if (checkIsBrowserEnv()) {
     // Load vitest/browser using dynamic import to avoid loading it in non-Vitest
     // environments.
     const { server } = await import("vitest/browser");
-    return server.commands.argosSnapshot(name, serialized, serializableOptions);
+    return server.commands.argosSnapshot(
+      resolvedName,
+      serialized,
+      serializableOptions,
+    );
   }
 
   // Node: write directly to disk.
   const { writeSnapshotFile } = await import("./snapshot-file");
-  return writeSnapshotFile(name, serialized, serializableOptions);
+  return writeSnapshotFile(resolvedName, serialized, serializableOptions);
 }
 
 /**

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,5 +1,6 @@
 import type { ArgosAttachment } from "@argos-ci/playwright";
 import { resolveAutoName } from "./auto-name";
+import { getTestMetadata, type TestMetadata } from "./metadata";
 import type {
   SerializableSnapshotOptions,
   VitestScreenshotOptions,
@@ -26,11 +27,13 @@ declare module "vitest/browser" {
     argosScreenshot: (
       name: string,
       options?: VitestScreenshotOptions,
+      test?: TestMetadata,
     ) => Promise<ArgosAttachment[]>;
     argosSnapshot: (
       name: string,
       content: string,
       options?: SerializableSnapshotOptions,
+      test?: TestMetadata,
     ) => Promise<ArgosAttachment[]>;
   }
 }
@@ -85,14 +88,19 @@ export async function argosScreenshot(
     return [];
   }
 
-  const resolvedName = await resolveAutoName(name, {
-    reservedLength: SCREENSHOT_NAME_RESERVED,
-  });
+  const [resolvedName, test] = await Promise.all([
+    resolveAutoName(name, { reservedLength: SCREENSHOT_NAME_RESERVED }),
+    // Gather the test metadata here (browser side), where the Vitest test
+    // context is available; it crosses the RPC boundary to the Node command.
+    getTestMetadata(),
+  ]);
 
   // Load vitest/browser using dynamic import to avoid loading it in non-Vitest
   // environments.
   const { server } = await import("vitest/browser");
-  return server.commands.argosScreenshot(resolvedName, options);
+  // Pass a defined `options` so the trailing `test` argument is never preceded
+  // by an `undefined` hole (which the browser/node RPC would drop).
+  return server.commands.argosScreenshot(resolvedName, options ?? {}, test);
 }
 
 /**
@@ -143,10 +151,15 @@ export async function argosSnapshot(
   const extension = rawExtension.startsWith(".")
     ? rawExtension
     : `.${rawExtension}`;
-  const resolvedName = await resolveAutoName(options.name, {
-    reservedLength:
-      ".snapshot".length + extension.length + METADATA_SUFFIX.length,
-  });
+  const [resolvedName, test] = await Promise.all([
+    resolveAutoName(options.name, {
+      reservedLength:
+        ".snapshot".length + extension.length + METADATA_SUFFIX.length,
+    }),
+    // Gather the test metadata here (browser or Node), where the Vitest test
+    // context is available.
+    getTestMetadata(),
+  ]);
 
   // Serialize on the test side (browser or Node), so values that only exist
   // here (DOM nodes, class instances, …) are serialized before crossing the RPC
@@ -169,12 +182,13 @@ export async function argosSnapshot(
       resolvedName,
       serialized,
       serializableOptions,
+      test,
     );
   }
 
   // Node: write directly to disk.
   const { writeSnapshotFile } = await import("./snapshot-file");
-  return writeSnapshotFile(resolvedName, serialized, serializableOptions);
+  return writeSnapshotFile(resolvedName, serialized, serializableOptions, test);
 }
 
 /**

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -9,6 +9,18 @@ import { serializeSnapshot } from "./serialize";
 
 export type { VitestScreenshotOptions, VitestSnapshotOptions };
 
+/** Suffix appended to every captured file for its metadata sidecar. */
+const METADATA_SUFFIX = ".argos.json";
+
+/**
+ * Characters reserved after a screenshot name when building its filename: the
+ * `` ` vw-<width>` `` viewport suffix, the largest capture extension
+ * (`.aria.yml`), and the metadata sidecar. Keeps auto-generated names within
+ * the filesystem limit.
+ */
+const SCREENSHOT_NAME_RESERVED =
+  " vw-99999".length + ".aria.yml".length + METADATA_SUFFIX.length;
+
 declare module "vitest/browser" {
   interface BrowserCommands {
     argosScreenshot: (
@@ -31,7 +43,9 @@ declare module "vitest/browser" {
  *
  * The `name` is optional: when omitted, Argos generates one automatically from
  * the current test, mimicking {@link https://vitest.dev/guide/snapshot Vitest's
- * snapshot naming} (`` `${test.fullName} ${count}` ``).
+ * snapshot naming}. The name includes the test file path (Argos names are global
+ * across the build, unlike Vitest's per-file `.snap`), so names stay unique
+ * across files.
  *
  * @example
  * ```ts
@@ -41,7 +55,7 @@ declare module "vitest/browser" {
  * test("Button", async () => {
  *   render(<Button>Click me</Button>);
  *   await argosScreenshot("button"); // explicit name
- *   await argosScreenshot();         // automatic name
+ *   await argosScreenshot();         // -> "src/Button.test.tsx > Button 1"
  * });
  * ```
  *
@@ -71,7 +85,9 @@ export async function argosScreenshot(
     return [];
   }
 
-  const resolvedName = await resolveAutoName(name);
+  const resolvedName = await resolveAutoName(name, {
+    reservedLength: SCREENSHOT_NAME_RESERVED,
+  });
 
   // Load vitest/browser using dynamic import to avoid loading it in non-Vitest
   // environments.
@@ -90,8 +106,9 @@ export async function argosScreenshot(
  *
  * The name is optional: pass it via `options.name`, or omit it to have Argos
  * generate one automatically from the current test, mimicking
- * {@link https://vitest.dev/guide/snapshot Vitest's snapshot naming}
- * (`` `${test.fullName} ${count}` ``).
+ * {@link https://vitest.dev/guide/snapshot Vitest's snapshot naming}. The name
+ * includes the test file path (Argos names are global across the build, unlike
+ * Vitest's per-file `.snap`), so names stay unique across files.
  *
  * @example
  * ```ts
@@ -99,7 +116,7 @@ export async function argosScreenshot(
  *
  * test("API response", async () => {
  *   const data = await fetchUser();
- *   await argosSnapshot(data);                  // automatic name
+ *   await argosSnapshot(data);                   // -> "src/user.test.ts > API response 1"
  *   await argosSnapshot(data, { name: "user" }); // explicit name
  * });
  * ```
@@ -119,7 +136,17 @@ export async function argosSnapshot(
     return [];
   }
 
-  const resolvedName = await resolveAutoName(options.name);
+  // Reserve room for the `.snapshot<ext>` suffix and the metadata sidecar so an
+  // auto-generated filename stays within the filesystem limit. Kept in sync with
+  // `writeSnapshotFile` in `snapshot-file.ts`.
+  const rawExtension = options.extension ?? ".txt";
+  const extension = rawExtension.startsWith(".")
+    ? rawExtension
+    : `.${rawExtension}`;
+  const resolvedName = await resolveAutoName(options.name, {
+    reservedLength:
+      ".snapshot".length + extension.length + METADATA_SUFFIX.length,
+  });
 
   // Serialize on the test side (browser or Node), so values that only exist
   // here (DOM nodes, class instances, …) are serialized before crossing the RPC

--- a/packages/vitest/src/metadata.test.ts
+++ b/packages/vitest/src/metadata.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getTestMetadata } from "./metadata";
+
+describe("outer", () => {
+  it("builds test metadata from the current test", async () => {
+    const test = await getTestMetadata();
+    expect(test).toBeTruthy();
+    expect(test?.id).toBeTruthy();
+    // The leaf title and the full title path (file + describes + title).
+    expect(test?.title).toBe("builds test metadata from the current test");
+    expect(test?.titlePath).toEqual([
+      "src/metadata.test.ts",
+      "outer",
+      "builds test metadata from the current test",
+    ]);
+    // The location file is absolute here; the Node side makes it repo-relative.
+    expect(test?.location?.file.endsWith("src/metadata.test.ts")).toBe(true);
+  });
+
+  it(
+    "reports the configured retries and current retry",
+    { retry: 3 },
+    async () => {
+      const test = await getTestMetadata();
+      expect(test?.retries).toBe(3);
+      expect(test?.retry).toBe(0);
+    },
+  );
+});

--- a/packages/vitest/src/metadata.ts
+++ b/packages/vitest/src/metadata.ts
@@ -1,0 +1,88 @@
+import type { ScreenshotMetadata } from "@argos-ci/util";
+import {
+  getCurrentTest,
+  type CurrentSuite,
+  type CurrentTask,
+} from "./test-context";
+
+/** The `test` slice of {@link ScreenshotMetadata}. */
+export type TestMetadata = ScreenshotMetadata["test"];
+
+/**
+ * Build the title path of a task (`[file, ...describes, title]`), replicating
+ * Vitest's own `getNames` helper so it matches the framework's conventions.
+ */
+function getTitlePath(task: CurrentTask): string[] {
+  const names = [task.name];
+  let current: CurrentSuite = task;
+  while (current.suite) {
+    current = current.suite;
+    if (current.name) {
+      names.unshift(current.name);
+    }
+  }
+  // The file task sits at the top of the suite chain; only prepend it when the
+  // walk did not already reach it (mirrors Vitest's `current !== task.file`).
+  if ((current as unknown) !== (task.file as unknown)) {
+    names.unshift(task.file.name);
+  }
+  return names;
+}
+
+/**
+ * Build the Argos `test` metadata from a Vitest test task, mirroring the
+ * Playwright SDK.
+ *
+ * `location.file` is left absolute here; the Node side (the Playwright SDK for
+ * screenshots, {@link writeSnapshotFile} for snapshots) resolves it relative to
+ * the git repository — the same treatment the Playwright SDK applies.
+ */
+export function buildTestMetadata(
+  task: CurrentTask,
+): NonNullable<TestMetadata> {
+  return {
+    id: task.id,
+    title: task.name,
+    titlePath: getTitlePath(task),
+    tags: task.tags && task.tags.length > 0 ? task.tags : undefined,
+    // `retry`/`repeats` on the task are the configured maximums; the current
+    // counts live on the result.
+    retries: task.retry ?? undefined,
+    retry: task.result?.retryCount ?? undefined,
+    repeat: task.result?.repeatCount ?? task.repeats ?? undefined,
+    location: {
+      file: task.file.filepath,
+      line: task.location?.line ?? 0,
+      column: task.location?.column ?? 0,
+    },
+    annotations:
+      task.annotations && task.annotations.length > 0
+        ? task.annotations.map((annotation) => ({
+            type: annotation.type,
+            description: annotation.message,
+            location: annotation.location
+              ? {
+                  file: annotation.location.file ?? task.file.filepath,
+                  line: annotation.location.line ?? 0,
+                  column: annotation.location.column ?? 0,
+                }
+              : undefined,
+          }))
+        : undefined,
+  };
+}
+
+/**
+ * Get the Argos `test` metadata for the current Vitest test, or `null` when not
+ * running inside a test.
+ *
+ * Runs on the test side (browser or Node) where the test context is available;
+ * the resulting plain object crosses the browser/Node RPC boundary unchanged.
+ */
+export async function getTestMetadata(): Promise<TestMetadata> {
+  const task = await getCurrentTest();
+  if (!task) {
+    return null;
+  }
+  return buildTestMetadata(task);
+}

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -108,9 +108,9 @@ export interface VitestSnapshotOptions {
   /**
    * Folder where the snapshot is written.
    *
-   * In Node tests this defaults to `"./screenshots"`. In browser tests it
+   * In Node tests this defaults to `"./snapshots"`. In browser tests it
    * defaults to the plugin `root` and can be overridden per call.
-   * @default "./screenshots"
+   * @default "./snapshots"
    */
   root?: string;
 

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -95,6 +95,15 @@ export interface VitestScreenshotOptions {
  */
 export interface VitestSnapshotOptions {
   /**
+   * Unique name of the snapshot.
+   *
+   * When omitted, Argos generates one automatically from the current test,
+   * mimicking {@link https://vitest.dev/guide/snapshot Vitest's snapshot naming}
+   * (`` `${test.fullName} ${count}` ``).
+   */
+  name?: string;
+
+  /**
    * Folder where the snapshot is written.
    *
    * In Node tests this defaults to `"./screenshots"`. In browser tests it
@@ -124,12 +133,13 @@ export interface VitestSnapshotOptions {
 
 /**
  * Subset of {@link VitestSnapshotOptions} that can cross the Vitest
- * browser/node RPC boundary (everything but `serialize`, which is applied
- * before the value is sent to Node).
+ * browser/node RPC boundary. Excludes `serialize` (applied before the value is
+ * sent to Node) and `name` (resolved on the test side and passed to the Node
+ * primitives as a separate argument).
  */
 export type SerializableSnapshotOptions = Omit<
   VitestSnapshotOptions,
-  "serialize"
+  "serialize" | "name"
 >;
 
 /**

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -98,8 +98,10 @@ export interface VitestSnapshotOptions {
    * Unique name of the snapshot.
    *
    * When omitted, Argos generates one automatically from the current test,
-   * mimicking {@link https://vitest.dev/guide/snapshot Vitest's snapshot naming}
-   * (`` `${test.fullName} ${count}` ``).
+   * mimicking {@link https://vitest.dev/guide/snapshot Vitest's snapshot naming}.
+   * The generated name includes the test file path so names stay unique across
+   * files (Argos names are global across the build, unlike Vitest's per-file
+   * `.snap`).
    */
   name?: string;
 

--- a/packages/vitest/src/plugin.ts
+++ b/packages/vitest/src/plugin.ts
@@ -45,7 +45,7 @@ const cwd = process.cwd();
  */
 export function argosVitestPlugin(options?: ArgosVitestPluginOptions): Plugin {
   const {
-    root: unresolvedRoot = "./screenshots",
+    root: unresolvedRoot = "./snapshots",
     uploadToArgos,
     ...otherOptions
   } = options ?? {};

--- a/packages/vitest/src/plugin.ts
+++ b/packages/vitest/src/plugin.ts
@@ -65,6 +65,9 @@ export function argosVitestPlugin(options?: ArgosVitestPluginOptions): Plugin {
           include: ["@argos-ci/vitest"],
         },
         test: {
+          // Record each test's source location so Argos can attach it to the
+          // screenshot/snapshot metadata (and link back to the test source).
+          includeTaskLocation: true,
           browser: {
             commands: {
               argosScreenshot: createArgosScreenshotCommand({

--- a/packages/vitest/src/reporter.test.ts
+++ b/packages/vitest/src/reporter.test.ts
@@ -1,13 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Vitest } from "vitest/node";
 
-const { upload } = vi.hoisted(() => ({ upload: vi.fn() }));
-vi.mock("@argos-ci/core", () => ({ upload }));
+const { upload, readConfig } = vi.hoisted(() => ({
+  upload: vi.fn(),
+  readConfig: vi.fn(),
+}));
+vi.mock("@argos-ci/core", () => ({ upload, readConfig }));
 
 import { ArgosReporter } from "./reporter";
 
-function createVitest(watch: boolean): Vitest {
-  return { config: { watch } } as unknown as Vitest;
+function createVitest(config: {
+  watch?: boolean;
+  shard?: { index: number; count: number };
+}): Vitest {
+  return { config: { watch: false, ...config } } as unknown as Vitest;
+}
+
+/** Default Argos config with no parallel env variables set. */
+function argosConfig(
+  overrides: Partial<{
+    parallelNonce: string | null;
+    parallelTotal: number | null;
+    parallelIndex: number | null;
+  }> = {},
+) {
+  return {
+    parallelNonce: null,
+    parallelTotal: null,
+    parallelIndex: null,
+    ...overrides,
+  };
 }
 
 describe("ArgosReporter", () => {
@@ -18,6 +40,8 @@ describe("ArgosReporter", () => {
     upload.mockResolvedValue({
       build: { url: "https://argos-ci.com/build/1" },
     });
+    readConfig.mockReset();
+    readConfig.mockResolvedValue(argosConfig());
     log = vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
@@ -27,7 +51,7 @@ describe("ArgosReporter", () => {
 
   it("uploads screenshots, ARIA and value snapshots at the end of a non-watch run and logs the build URL", async () => {
     const reporter = new ArgosReporter({ buildName: "test" });
-    reporter.onInit(createVitest(false));
+    reporter.onInit(createVitest({}));
     await reporter.onTestRunEnd();
     expect(upload).toHaveBeenCalledTimes(1);
     expect(upload).toHaveBeenCalledWith({
@@ -45,7 +69,7 @@ describe("ArgosReporter", () => {
       buildName: "test",
       files: ["custom/**/*.png"],
     });
-    reporter.onInit(createVitest(false));
+    reporter.onInit(createVitest({}));
     await reporter.onTestRunEnd();
     expect(upload).toHaveBeenCalledWith({
       files: ["custom/**/*.png"],
@@ -57,21 +81,97 @@ describe("ArgosReporter", () => {
   it("propagates upload failures", async () => {
     upload.mockRejectedValue(new Error("upload failed"));
     const reporter = new ArgosReporter({ buildName: "test" });
-    reporter.onInit(createVitest(false));
+    reporter.onInit(createVitest({}));
     await expect(reporter.onTestRunEnd()).rejects.toThrow("upload failed");
   });
 
   it("does not upload in watch mode", async () => {
     const reporter = new ArgosReporter({ buildName: "test" });
-    reporter.onInit(createVitest(true));
+    reporter.onInit(createVitest({ watch: true }));
     await reporter.onTestRunEnd();
     expect(upload).not.toHaveBeenCalled();
   });
 
   it("onFinished delegates to onTestRunEnd for Vitest v3 compatibility", async () => {
     const reporter = new ArgosReporter({ buildName: "test" });
-    reporter.onInit(createVitest(false));
+    reporter.onInit(createVitest({}));
     await reporter.onFinished();
     expect(upload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not set parallel when not sharding", async () => {
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest({}));
+    await reporter.onTestRunEnd();
+    // Without a shard config we never read the Argos config.
+    expect(readConfig).not.toHaveBeenCalled();
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({ parallel: undefined }),
+    );
+  });
+
+  it("derives parallel options from `vitest --shard=2/4`", async () => {
+    readConfig.mockResolvedValue(argosConfig({ parallelNonce: "nonce-1" }));
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest({ shard: { index: 2, count: 4 } }));
+    await reporter.onTestRunEnd();
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parallel: { total: 4, nonce: "nonce-1", index: 2 },
+      }),
+    );
+  });
+
+  it("throws when sharding without ARGOS_PARALLEL_NONCE", async () => {
+    readConfig.mockResolvedValue(argosConfig({ parallelNonce: null }));
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest({ shard: { index: 1, count: 4 } }));
+    await expect(reporter.onTestRunEnd()).rejects.toThrow(
+      "ARGOS_PARALLEL_NONCE",
+    );
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("lets ARGOS_PARALLEL_TOTAL/INDEX override the shard values", async () => {
+    readConfig.mockResolvedValue(
+      argosConfig({
+        parallelNonce: "nonce-1",
+        parallelTotal: 8,
+        parallelIndex: 5,
+      }),
+    );
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest({ shard: { index: 2, count: 4 } }));
+    await reporter.onTestRunEnd();
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parallel: { total: 8, nonce: "nonce-1", index: 5 },
+      }),
+    );
+  });
+
+  it("ignores a single shard (count 1)", async () => {
+    const reporter = new ArgosReporter({ buildName: "test" });
+    reporter.onInit(createVitest({ shard: { index: 1, count: 1 } }));
+    await reporter.onTestRunEnd();
+    expect(readConfig).not.toHaveBeenCalled();
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({ parallel: undefined }),
+    );
+  });
+
+  it("lets an explicit reporter `parallel` config win over shard detection", async () => {
+    readConfig.mockResolvedValue(argosConfig({ parallelNonce: "nonce-1" }));
+    const reporter = new ArgosReporter({
+      buildName: "test",
+      parallel: { total: 2, nonce: "explicit", index: 1 },
+    });
+    reporter.onInit(createVitest({ shard: { index: 2, count: 4 } }));
+    await reporter.onTestRunEnd();
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parallel: { total: 2, nonce: "explicit", index: 1 },
+      }),
+    );
   });
 });

--- a/packages/vitest/src/reporter.ts
+++ b/packages/vitest/src/reporter.ts
@@ -1,9 +1,39 @@
-import { upload } from "@argos-ci/core";
+import { readConfig, upload, type UploadParameters } from "@argos-ci/core";
 import type { Vitest } from "vitest/node";
 import type { Reporter } from "vitest/reporters";
 import type { ArgosReporterConfig } from "./options";
 
 export type { ArgosReporterConfig };
+
+/**
+ * Derive the Argos parallel configuration from Vitest's shard settings, matching
+ * the Playwright reporter.
+ *
+ * Vitest's `--shard=<index>/<count>` populates `config.shard` as
+ * `{ index, count }` (the `index` is 1-based, like the Argos `parallel.index`).
+ * When sharding is active, Argos still needs `ARGOS_PARALLEL_NONCE` to group the
+ * shards into a single build; the total and index default to the shard values
+ * but can be overridden via `ARGOS_PARALLEL_TOTAL` / `ARGOS_PARALLEL_INDEX`.
+ */
+async function getParallelFromConfig(config: {
+  shard?: { index: number; count: number } | undefined;
+}): Promise<UploadParameters["parallel"] | null> {
+  const { shard } = config;
+  if (!shard || shard.count === 1) {
+    return null;
+  }
+  const argosConfig = await readConfig();
+  if (!argosConfig.parallelNonce) {
+    throw new Error(
+      "Vitest shard mode detected. Please specify the ARGOS_PARALLEL_NONCE environment variable. Read https://argos-ci.com/docs/parallel-testing",
+    );
+  }
+  return {
+    total: argosConfig.parallelTotal ?? shard.count,
+    nonce: argosConfig.parallelNonce,
+    index: argosConfig.parallelIndex ?? shard.index,
+  };
+}
 
 /**
  * Vitest reporter that uploads the screenshots captured during the run to Argos.
@@ -30,6 +60,9 @@ export class ArgosReporter implements Reporter {
     if (this.vitest.config.watch) {
       return;
     }
+    // Auto-detect `vitest --shard=<index>/<count>` and map it to Argos parallel
+    // options, so users only need `ARGOS_PARALLEL_NONCE`.
+    const parallel = await getParallelFromConfig(this.vitest.config);
     const res = await upload({
       // Default to uploading screenshots, ARIA snapshots and `argosSnapshot`
       // files. Without this, `upload` only matches images
@@ -40,6 +73,9 @@ export class ArgosReporter implements Reporter {
       // The `.snapshot.*` glob would otherwise also match the `.argos.json`
       // metadata sidecars written next to each snapshot.
       ignore: ["**/*.argos.json"],
+      // Auto-detected from the shard config; an explicit `parallel` in the
+      // reporter config still wins (spread below).
+      parallel: parallel ?? undefined,
       ...this.config,
     });
     console.log(`✅ Argos build created: ${res.build.url}`);

--- a/packages/vitest/src/snapshot-command.test.ts
+++ b/packages/vitest/src/snapshot-command.test.ts
@@ -24,9 +24,12 @@ describe("createArgosSnapshotCommand", () => {
   it("writes the serialized content with the plugin root", async () => {
     const command = createArgosSnapshotCommand({ root: "/abs/screenshots" });
     await command(ctx, "user", "serialized");
-    expect(writeSnapshotFile).toHaveBeenCalledWith("user", "serialized", {
-      root: "/abs/screenshots",
-    });
+    expect(writeSnapshotFile).toHaveBeenCalledWith(
+      "user",
+      "serialized",
+      { root: "/abs/screenshots" },
+      undefined,
+    );
   });
 
   it("lets per-call options override the plugin root", async () => {
@@ -36,10 +39,28 @@ describe("createArgosSnapshotCommand", () => {
       extension: ".json",
       tag: "a",
     });
-    expect(writeSnapshotFile).toHaveBeenCalledWith("user", "serialized", {
-      root: "/other",
-      extension: ".json",
-      tag: "a",
-    });
+    expect(writeSnapshotFile).toHaveBeenCalledWith(
+      "user",
+      "serialized",
+      { root: "/other", extension: ".json", tag: "a" },
+      undefined,
+    );
+  });
+
+  it("forwards the test metadata to the writer", async () => {
+    const command = createArgosSnapshotCommand({ root: "/abs/screenshots" });
+    const test = {
+      id: "1_0_0",
+      title: "user",
+      titlePath: ["src/user.test.ts", "user"],
+      location: { file: "/abs/src/user.test.ts", line: 1, column: 1 },
+    };
+    await command(ctx, "user", "serialized", undefined, test);
+    expect(writeSnapshotFile).toHaveBeenCalledWith(
+      "user",
+      "serialized",
+      { root: "/abs/screenshots" },
+      test,
+    );
   });
 });

--- a/packages/vitest/src/snapshot-command.ts
+++ b/packages/vitest/src/snapshot-command.ts
@@ -1,5 +1,6 @@
 import type { BrowserCommand } from "vitest/node";
 import type { ArgosAttachment } from "@argos-ci/playwright";
+import type { TestMetadata } from "./metadata";
 import type {
   ArgosVitestPluginOptions,
   SerializableSnapshotOptions,
@@ -15,6 +16,7 @@ export type ArgosSnapshotCommandArgs = [
   name: string,
   content: string,
   options?: SerializableSnapshotOptions,
+  test?: TestMetadata,
 ];
 
 /**
@@ -25,7 +27,13 @@ export type ArgosSnapshotCommandArgs = [
 export const createArgosSnapshotCommand = (
   pluginOptions: ArgosVitestPluginOptions = {},
 ): BrowserCommand<ArgosSnapshotCommandArgs> => {
-  return async (_ctx, name, content, options): Promise<ArgosAttachment[]> => {
+  return async (
+    _ctx,
+    name,
+    content,
+    options,
+    test,
+  ): Promise<ArgosAttachment[]> => {
     if (!name) {
       throw new Error("The `name` argument is required.");
     }
@@ -33,6 +41,6 @@ export const createArgosSnapshotCommand = (
       root: pluginOptions.root,
       ...options,
     };
-    return writeSnapshotFile(name, content, merged);
+    return writeSnapshotFile(name, content, merged, test);
   };
 };

--- a/packages/vitest/src/snapshot-file.ts
+++ b/packages/vitest/src/snapshot-file.ts
@@ -16,7 +16,7 @@ import { getArgosVitestVersion, getVitestVersion } from "./version";
  * Default folder where snapshots are written when no `root` is provided.
  * Matches the plugin default so Node and browser snapshots land together.
  */
-export const DEFAULT_SNAPSHOTS_ROOT = "./screenshots";
+export const DEFAULT_SNAPSHOTS_ROOT = "./snapshots";
 
 /**
  * Default extension of a serialized snapshot file.

--- a/packages/vitest/src/snapshot-file.ts
+++ b/packages/vitest/src/snapshot-file.ts
@@ -1,16 +1,39 @@
 import { writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { getSnapshotMimeType } from "@argos-ci/core";
 import {
   createDirectory,
+  getGitRepositoryPath,
   getMetadataPath,
   getScreenshotName,
   writeMetadata,
   type ScreenshotMetadata,
 } from "@argos-ci/util";
 import type { ArgosAttachment } from "@argos-ci/playwright";
+import type { TestMetadata } from "./metadata";
 import type { SerializableSnapshotOptions } from "./options";
 import { getArgosVitestVersion, getVitestVersion } from "./version";
+
+/**
+ * Resolve a `test` metadata's `location.file` relative to the git repository,
+ * matching the Playwright SDK. The test side reports an absolute path.
+ */
+async function resolveTestLocation(test: TestMetadata): Promise<TestMetadata> {
+  if (!test?.location) {
+    return test;
+  }
+  const repositoryPath = await getGitRepositoryPath();
+  if (!repositoryPath) {
+    return test;
+  }
+  return {
+    ...test,
+    location: {
+      ...test.location,
+      file: relative(repositoryPath, test.location.file),
+    },
+  };
+}
 
 /**
  * Default folder where snapshots are written when no `root` is provided.
@@ -47,6 +70,7 @@ export async function writeSnapshotFile(
   name: string,
   content: string,
   options: SerializableSnapshotOptions = {},
+  test?: TestMetadata,
 ): Promise<ArgosAttachment[]> {
   if (!name) {
     throw new Error("The `name` argument is required.");
@@ -57,9 +81,10 @@ export async function writeSnapshotFile(
   const filename = `${getScreenshotName(name)}${SNAPSHOT_INFIX}${extension}`;
   const snapshotPath = resolve(root, filename);
 
-  const [vitestVersion, sdkVersion] = await Promise.all([
+  const [vitestVersion, sdkVersion, resolvedTest] = await Promise.all([
     getVitestVersion(),
     getArgosVitestVersion(),
+    resolveTestLocation(test),
   ]);
 
   const tags = options.tag
@@ -74,6 +99,7 @@ export async function writeSnapshotFile(
     automationLibrary: { name: "vitest", version: vitestVersion },
     sdk: { name: "@argos-ci/vitest", version: sdkVersion },
     ...(tags ? { tags } : {}),
+    ...(resolvedTest ? { test: resolvedTest } : {}),
   };
 
   await createDirectory(dirname(snapshotPath));

--- a/packages/vitest/src/test-context.ts
+++ b/packages/vitest/src/test-context.ts
@@ -1,0 +1,60 @@
+/**
+ * Minimal structural view of a Vitest suite task (a `describe` block or the
+ * file task at the root of the chain).
+ */
+export interface CurrentSuite {
+  name?: string;
+  suite?: CurrentSuite;
+}
+
+/**
+ * Minimal structural view of the Vitest test task we read metadata from. Only
+ * the fields Argos uses are declared; the real object has many more.
+ */
+export interface CurrentTask extends CurrentSuite {
+  id: string;
+  name: string;
+  fullName: string;
+  file: { name: string; filepath: string };
+  /** Tags declared on the test (Vitest >= 4). */
+  tags?: string[] | undefined;
+  /** Configured maximum number of retries. */
+  retry?: number | undefined;
+  /** Configured number of repeats. */
+  repeats?: number | undefined;
+  /** Source location, only present when `includeTaskLocation` is enabled. */
+  location?: { line: number; column: number } | undefined;
+  annotations?:
+    | Array<{
+        type: string;
+        message?: string;
+        location?:
+          | { file?: string; line?: number; column?: number }
+          | undefined;
+      }>
+    | undefined;
+  result?: { retryCount?: number; repeatCount?: number } | undefined;
+}
+
+/**
+ * Get the current Vitest test task, or `undefined` when not inside a test.
+ *
+ * Vitest >= 4.1 exposes `TestRunner.getCurrentTest()` from the `vitest` entry
+ * point; the `vitest/suite` export is deprecated. We prefer the new API and
+ * fall back to `vitest/suite` for older 4.x. Both are imported dynamically so
+ * importing `@argos-ci/vitest` in a non-Vitest environment does not pull Vitest
+ * in — only call this once you know Vitest is available.
+ */
+export async function getCurrentTest(): Promise<CurrentTask | undefined> {
+  const vitest = (await import("vitest")) as {
+    TestRunner?: { getCurrentTest?: () => CurrentTask | undefined };
+  };
+  const runner = vitest.TestRunner;
+  if (runner?.getCurrentTest) {
+    return runner.getCurrentTest();
+  }
+  const suite = (await import("vitest/suite")) as {
+    getCurrentTest: () => CurrentTask | undefined;
+  };
+  return suite.getCurrentTest();
+}


### PR DESCRIPTION
## Description

A batch of `@argos-ci/vitest` improvements bringing it to parity with the Playwright SDK.

- [ARG-460](https://linear.app/argos/issue/ARG-460) — automatic snapshot/screenshot naming
- [ARG-459](https://linear.app/argos/issue/ARG-459) — test metadata
- [ARG-458](https://linear.app/argos/issue/ARG-458) — automatic shard detection

### 1. Automatic naming (ARG-460)

`name` is no longer required. When omitted, Argos derives one from the current test, mimicking [Vitest's own snapshot naming](https://vitest.dev/guide/snapshot) with a per-test counter.

```ts
test("Button", async () => {
  await argosScreenshot();              // -> "src/Button.test.tsx > Button 1"
  await argosScreenshot();              // -> "src/Button.test.tsx > Button 2"
  await argosSnapshot(data);            // -> "src/Button.test.tsx > Button 3"
  await argosSnapshot(data, { name: "user" }); // explicit name
});
```

- **`argosScreenshot`** keeps its name-first form; `name` is now optional.
- **`argosSnapshot`** becomes content-first with the name in `options`: `argosSnapshot(content, { name })` — removes the string-`name`/string-`content` ambiguity.
- **Globally unique across files:** the auto name includes the **test file path** (Argos names are global, unlike Vitest's per-file `.snap`).
- **Filename length cap:** mirrors the Playwright SDK — capped to keep the final filename within 255 chars, falling back to the unique test id when needed.

### 2. Test metadata (ARG-459)

Screenshots and snapshots now carry the Vitest **test metadata**, matching the Playwright SDK: `id`, `title`, `titlePath`, `tags`, `retries`/`retry`, `repeat`, `annotations`, and `location` (`file` git-relative; real `line`/`column` via `includeTaskLocation`, enabled by the plugin).

- Gathered on the test side and injected through the Playwright SDK's metadata config for screenshots, or written to the sidecar on the Node side for snapshots.
- Screenshots keep the browser-derived metadata Playwright already provides (`url`, `browser`, `colorScheme`, `mediaType`, `viewport`).
- The **automation library** is reported as `vitest` (not the underlying `@vitest/browser-playwright` provider), consistent between screenshots and snapshots.

### 3. Automatic shard detection (ARG-458)

The reporter reads Vitest's resolved `shard` config (`vitest --shard=<index>/<count>`) and derives the Argos `parallel` options, matching the Playwright reporter's `getParallelFromConfig`. Users only set `ARGOS_PARALLEL_NONCE`; `total`/`index` default to the shard's `count`/`index` and can be overridden via `ARGOS_PARALLEL_TOTAL`/`ARGOS_PARALLEL_INDEX`. An explicit `parallel` in the reporter config still wins.

### 4. Default output directory

The default `root` is now **`./snapshots`** instead of `./screenshots`, since the directory holds both screenshots and value snapshots. The **Storybook** integration keeps its own `./screenshots` default and is unaffected.

### Implementation notes

- Extracted `getCurrentTest` into `test-context.ts`, shared by naming and metadata; read via `TestRunner.getCurrentTest()` (Vitest ≥ 4.1) with a `vitest/suite` fallback, both dynamically imported so non-Vitest usage stays graceful.
- Passes a defined `options` object to the screenshot command so the trailing `test` RPC argument is never dropped after an `undefined` hole.

> [!WARNING]
> **Breaking changes** (package is at `0.x`, ships under a minor bump):
> - `argosSnapshot(name, content, options)` → `argosSnapshot(content, { name, ...options })`.
> - Default output directory `./screenshots` → `./snapshots` (pass `root: "./screenshots"` to keep the old location).

## Type of changes

`enhancement`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the Conventional Commits' policy
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

Optional checks:

- [x] My changes requires a change to the documentation
- [x] I have updated the documentation accordingly

## Further comments

Verified with typecheck, build, 43 unit tests, and 11 e2e tests (real Chromium), plus lint and prettier. Storybook typechecks against the updated package and keeps `./screenshots`. Docs updates are in a companion PR on `argos-ci/docs` (#228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)