### PR TITLE
feat(cli): add `analytics` command to fetch account analytics

### DIFF
--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4,6 +4,26 @@
  */
 
 export interface paths {
+    "/accounts/{accountSlug}/analytics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get account analytics
+         * @description Retrieve build and screenshot metrics for an account. The personal access token must be scoped to the account.
+         */
+        get: operations["getAccountAnalytics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/builds": {
         parameters: {
             query?: never;
@@ -696,6 +716,67 @@ export interface components {
          * @example 42
          */
         BuildNumber: string;
+        AccountAnalytics: {
+            screenshots: {
+                series: {
+                    total: number;
+                    /** @description Counts keyed by project ID. Use the sibling `projects` array to resolve each project name. */
+                    projects: {
+                        [key: string]: number;
+                    };
+                    /** @description Unix timestamp in milliseconds at the start of the period. */
+                    ts: number;
+                }[];
+                all: {
+                    total: number;
+                    /** @description Counts keyed by project ID. Use the sibling `projects` array to resolve each project name. */
+                    projects: {
+                        [key: string]: number;
+                    };
+                };
+                projects: {
+                    id: string;
+                    name: string;
+                }[];
+            };
+            builds: {
+                series: {
+                    total: number;
+                    /** @description Counts keyed by project ID. Use the sibling `projects` array to resolve each project name. */
+                    projects: {
+                        [key: string]: number;
+                    };
+                    changesDetected: number;
+                    noChanges: number;
+                    accepted: number;
+                    rejected: number;
+                    /** @description Unix timestamp in milliseconds at the start of the period. */
+                    ts: number;
+                }[];
+                all: {
+                    total: number;
+                    /** @description Counts keyed by project ID. Use the sibling `projects` array to resolve each project name. */
+                    projects: {
+                        [key: string]: number;
+                    };
+                    changesDetected: number;
+                    noChanges: number;
+                    accepted: number;
+                    rejected: number;
+                };
+                projects: {
+                    id: string;
+                    name: string;
+                }[];
+            };
+        };
+        /** @description Error response */
+        Error: {
+            error: string;
+            details?: {
+                message: string;
+            }[];
+        };
         /** @description Build */
         Build: {
             id: components["schemas"]["BuildId"];
@@ -770,13 +851,6 @@ export interface components {
             sha: components["schemas"]["Sha1Hash"];
             /** @description The branch name */
             branch: string;
-        };
-        /** @description Error response */
-        Error: {
-            error: string;
-            details?: {
-                message: string;
-            }[];
         };
         /** @description A user. */
         User: {
@@ -1124,6 +1198,65 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    getAccountAnalytics: {
+        parameters: {
+            query: {
+                /** @description Start of the analytics period, as an ISO 8601 datetime. */
+                from: string;
+                /** @description End of the analytics period, as an ISO 8601 datetime. Defaults to the current time. */
+                to?: string;
+                /** @description Time period used to group each series data point. */
+                groupBy: "day" | "week" | "month";
+                /** @description Optional project name filter. Pass one value or repeat the parameter for multiple projects. */
+                projectNames?: string | string[];
+            };
+            header?: never;
+            path: {
+                /** @description Slug of the account to retrieve analytics for. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Account analytics */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountAnalytics"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     createBuild: {
         parameters: {
             query?: never;

--- a/packages/cli/e2e/analytics.test.ts
+++ b/packages/cli/e2e/analytics.test.ts
@@ -118,7 +118,8 @@ describe("argos analytics", () => {
     expect(output.stdout).toContain("Screenshots:");
   });
 
-  test("accepts a date range, --group-by, and project filter", () => {
+  test("accepts a bounded date range and --group-by", () => {
+    // The API caps the range at 365 days, so use a fixed sub-year window.
     const output = run(
       [
         "analytics",
@@ -127,7 +128,9 @@ describe("argos analytics", () => {
         "--token",
         userAccessToken,
         "--from",
-        "2020-01-01",
+        "2024-01-01",
+        "--to",
+        "2024-06-01",
         "--group-by",
         "week",
         "--json",

--- a/packages/cli/e2e/analytics.test.ts
+++ b/packages/cli/e2e/analytics.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, test } from "vitest";
+
+import { getRequiredEnv, run, type CommandError } from "./utils";
+
+const userAccessToken = getRequiredEnv("USER_ACCESS_TOKEN");
+const projectToken = getRequiredEnv("ARGOS_TOKEN");
+const buildNumber = process.env.ARGOS_BUILD_NUMBER || "27748";
+
+const baseEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  HOME: mkdtempSync(join(tmpdir(), "argos-cli-e2e-")),
+  ARGOS_API_BASE_URL: process.env.ARGOS_API_BASE_URL,
+  ARGOS_TOKEN: "",
+};
+
+function expectRunToFail(
+  args: string[],
+  overrideEnv?: NodeJS.ProcessEnv,
+): CommandError {
+  try {
+    run(args, { ...baseEnv, ...overrideEnv });
+  } catch (error) {
+    return error as CommandError;
+  }
+  throw new Error(
+    `Expected command to fail: node bin/argos-cli.js ${args.join(" ")}`,
+  );
+}
+
+let account: string;
+
+beforeAll(() => {
+  // Derive the account slug from the seeded build's URL, so the analytics
+  // account always matches the account the tokens belong to.
+  const build = JSON.parse(
+    run(["build", "get", buildNumber, "--json"], {
+      ...baseEnv,
+      ARGOS_TOKEN: projectToken,
+    }).stdout,
+  );
+  const match = build.url.match(
+    /app\.argos-ci\.(?:com|dev(?::\d+)?)\/([^/?#]+)\//,
+  );
+  if (!match) {
+    throw new Error(`Could not parse account from build URL: ${build.url}`);
+  }
+  account = match[1];
+});
+
+describe("argos analytics", () => {
+  test("fails when no token is provided", () => {
+    const error = expectRunToFail(["analytics", "--account", account]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("No Argos token found");
+  });
+
+  test("fails when no account is provided", () => {
+    const error = expectRunToFail(["analytics", "--token", userAccessToken]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("An account is required");
+  });
+
+  test("rejects an invalid --group-by value", () => {
+    const error = expectRunToFail([
+      "analytics",
+      "--account",
+      account,
+      "--token",
+      userAccessToken,
+      "--group-by",
+      "year",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("Allowed choices are day, week, month");
+  });
+
+  test("rejects an invalid --from date", () => {
+    const error = expectRunToFail([
+      "analytics",
+      "--account",
+      account,
+      "--token",
+      userAccessToken,
+      "--from",
+      "not-a-date",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain('Invalid --from value: "not-a-date"');
+  });
+
+  test("returns account analytics in JSON mode", () => {
+    const output = run(
+      ["analytics", "--account", account, "--token", userAccessToken, "--json"],
+      baseEnv,
+    );
+    const analytics = JSON.parse(output.stdout);
+
+    expect(typeof analytics.screenshots.all.total).toBe("number");
+    expect(Array.isArray(analytics.screenshots.series)).toBe(true);
+    expect(Array.isArray(analytics.screenshots.projects)).toBe(true);
+
+    expect(typeof analytics.builds.all.total).toBe("number");
+    expect(typeof analytics.builds.all.changesDetected).toBe("number");
+    expect(Array.isArray(analytics.builds.series)).toBe(true);
+    expect(Array.isArray(analytics.builds.projects)).toBe(true);
+  });
+
+  test("prints human-readable analytics", () => {
+    const output = run(
+      ["analytics", "--account", account, "--token", userAccessToken],
+      baseEnv,
+    );
+    expect(output.stdout).toContain(`Analytics for ${account}`);
+    expect(output.stdout).toContain("Builds:");
+    expect(output.stdout).toContain("Screenshots:");
+  });
+
+  test("accepts a date range, --group-by, and project filter", () => {
+    const output = run(
+      [
+        "analytics",
+        "--account",
+        account,
+        "--token",
+        userAccessToken,
+        "--from",
+        "2020-01-01",
+        "--group-by",
+        "week",
+        "--json",
+      ],
+      baseEnv,
+    );
+    const analytics = JSON.parse(output.stdout);
+    expect(typeof analytics.builds.all.total).toBe("number");
+  });
+});

--- a/packages/cli/src/commands/analytics.ts
+++ b/packages/cli/src/commands/analytics.ts
@@ -1,0 +1,110 @@
+import { type Command, Option } from "commander";
+import { createApiClient, unwrap } from "../lib/api";
+import { fail } from "../lib/cli-error";
+import { formatAnalytics } from "../lib/format";
+import { handleCliError, output } from "../lib/run";
+import { resolveToken } from "../lib/target";
+import { jsonOption, tokenOption } from "../options";
+
+type GroupBy = "day" | "week" | "month";
+
+type AnalyticsOptions = {
+  account?: string | undefined;
+  from?: string | undefined;
+  to?: string | undefined;
+  groupBy: GroupBy;
+  project?: string[] | undefined;
+  token?: string | undefined;
+  json?: boolean | undefined;
+};
+
+const DEFAULT_PERIOD_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Coerce a user-supplied date into an ISO 8601 datetime, or fail cleanly. */
+function toIsoOrFail(value: string, option: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    fail(`Invalid --${option} value: "${value}". Use an ISO 8601 datetime.`);
+  }
+  return date.toISOString();
+}
+
+/** Collect a repeatable `--project` flag into an array of project names. */
+function collectProject(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+export function analyticsCommand(program: Command) {
+  program
+    .command("analytics")
+    .description("Fetch build and screenshot analytics for an account")
+    .option(
+      "--account <slug>",
+      "Slug of the account (personal or team) to fetch analytics for",
+    )
+    .option(
+      "--from <datetime>",
+      `Start of the analytics period (ISO 8601). Defaults to ${DEFAULT_PERIOD_DAYS} days ago.`,
+    )
+    .option(
+      "--to <datetime>",
+      "End of the analytics period (ISO 8601). Defaults to now.",
+    )
+    .addOption(
+      new Option(
+        "--group-by <period>",
+        "Time period used to group each series data point",
+      )
+        .choices(["day", "week", "month"])
+        .default("day"),
+    )
+    .option(
+      "--project <name>",
+      "Filter by project name. Repeat the flag to include multiple projects.",
+      collectProject,
+    )
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(async (options: AnalyticsOptions) => {
+      try {
+        const accountSlug = options.account || process.env["ARGOS_ACCOUNT"];
+        if (!accountSlug) {
+          fail(
+            "An account is required. Use --account <slug> or set ARGOS_ACCOUNT.",
+          );
+        }
+        const from = options.from
+          ? toIsoOrFail(options.from, "from")
+          : new Date(Date.now() - DEFAULT_PERIOD_DAYS * DAY_MS).toISOString();
+        const to = options.to ? toIsoOrFail(options.to, "to") : undefined;
+
+        const client = createApiClient(
+          await resolveToken({ token: options.token }),
+        );
+        const analytics = unwrap(
+          await client.GET("/accounts/{accountSlug}/analytics", {
+            params: {
+              path: { accountSlug },
+              query: {
+                from,
+                to,
+                groupBy: options.groupBy,
+                projectNames: options.project,
+              },
+            },
+          }),
+        );
+        output(analytics, options, (data) =>
+          formatAnalytics(data, {
+            account: accountSlug,
+            from,
+            to,
+            groupBy: options.groupBy,
+          }),
+        );
+      } catch (error) {
+        handleCliError(error, "user");
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { logoutCommand } from "./commands/logout";
 import { deployCommand } from "./commands/deploy";
 import { whoamiCommand } from "./commands/whoami";
 import { createProjectCommand } from "./commands/create-project";
+import { analyticsCommand } from "./commands/analytics";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -37,6 +38,7 @@ logoutCommand(program);
 deployCommand(program);
 whoamiCommand(program);
 createProjectCommand(program);
+analyticsCommand(program);
 
 if (!process.argv.slice(2).length) {
   program.outputHelp();

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -7,6 +7,8 @@ type BuildReview = ArgosAPISchema.components["schemas"]["BuildReview"];
 type Comment = ArgosAPISchema.components["schemas"]["Comment"];
 type User = ArgosAPISchema.components["schemas"]["User"];
 type Project = ArgosAPISchema.components["schemas"]["Project"];
+type AccountAnalytics =
+  ArgosAPISchema.components["schemas"]["AccountAnalytics"];
 
 /** Render a scalar, using `-` for empty values. */
 export function formatValue(value: string | number | null | undefined): string {
@@ -147,6 +149,56 @@ export function formatReviews(reviews: BuildReview[]): string {
   ]
     .slice(0, -1)
     .join("\n");
+}
+
+export function formatAnalytics(
+  analytics: AccountAnalytics,
+  context: {
+    account: string;
+    from: string;
+    to?: string | undefined;
+    groupBy: string;
+  },
+): string {
+  const { screenshots, builds } = analytics;
+  const lines = [
+    `Analytics for ${context.account}`,
+    `Period: ${context.from} → ${context.to ?? "now"} (grouped by ${context.groupBy})`,
+    "",
+    `Builds: ${builds.all.total}`,
+    `  Changes detected: ${builds.all.changesDetected}`,
+    `  No changes: ${builds.all.noChanges}`,
+    `  Accepted: ${builds.all.accepted}`,
+    `  Rejected: ${builds.all.rejected}`,
+    `Screenshots: ${screenshots.all.total}`,
+  ];
+
+  // Resolve project IDs (the keys of the `all.projects` count maps) to names.
+  const names = new Map<string, string>();
+  for (const project of [...builds.projects, ...screenshots.projects]) {
+    names.set(project.id, project.name);
+  }
+  const ids = new Set([
+    ...Object.keys(builds.all.projects),
+    ...Object.keys(screenshots.all.projects),
+  ]);
+  if (ids.size > 0) {
+    const rows = [...ids]
+      .map((id) => ({
+        name: names.get(id) ?? id,
+        builds: builds.all.projects[id] ?? 0,
+        screenshots: screenshots.all.projects[id] ?? 0,
+      }))
+      .sort((a, b) => b.builds - a.builds || b.screenshots - a.screenshots);
+    lines.push("", `Projects (${rows.length}):`);
+    for (const row of rows) {
+      lines.push(
+        `  ${row.name}: ${row.builds} builds, ${row.screenshots} screenshots`,
+      );
+    }
+  }
+
+  return lines.join("\n");
 }
 
 function indent(text: string): string {


### PR DESCRIPTION
## What

Adds an `argos analytics` command that fetches build and screenshot metrics for an account, backed by the new `GET /accounts/{accountSlug}/analytics` endpoint from argos-ci/argos#2357.

## Usage

```bash
argos analytics --account my-team --token <personal-access-token>
```

Options:
- `--account <slug>` — account to fetch analytics for (or `ARGOS_ACCOUNT`). Required.
- `--from <datetime>` — start of the period (ISO 8601). Defaults to 30 days ago.
- `--to <datetime>` — end of the period (ISO 8601). Defaults to now.
- `--group-by <period>` — `day` \| `week` \| `month`. Defaults to `day`.
- `--project <name>` — filter by project name; repeat the flag for multiple projects.
- `--token` / `--json` — shared token and machine-readable output options.

Requires a **personal access token** scoped to the account (project tokens won't work).

## Changes

- `packages/cli/src/commands/analytics.ts` — new command (date coercion + validation, repeatable project filter).
- `packages/cli/src/lib/format.ts` — `formatAnalytics` human-readable renderer with a per-project breakdown.
- `packages/cli/src/index.ts` — register the command.
- `packages/api-client/src/schema.ts` — regenerated to include the analytics endpoint.

## Testing

- `pnpm check-types`, `pnpm lint`, `pnpm check-format`, `pnpm test` pass in both `cli` and `api-client`.
- Verified `--help`, missing-account, invalid `--group-by`, and invalid date handling locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)