### PR TITLE
feat(cli): expose test flakiness and change ignore/unignore

### DIFF
--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -373,11 +373,51 @@ export interface paths {
         };
         /**
          * List a build's screenshot diffs
-         * @description List the screenshot diffs of a build, with pagination. Each diff compares a baseline screenshot to the one captured by the build. Use `onlyChanged` to return only the diffs that require review.
+         * @description List the screenshot diffs of a build, with pagination. Each diff compares a baseline screenshot to the one captured by the build. Each diff also carries its test's flakiness metrics and, when it is a change, its ignore state and occurrence count — so you can tell whether a change is worth reviewing or is just a flaky one. Use `needsReview` to return only the diffs that require review.
          */
-        get: operations["getBuildDiffs"];
+        get: operations["listBuildDiffs"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/changes/{changeId}/ignore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ignore a test change
+         * @description Ignore a test change so its diffs no longer require review and are automatically approved on future builds. Use it to silence a change that has been identified as flaky.
+         */
+        post: operations["ignoreChange"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/changes/{changeId}/unignore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unignore a test change
+         * @description Stop ignoring a test change so its diffs require review again on future builds.
+         */
+        post: operations["unignoreChange"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1123,6 +1163,42 @@ export interface components {
                 /** @description Content type of the snapshot file */
                 contentType: string;
             } | null;
+            test: components["schemas"]["Test"] | null;
+            change: components["schemas"]["Change"] | null;
+        };
+        /** @description Test associated to a diff, with flakiness metrics to help decide whether a change is worth reviewing. */
+        Test: {
+            /** @description Unique identifier of the test */
+            id: string;
+            /** @description Name of the test */
+            name: string;
+            /** @description Name of the build the test belongs to */
+            buildName: string;
+            metrics: components["schemas"]["TestMetrics"];
+        };
+        /** @description Flakiness metrics of a test over the requested period. */
+        TestMetrics: {
+            /** @description Number of builds in which this test ran over the metrics period. */
+            total: number;
+            /** @description Number of times the test changed (produced a diff) over the metrics period. */
+            changes: number;
+            /** @description Number of changes that were seen only once over the metrics period. A high ratio of unique changes is a strong flakiness signal. */
+            uniqueChanges: number;
+            /** @description Ratio of builds without a change, between 0 and 1. `1` means the test never changed. */
+            stability: number;
+            /** @description How consistent the changes are, between 0 and 1. `1` means changes repeat the same way; a low value means changes are erratic. */
+            consistency: number;
+            /** @description Overall flakiness score between 0 and 1, derived from stability and consistency. `0` means stable, `1` means highly flaky. */
+            flakiness: number;
+        };
+        /** @description A test change: a specific visual difference (fingerprint) of a test that can be ignored to silence flaky changes. */
+        Change: {
+            /** @description Unique identifier of the change (a test + fingerprint pair). Use it with the ignore/unignore endpoints. */
+            id: string;
+            /** @description Whether this change is currently ignored. Ignored changes no longer require review and are automatically approved. */
+            ignored: boolean;
+            /** @description Number of times this change has been seen over the metrics period. A high count for a recurring change is a strong flakiness signal. */
+            occurrences: number;
         };
         /** @description Build review */
         BuildReview: {
@@ -2493,7 +2569,7 @@ export interface operations {
             };
         };
     };
-    getBuildDiffs: {
+    listBuildDiffs: {
         parameters: {
             query?: {
                 /** @description Number of items per page (max 100) */
@@ -2502,6 +2578,8 @@ export interface operations {
                 page?: string;
                 /** @description Only return diffs that require review. Matches `changed`, `added`, and `removed`, except `removed` is excluded for subset builds. */
                 needsReview?: string;
+                /** @description Period over which the test flakiness metrics are computed. */
+                metricsPeriod?: "LAST_24_HOURS" | "LAST_3_DAYS" | "LAST_7_DAYS" | "LAST_30_DAYS" | "LAST_90_DAYS";
             };
             header?: never;
             path: {
@@ -2537,6 +2615,152 @@ export interface operations {
             };
             /** @description Unauthorized */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    ignoreChange: {
+        parameters: {
+            query?: {
+                /** @description Period over which the test flakiness metrics are computed. */
+                metricsPeriod?: "LAST_24_HOURS" | "LAST_3_DAYS" | "LAST_7_DAYS" | "LAST_30_DAYS" | "LAST_90_DAYS";
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description Identifier of the change to update, as returned in a diff's `change.id`. */
+                changeId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Change ignored — returns the updated change */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Change"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    unignoreChange: {
+        parameters: {
+            query?: {
+                /** @description Period over which the test flakiness metrics are computed. */
+                metricsPeriod?: "LAST_24_HOURS" | "LAST_3_DAYS" | "LAST_7_DAYS" | "LAST_30_DAYS" | "LAST_90_DAYS";
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description Identifier of the change to update, as returned in a diff's `change.id`. */
+                changeId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Change unignored — returns the updated change */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Change"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/cli/e2e/build.test.ts
+++ b/packages/cli/e2e/build.test.ts
@@ -156,4 +156,30 @@ describe("argos build snapshots", () => {
 
     expect(Array.isArray(snapshotsNeedingReview)).toBe(true);
   });
+
+  test("accepts --metrics-period and enriches diffs with flakiness data", () => {
+    const output = run(
+      ["build", "snapshots", buildNumber, "--metrics-period", "30d", "--json"],
+      baseEnv,
+    );
+    const diffs = JSON.parse(output.stdout);
+    expect(Array.isArray(diffs)).toBe(true);
+    // `test` and `change` are always present on a diff (both nullable). `every`
+    // holds trivially for an empty build, so the assertion stays unconditional.
+    expect(
+      diffs.every((diff: object) => "test" in diff && "change" in diff),
+    ).toBe(true);
+  });
+
+  test("rejects an invalid --metrics-period value", () => {
+    const error = expectRunToFail([
+      "build",
+      "snapshots",
+      buildNumber,
+      "--metrics-period",
+      "5y",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("Allowed choices are 24h, 3d, 7d, 30d, 90d");
+  });
 });

--- a/packages/cli/e2e/change.test.ts
+++ b/packages/cli/e2e/change.test.ts
@@ -1,0 +1,191 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, test } from "vitest";
+
+import { getRequiredEnv, run, type CommandError } from "./utils";
+
+const userAccessToken = getRequiredEnv("USER_ACCESS_TOKEN");
+const projectToken = getRequiredEnv("ARGOS_TOKEN");
+const buildNumber = process.env.ARGOS_BUILD_NUMBER || "27748";
+
+const baseEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  HOME: mkdtempSync(join(tmpdir(), "argos-cli-e2e-")),
+  ARGOS_API_BASE_URL: process.env.ARGOS_API_BASE_URL,
+  ARGOS_TOKEN: "",
+  ARGOS_PROJECT: "",
+};
+
+function expectRunToFail(
+  args: string[],
+  overrideEnv?: NodeJS.ProcessEnv,
+): CommandError {
+  try {
+    run(args, { ...baseEnv, ...overrideEnv });
+  } catch (error) {
+    return error as CommandError;
+  }
+  throw new Error(
+    `Expected command to fail: node bin/argos-cli.js ${args.join(" ")}`,
+  );
+}
+
+let projectPath: string;
+// The change id of a diff in the seeded build, when it has one. Used to
+// exercise the ignore/unignore round trip against the real API.
+let changeId: string | null = null;
+
+beforeAll(() => {
+  const build = JSON.parse(
+    run(["build", "get", buildNumber, "--json"], {
+      ...baseEnv,
+      ARGOS_TOKEN: projectToken,
+    }).stdout,
+  );
+  const match = build.url.match(
+    /app\.argos-ci\.(?:com|dev(?::\d+)?)\/([^/?#]+)\/([^/?#]+)\/builds\//,
+  );
+  if (!match) {
+    throw new Error(`Could not parse project from build URL: ${build.url}`);
+  }
+  projectPath = `${match[1]}/${match[2]}`;
+
+  const diffs = JSON.parse(
+    run(["build", "snapshots", buildNumber, "--json"], {
+      ...baseEnv,
+      ARGOS_TOKEN: projectToken,
+    }).stdout,
+  );
+  changeId =
+    diffs.find((diff: { change?: { id: string } | null }) => diff.change)
+      ?.change.id ?? null;
+});
+
+describe("argos change ignore", () => {
+  test("fails when no token is provided", () => {
+    const error = expectRunToFail([
+      "change",
+      "ignore",
+      "PROJECT-abc-xyz",
+      "--project",
+      "acme/web",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("No Argos token found");
+  });
+
+  test("fails when no project is provided", () => {
+    const error = expectRunToFail([
+      "change",
+      "ignore",
+      "PROJECT-abc-xyz",
+      "--token",
+      userAccessToken,
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("--project <owner/project> is required");
+  });
+
+  test("rejects an invalid --metrics-period value", () => {
+    const error = expectRunToFail([
+      "change",
+      "ignore",
+      "PROJECT-abc-xyz",
+      "--token",
+      userAccessToken,
+      "--project",
+      projectPath,
+      "--metrics-period",
+      "5y",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("Allowed choices are 24h, 3d, 7d, 30d, 90d");
+  });
+
+  test("fails for an unknown change", () => {
+    const error = expectRunToFail([
+      "change",
+      "ignore",
+      "not-a-real-change",
+      "--token",
+      userAccessToken,
+      "--project",
+      projectPath,
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toMatch(/not found/i);
+  });
+});
+
+describe("argos change ignore / unignore", () => {
+  test("ignores then unignores a change in JSON mode", () => {
+    if (!changeId) {
+      console.warn(
+        `Build #${buildNumber} has no change to ignore; skipping the round trip.`,
+      );
+      return;
+    }
+
+    const ignored = JSON.parse(
+      run(
+        [
+          "change",
+          "ignore",
+          changeId,
+          "--token",
+          userAccessToken,
+          "--project",
+          projectPath,
+          "--json",
+        ],
+        baseEnv,
+      ).stdout,
+    );
+    expect(ignored.id).toBe(changeId);
+    expect(ignored.ignored).toBe(true);
+    expect(typeof ignored.occurrences).toBe("number");
+
+    const unignored = JSON.parse(
+      run(
+        [
+          "change",
+          "unignore",
+          changeId,
+          "--token",
+          userAccessToken,
+          "--project",
+          projectPath,
+          "--json",
+        ],
+        baseEnv,
+      ).stdout,
+    );
+    expect(unignored.id).toBe(changeId);
+    expect(unignored.ignored).toBe(false);
+  });
+
+  test("prints human-readable change output", () => {
+    if (!changeId) {
+      console.warn(
+        `Build #${buildNumber} has no change to ignore; skipping the round trip.`,
+      );
+      return;
+    }
+
+    const output = run(
+      [
+        "change",
+        "unignore",
+        changeId,
+        "--token",
+        userAccessToken,
+        "--project",
+        projectPath,
+      ],
+      baseEnv,
+    );
+    expect(output.stdout).toContain(`Change ${changeId}`);
+    expect(output.stdout).toContain("Ignored: no");
+  });
+});

--- a/packages/cli/src/commands/build/snapshots.ts
+++ b/packages/cli/src/commands/build/snapshots.ts
@@ -4,7 +4,14 @@ import { unwrap } from "../../lib/api";
 import { formatSnapshots } from "../../lib/format";
 import { handleCliError, output, type BaseCommandOptions } from "../../lib/run";
 import { resolveBuildTarget, type BuildTarget } from "../../lib/target";
-import { jsonOption, tokenOption } from "../../options";
+import {
+  jsonOption,
+  metricsPeriodOption,
+  type MetricsPeriod,
+  type MetricsPeriodOption,
+  toMetricsPeriod,
+  tokenOption,
+} from "../../options";
 import { Option } from "commander";
 
 type Build = ArgosAPISchema.components["schemas"]["Build"];
@@ -28,7 +35,7 @@ async function fetchBuild(target: BuildTarget): Promise<Build> {
 /** Fetch every diff of a build, following pagination. */
 async function fetchAllDiffs(
   target: BuildTarget,
-  options: { needsReview: boolean },
+  options: { needsReview: boolean; metricsPeriod: MetricsPeriod },
 ): Promise<SnapshotDiff[]> {
   const { client, owner, project, buildNumber } = target;
   const results: SnapshotDiff[] = [];
@@ -42,6 +49,7 @@ async function fetchAllDiffs(
             query: {
               page: String(page),
               perPage: String(PER_PAGE),
+              metricsPeriod: options.metricsPeriod,
               ...(options.needsReview ? { needsReview: "true" } : {}),
             },
           },
@@ -67,12 +75,14 @@ export function registerBuildSnapshots(build: Command) {
         "Only include snapshot diffs that require review",
       ),
     )
+    .addOption(metricsPeriodOption)
     .addOption(tokenOption)
     .addOption(jsonOption)
     .action(
       async (
         reference: string,
-        options: BaseCommandOptions & { needsReview?: boolean },
+        options: BaseCommandOptions &
+          MetricsPeriodOption & { needsReview?: boolean },
       ) => {
         try {
           const target = await resolveBuildTarget(reference, options, {
@@ -92,6 +102,7 @@ export function registerBuildSnapshots(build: Command) {
 
           const diffs = await fetchAllDiffs(target, {
             needsReview: Boolean(options.needsReview),
+            metricsPeriod: toMetricsPeriod(options.metricsPeriod),
           });
           output(diffs, options, (data) => formatSnapshots(data, build));
         } catch (error) {

--- a/packages/cli/src/commands/change/_action.ts
+++ b/packages/cli/src/commands/change/_action.ts
@@ -1,0 +1,72 @@
+import type { Command } from "commander";
+import type { ArgosAPISchema, ArgosAPIClient } from "@argos-ci/api-client";
+import { formatChange } from "../../lib/format";
+import { handleCliError, output, type BaseCommandOptions } from "../../lib/run";
+import { resolveProjectTarget } from "../../lib/target";
+import {
+  changeProjectPathOption,
+  jsonOption,
+  metricsPeriodOption,
+  type MetricsPeriod,
+  type MetricsPeriodOption,
+  toMetricsPeriod,
+  tokenOption,
+} from "../../options";
+
+type Change = ArgosAPISchema.components["schemas"]["Change"];
+
+export type ChangeActionContext = {
+  client: ArgosAPIClient;
+  owner: string;
+  project: string;
+  changeId: string;
+  metricsPeriod: MetricsPeriod;
+};
+
+/**
+ * Register a `change <name> <changeId>` command that runs `perform` and prints
+ * the updated change. Both change actions (ignore, unignore) share the same
+ * shape and differ only by the endpoint they hit. They act as a user, so they
+ * need a personal access token, and the project comes from `--project` or
+ * `ARGOS_PROJECT` since a change id does not carry the account slug.
+ */
+export function defineChangeAction(opts: {
+  name: string;
+  description: string;
+  perform: (ctx: ChangeActionContext) => Promise<Change>;
+}) {
+  return (change: Command) => {
+    change
+      .command(opts.name)
+      .description(opts.description)
+      .argument(
+        "<changeId>",
+        "Change ID, taken from a diff's `change.id` (see `argos build snapshots`)",
+      )
+      .addOption(tokenOption)
+      .addOption(changeProjectPathOption)
+      .addOption(metricsPeriodOption)
+      .addOption(jsonOption)
+      .action(
+        async (
+          changeId: string,
+          options: BaseCommandOptions & MetricsPeriodOption,
+        ) => {
+          try {
+            const { client, owner, project } =
+              await resolveProjectTarget(options);
+            const result = await opts.perform({
+              client,
+              owner,
+              project,
+              changeId,
+              metricsPeriod: toMetricsPeriod(options.metricsPeriod),
+            });
+            output(result, options, formatChange);
+          } catch (error) {
+            handleCliError(error, "user");
+          }
+        },
+      );
+  };
+}

--- a/packages/cli/src/commands/change/ignore.ts
+++ b/packages/cli/src/commands/change/ignore.ts
@@ -1,0 +1,20 @@
+import { unwrap } from "../../lib/api";
+import { defineChangeAction } from "./_action";
+
+export const registerChangeIgnore = defineChangeAction({
+  name: "ignore",
+  description:
+    "Ignore a flaky test change so its diffs stop requiring review and are auto-approved on future builds",
+  perform: async ({ client, owner, project, changeId, metricsPeriod }) =>
+    unwrap(
+      await client.POST(
+        "/projects/{owner}/{project}/changes/{changeId}/ignore",
+        {
+          params: {
+            path: { owner, project, changeId },
+            query: { metricsPeriod },
+          },
+        },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/change/index.ts
+++ b/packages/cli/src/commands/change/index.ts
@@ -1,0 +1,11 @@
+import type { Command } from "commander";
+import { registerChangeIgnore } from "./ignore";
+import { registerChangeUnignore } from "./unignore";
+
+export function changeCommand(program: Command) {
+  const change = program
+    .command("change")
+    .description("Ignore or unignore flaky test changes");
+  registerChangeIgnore(change);
+  registerChangeUnignore(change);
+}

--- a/packages/cli/src/commands/change/unignore.ts
+++ b/packages/cli/src/commands/change/unignore.ts
@@ -1,0 +1,20 @@
+import { unwrap } from "../../lib/api";
+import { defineChangeAction } from "./_action";
+
+export const registerChangeUnignore = defineChangeAction({
+  name: "unignore",
+  description:
+    "Stop ignoring a test change so its diffs require review again on future builds",
+  perform: async ({ client, owner, project, changeId, metricsPeriod }) =>
+    unwrap(
+      await client.POST(
+        "/projects/{owner}/{project}/changes/{changeId}/unignore",
+        {
+          params: {
+            path: { owner, project, changeId },
+            query: { metricsPeriod },
+          },
+        },
+      ),
+    ),
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import { deployCommand } from "./commands/deploy";
 import { whoamiCommand } from "./commands/whoami";
 import { createProjectCommand } from "./commands/create-project";
 import { analyticsCommand } from "./commands/analytics";
+import { changeCommand } from "./commands/change";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -39,6 +40,7 @@ deployCommand(program);
 whoamiCommand(program);
 createProjectCommand(program);
 analyticsCommand(program);
+changeCommand(program);
 
 if (!process.argv.slice(2).length) {
   program.outputHelp();

--- a/packages/cli/src/lib/format.test.ts
+++ b/packages/cli/src/lib/format.test.ts
@@ -2,6 +2,7 @@ import type { ArgosAPISchema } from "@argos-ci/api-client";
 import { describe, expect, it } from "vitest";
 import {
   formatBuild,
+  formatChange,
   formatComment,
   formatComments,
   formatProject,
@@ -125,6 +126,79 @@ describe("formatSnapshots", () => {
     expect(output).toContain(
       "Review: https://app.argos-ci.com/o/p/builds/42/diff-1",
     );
+  });
+
+  it("surfaces flakiness metrics and the change id", () => {
+    const diffs = [
+      {
+        id: "diff-1",
+        name: "home / desktop",
+        status: "changed",
+        score: 0.1,
+        group: null,
+        url: null,
+        base: null,
+        head: null,
+        test: {
+          id: "P-abc",
+          name: "home",
+          buildName: "default",
+          metrics: {
+            total: 20,
+            changes: 5,
+            uniqueChanges: 4,
+            stability: 0.75,
+            consistency: 0.2,
+            flakiness: 0.6,
+          },
+        },
+        change: { id: "P-abc-xyz", ignored: true, occurrences: 12 },
+      },
+    ] as unknown as SnapshotDiff[];
+    const output = formatSnapshots(diffs, build);
+    expect(output).toContain(
+      "Flakiness: 0.60 (stability 0.75, consistency 0.20)",
+    );
+    expect(output).toContain("Change: P-abc-xyz [ignored] · 12 occurrences");
+  });
+
+  it("omits flakiness and change lines when absent", () => {
+    const diffs = [
+      {
+        id: "diff-1",
+        name: "home / desktop",
+        status: "unchanged",
+        score: null,
+        group: null,
+        url: null,
+        base: null,
+        head: null,
+        test: null,
+        change: null,
+      },
+    ] as unknown as SnapshotDiff[];
+    const output = formatSnapshots(diffs, build);
+    expect(output).not.toContain("Flakiness:");
+    expect(output).not.toContain("Change:");
+  });
+});
+
+describe("formatChange", () => {
+  it("summarizes an ignored change", () => {
+    const output = formatChange({
+      id: "P-abc-xyz",
+      ignored: true,
+      occurrences: 7,
+    });
+    expect(output).toContain("Change P-abc-xyz");
+    expect(output).toContain("Ignored: yes");
+    expect(output).toContain("Occurrences: 7");
+  });
+
+  it("reports an unignored change", () => {
+    expect(
+      formatChange({ id: "P-abc-xyz", ignored: false, occurrences: 0 }),
+    ).toContain("Ignored: no");
   });
 });
 

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -3,6 +3,8 @@ import type { ArgosAPISchema } from "@argos-ci/api-client";
 type Build = ArgosAPISchema.components["schemas"]["Build"];
 type SnapshotDiff = ArgosAPISchema.components["schemas"]["SnapshotDiff"];
 type SnapshotDiffStatus = SnapshotDiff["status"];
+type TestMetrics = ArgosAPISchema.components["schemas"]["TestMetrics"];
+type Change = ArgosAPISchema.components["schemas"]["Change"];
 type BuildReview = ArgosAPISchema.components["schemas"]["BuildReview"];
 type Comment = ArgosAPISchema.components["schemas"]["Comment"];
 type User = ArgosAPISchema.components["schemas"]["User"];
@@ -94,6 +96,39 @@ export function formatBuild(build: Build): string {
   ].join("\n");
 }
 
+/** Render a 0–1 metric to two decimals, or `-` when absent. */
+function formatRatio(value: number | null | undefined): string {
+  return value === null || value === undefined ? "-" : value.toFixed(2);
+}
+
+/** Compact one-line summary of a test's flakiness metrics. */
+function formatFlakiness(metrics: TestMetrics): string {
+  return `${formatRatio(metrics.flakiness)} (stability ${formatRatio(metrics.stability)}, consistency ${formatRatio(metrics.consistency)})`;
+}
+
+/** Human-readable lines for a single snapshot diff. */
+function formatSnapshotDiff(diff: SnapshotDiff, build: Build): string[] {
+  const lines = [
+    `${diff.name} [${diff.status}]`,
+    `  Review: ${build.url}/${diff.id}`,
+    `  Mask: ${formatValue(diff.url)}`,
+    `  Base file: ${formatValue(diff.base?.url)}`,
+    `  Head file: ${formatValue(diff.head?.url)}`,
+    `  Score: ${formatValue(diff.score)}`,
+    `  Group: ${formatValue(diff.group)}`,
+  ];
+  if (diff.test) {
+    lines.push(`  Flakiness: ${formatFlakiness(diff.test.metrics)}`);
+  }
+  if (diff.change) {
+    const ignored = diff.change.ignored ? " [ignored]" : "";
+    lines.push(
+      `  Change: ${diff.change.id}${ignored} · ${diff.change.occurrences} occurrences`,
+    );
+  }
+  return lines;
+}
+
 export function formatSnapshots(diffs: SnapshotDiff[], build: Build): string {
   if (diffs.length === 0) {
     return "No snapshots found.";
@@ -103,19 +138,18 @@ export function formatSnapshots(diffs: SnapshotDiff[], build: Build): string {
     `Count: ${diffs.length}`,
     `Summary: ${formatSnapshotSummary(diffs)}`,
     "",
-    ...diffs.flatMap((diff) => [
-      `${diff.name} [${diff.status}]`,
-      `  Review: ${build.url}/${diff.id}`,
-      `  Mask: ${formatValue(diff.url)}`,
-      `  Base file: ${formatValue(diff.base?.url)}`,
-      `  Head file: ${formatValue(diff.head?.url)}`,
-      `  Score: ${formatValue(diff.score)}`,
-      `  Group: ${formatValue(diff.group)}`,
-      "",
-    ]),
+    ...diffs.flatMap((diff) => [...formatSnapshotDiff(diff, build), ""]),
   ]
     .slice(0, -1)
     .join("\n");
+}
+
+export function formatChange(change: Change): string {
+  return [
+    `Change ${change.id}`,
+    `Ignored: ${change.ignored ? "yes" : "no"}`,
+    `Occurrences: ${change.occurrences}`,
+  ].join("\n");
 }
 
 export function formatReview(review: BuildReview): string {

--- a/packages/cli/src/lib/target.ts
+++ b/packages/cli/src/lib/target.ts
@@ -33,6 +33,11 @@ export type BuildTarget = ProjectPath & {
   buildNumber: string;
 };
 
+/** A resolved project, ready to drive project-scoped API calls. */
+export type ProjectTarget = ProjectPath & {
+  client: ArgosAPIClient;
+};
+
 /**
  * Resolve the API token, preferring an explicit token (`--token` /
  * `ARGOS_TOKEN`) over the one stored by `argos login`.
@@ -99,4 +104,22 @@ export async function resolveBuildTarget(
     project: project.name,
     buildNumber,
   };
+}
+
+/**
+ * Resolve a project-scoped command target: an authenticated client and the
+ * `owner`/`project` pair every project endpoint needs. The project path comes
+ * from `--project owner/project` or the `ARGOS_PROJECT` environment variable.
+ */
+export async function resolveProjectTarget(
+  options: TargetOptions,
+): Promise<ProjectTarget> {
+  const client = createApiClient(await resolveToken(options));
+  const projectPath = options.project || process.env["ARGOS_PROJECT"];
+  if (!projectPath) {
+    fail(
+      "--project <owner/project> is required. Pass it or set ARGOS_PROJECT.",
+    );
+  }
+  return { client, ...parseProjectPathOrFail(projectPath) };
 }

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -38,3 +38,40 @@ export const projectPathOption = new Option(
   "--project <owner/project>",
   "Project path in owner/project format. Required for build-number references on review and comment commands",
 );
+
+export const changeProjectPathOption = new Option(
+  "--project <owner/project>",
+  "Project the change belongs to, in owner/project format. Also ARGOS_PROJECT",
+);
+
+/** API values accepted by the `metricsPeriod` query parameter. */
+export type MetricsPeriod =
+  | "LAST_24_HOURS"
+  | "LAST_3_DAYS"
+  | "LAST_7_DAYS"
+  | "LAST_30_DAYS"
+  | "LAST_90_DAYS";
+
+const METRICS_PERIOD_BY_CHOICE = {
+  "24h": "LAST_24_HOURS",
+  "3d": "LAST_3_DAYS",
+  "7d": "LAST_7_DAYS",
+  "30d": "LAST_30_DAYS",
+  "90d": "LAST_90_DAYS",
+} as const satisfies Record<string, MetricsPeriod>;
+
+export type MetricsPeriodOption = { metricsPeriod: string };
+export const metricsPeriodOption = new Option(
+  "--metrics-period <period>",
+  "Window over which test flakiness metrics are computed",
+)
+  .choices(Object.keys(METRICS_PERIOD_BY_CHOICE))
+  .default("7d");
+
+/** Map a `--metrics-period` choice to the value the API expects. */
+export function toMetricsPeriod(choice: string): MetricsPeriod {
+  return (
+    METRICS_PERIOD_BY_CHOICE[choice as keyof typeof METRICS_PERIOD_BY_CHOICE] ??
+    "LAST_7_DAYS"
+  );
+}

--- a/skills/argos-cli/SKILL.md
+++ b/skills/argos-cli/SKILL.md
@@ -2,17 +2,18 @@
 name: argos-cli
 description: >
   Operate Argos visual testing from the terminal with the `argos` CLI — inspect
-  builds and snapshot diffs, submit reviews, post comments, upload screenshots,
-  and manage CI builds. Use whenever running `argos` commands or working with
-  Argos builds, snapshots, or visual-regression reviews from a shell, script, or
-  CI pipeline. Load before running `argos` — it covers the token model and JSON
-  output contract that prevent silent failures.
+  builds and snapshot diffs, submit reviews, post comments, ignore flaky test
+  changes, fetch analytics, upload screenshots, and manage CI builds. Use
+  whenever running `argos` commands or working with Argos builds, snapshots,
+  flakiness, or visual-regression reviews from a shell, script, or CI pipeline.
+  Load before running `argos` — it covers the token model and JSON output
+  contract that prevent silent failures.
 license: MIT
 metadata:
   author: argos-ci
   homepage: https://argos-ci.com
   source: https://github.com/argos-ci/argos-javascript
-argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project owner/project` for build-number refs on review/comment commands.
+argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project owner/project` for build-number refs on review/comment commands and for every `change` command.
 ---
 
 # Argos CLI
@@ -31,28 +32,38 @@ command map.
 ## Authentication
 
 A `<buildReference>` is a build number (e.g. `72652`) or a full build URL. With a
-number, add `--project owner/project`; a URL already contains it.
+number, add `--project owner/project`; a URL already contains it. A `<changeId>`
+is not a build ref: it comes from a diff's `change.id` and does **not** carry the
+account, so every `change` command needs `--project owner/project` (or
+`ARGOS_PROJECT`).
 
 Two token types — pick by command:
 
-| Commands                               | Token                       | Resolution order                            |
-| -------------------------------------- | --------------------------- | ------------------------------------------- |
-| `build get`, `build snapshots`         | Project token               | `--token` › `ARGOS_TOKEN`                   |
-| `review *`, `comment *`                | Personal access token (PAT) | `--token` › `ARGOS_TOKEN` › `argos login`   |
-| `upload`, `finalize`, `skip`, `deploy` | CI / project token          | `--token` › `ARGOS_TOKEN` (or tokenless CI) |
+| Commands                                                           | Token                       | Resolution order                            |
+| ------------------------------------------------------------------ | --------------------------- | ------------------------------------------- |
+| `build get`, `build snapshots`                                     | Project token               | `--token` › `ARGOS_TOKEN`                   |
+| `review *`, `comment *`, `change *`, `analytics`, `create-project` | Personal access token (PAT) | `--token` › `ARGOS_TOKEN` › `argos login`   |
+| `upload`, `finalize`, `skip`, `deploy`                             | CI / project token          | `--token` › `ARGOS_TOKEN` (or tokenless CI) |
 
-Project tokens read build data but **cannot** review or comment — those need a
-PAT. If no suitable token is available, ask the user. For review/comment, if no
-PAT exists, report the conclusion and evidence instead of acting. `argos login`
-is for interactive humans, not CI.
+Project tokens read build data but **cannot** review, comment, or ignore
+changes — those need a PAT. If no suitable token is available, ask the user. For
+these actions, if no PAT exists, report the conclusion and evidence instead of
+acting. `argos login` is for interactive humans, not CI.
 
 ## Commands
 
-- **Inspect** — `build get <ref>` · `build snapshots <ref> [--needs-review]`
+- **Inspect** — `build get <ref>` · `build snapshots <ref> [--needs-review] [--metrics-period 24h|3d|7d|30d|90d]`
 - **Review** — `review list <ref>` · `review create <ref> --event <approve|reject|comment> [--body <md>]` · `review dismiss <ref> <reviewId>`
 - **Comment** — `comment list <ref>` · `comment create <ref> --body <md> [--reply-to <id>] [--diff <id>] [--draft]` · `comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <ref> <id>` · `comment react|unreact <ref> <id> <emoji>`
+- **Flakiness** — `change ignore <changeId> --project owner/project` · `change unignore <changeId> --project owner/project`
+- **Account** — `analytics --account <slug>` · `create-project <name> --account <slug>` · `whoami`
 - **CI** — `upload <dir>` · `finalize` · `skip` · `deploy <dir>`
 - **Auth** — `login` · `logout`
+
+`build snapshots --json` enriches each diff with `test.metrics` (flakiness:
+`stability`, `consistency`, `flakiness`, all 0–1) and, on a change, `change`
+(`id`, `ignored`, `occurrences`). High `occurrences` or `flakiness` flags a
+change worth ignoring; pass its `change.id` to `change ignore`.
 
 ## Common flows
 
@@ -62,6 +73,15 @@ Review a build (inspect with a project token, decide with a PAT):
 ARGOS_TOKEN=<project-token> argos build snapshots <ref> --needs-review --json
 argos review create <ref> --token <pat> --event approve --json
 # regression: argos review create <ref> --token <pat> --event reject --body "..."
+```
+
+Silence a flaky change (inspect with a project token, ignore with a PAT).
+Ignored changes stop requiring review and are auto-approved on future builds:
+
+```bash
+ARGOS_TOKEN=<project-token> argos build snapshots <ref> --json   # read each diff's change.id + occurrences
+argos change ignore <changeId> --token <pat> --project owner/project
+# revert: argos change unignore <changeId> --token <pat> --project owner/project
 ```
 
 Upload screenshots in CI:

--- a/skills/argos-pr-review/SKILL.md
+++ b/skills/argos-pr-review/SKILL.md
@@ -40,16 +40,31 @@ and evidence instead of posting — the CLI can't submit the review.
 
 2. **Fetch what changed** — `argos build snapshots <ref> --needs-review --json`.
    For each diff inspect `url` (diff mask), `base.url` (before), `head.url`
-   (after), and `head.metadata`.
+   (after), and `head.metadata`, plus the flakiness signals `test.metrics` and,
+   on a change, `change.occurrences` / `change.ignored` (used in step 3).
 
 3. **Judge each diff** against the inferred intent:
    - **Intentional** — matches the code change and renders cleanly.
    - **Regression** — broken layout/overlap, clipping, wrong state/theme/route,
      missing content, or a removed snapshot with no matching test removal.
-   - **Flaky** — a spinner/skeleton, async content not yet loaded, mid-animation,
-     drifting dynamic values, `head.metadata.test.retry > 0`, or identical
-     `score`/`head.url` across browsers (strong signal both captured the same
-     transient state). `retries` (the configured budget) is not itself a signal.
+   - **Flaky** — weigh two independent signals; when they agree, call it flaky
+     with confidence:
+     - _Test history_ — `test.metrics.flakiness` (0 stable → 1 flaky) and
+       `change.occurrences` (how many times this **exact** diff has recurred over
+       the metrics period). A high flakiness score or a recurring change is strong
+       evidence the diff is environmental noise, not this PR's work; `stability`
+       (builds without a change), `consistency` (do changes repeat identically),
+       and `uniqueChanges` explain _why_ it scores that way. `change.ignored: true`
+       is already known-flaky and auto-approved — never read it as a regression.
+     - _This capture_ — a spinner/skeleton, async content not yet loaded,
+       mid-animation, drifting dynamic values, `head.metadata.test.retry > 0`, or
+       identical `score`/`head.url` across browsers (both captured the same
+       transient state). `retries` (the configured budget) is not itself a signal.
+
+     Conversely, a **stable** test (`flakiness`→0, high `stability`, a first-time
+     change) that changed is more likely intentional or a real regression — don't
+     dismiss it as flaky on the visuals alone. Tune the window with
+     `build snapshots --metrics-period <24h|3d|7d|30d|90d>` (default `7d`).
 
 4. **Comment on specific diffs — the highest-value output of an agent review.**
    A binary approve/reject is cheap; specific, anchored feedback is what makes an
@@ -72,6 +87,11 @@ and evidence instead of posting — the CLI can't submit the review.
    - Request changes: `argos review create <ref> --token <pat> --event reject --body "<summary>"`
    - Neutral note only: `--event comment --body "<summary>"`
    - Add `--project owner/project` for build-number refs (not URLs).
+   - Silence a **confirmed recurring** flake so it stops blocking future builds:
+     `argos change ignore <change.id> --token <pat> --project owner/project`
+     (reverse with `change unignore`). Only ignore flakes the metrics confirm —
+     never to bypass a real diff; prefer a code fix
+     ([references/flaky-fixes.md](references/flaky-fixes.md)) when one exists.
    - Lead with the inferred intent, the snapshots reviewed, and the evidence. In
      the PR, cite the build URL and affected snapshot names; for flakes, name the
      signal and recommend a fix.


### PR DESCRIPTION
Surfaces the new REST API from argos-ci/argos (ARG-462 — test flakiness stats on build diffs + change ignore endpoints) in the CLI, and brings the skills and docs along.

## Changes

**`@argos-ci/cli`**
- New `argos change ignore|unignore <changeId> --project owner/project` — silence a flaky test change (or restore it), the CLI equivalent of the **Ignore** button in a build review. PAT-authenticated; the project comes from `--project` / `ARGOS_PROJECT` since a change id doesn't carry the account.
- `argos build snapshots` now enriches each diff with its test's flakiness metrics (`test.metrics`) and, on a change, its ignore state and occurrence count (`change`). New `--metrics-period <24h|3d|7d|30d|90d>` option (default `7d`) sets the window; the human-readable output shows the flakiness score and the actionable `change.id`.
- Added a `resolveProjectTarget` helper for project-scoped, PAT-authenticated commands, and a shared `--metrics-period` option.

**`@argos-ci/api-client`**
- Regenerated `schema.ts` from the backend's OpenAPI spec: adds the `Test` / `TestMetrics` / `Change` schemas, the `test` / `change` fields on `SnapshotDiff`, the `metricsPeriod` query param on `listBuildDiffs`, and the `ignoreChange` / `unignoreChange` operations.

**Skills**
- `argos-cli`: documents the `change` commands, the flakiness fields on `build snapshots`, and an up-to-date token table.
- `argos-pr-review`: now weighs `test.metrics` and `change.occurrences` (test history) alongside the visual heuristics (this capture) when judging whether a diff is flaky, and can silence a confirmed recurring flake with `change ignore`.

## Testing

- `check-types`, `lint`, `check-format` green on both packages.
- Unit tests: `formatChange` and the enriched `formatSnapshots` (50 pass).
- e2e: `change ignore`/`unignore` (auth, project resolution, unknown-change 404, ignore/unignore round trip) and the new `build snapshots` fields/option. The round-trip test guards cleanly when the seeded build has no change.

## Docs

Documented in argos-ci/docs#229 (`build snapshots` enrichment + `change ignore`/`unignore` sections, cross-linked to the flaky-test-detection guide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)