### PR TITLE
feat(cli): use OAuth 2.1 for argos login (ARG-426)

### DIFF
--- a/packages/cli/e2e/auth.test.ts
+++ b/packages/cli/e2e/auth.test.ts
@@ -135,6 +135,19 @@ describe("auth token storage", () => {
     );
   });
 
+  test("clears config files with a non-string token", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const configPath = getConfigPath();
+    await mkdir(dirname(configPath), { recursive: true });
+    await writeFile(configPath, JSON.stringify({ token: 123 }));
+
+    await expect(getAccessToken()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      "Warning: Config file is invalid and has been cleared. Run `argos login` again.",
+    );
+  });
+
   test("ignores config files without credentials", async () => {
     const configPath = getConfigPath();
     await mkdir(dirname(configPath), { recursive: true });

--- a/packages/cli/e2e/auth.test.ts
+++ b/packages/cli/e2e/auth.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { getStoredToken, removeToken, saveToken } from "../src/auth";
+import {
+  clearStoredCredentials,
+  getAccessToken,
+  getStoredCredentials,
+  saveOAuthTokens,
+} from "../src/auth";
+import type { OAuthTokenSet } from "../src/lib/oauth";
 
 let homeDir: string;
 let originalHome: string | undefined;
@@ -11,6 +17,16 @@ let originalUserProfile: string | undefined;
 
 function getConfigPath() {
   return resolve(homeDir, ".config", "argos-ci", "config.json");
+}
+
+function tokenSet(overrides: Partial<OAuthTokenSet> = {}): OAuthTokenSet {
+  return {
+    accessToken: "argos_oat_access",
+    refreshToken: "argos_ort_refresh",
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    scope: "profile",
+    ...overrides,
+  };
 }
 
 beforeEach(async () => {
@@ -23,6 +39,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 
   if (originalHome === undefined) {
     delete process.env.HOME;
@@ -41,28 +58,68 @@ afterEach(async () => {
 
 describe("auth token storage", () => {
   test("returns undefined when no config file exists", async () => {
-    await expect(getStoredToken()).resolves.toBeUndefined();
+    await expect(getAccessToken()).resolves.toBeUndefined();
   });
 
-  test("saves a token in the user config directory", async () => {
-    await saveToken("argos-token");
+  test("saves and reads an OAuth token set", async () => {
+    const tokens = tokenSet();
+    await saveOAuthTokens(tokens);
 
-    await expect(getStoredToken()).resolves.toBe("argos-token");
-
-    const configPath = getConfigPath();
-    await expect(readFile(configPath, "utf8")).resolves.toBe(
-      JSON.stringify({ token: "argos-token" }, null, 2),
-    );
-  });
-
-  test("overwrites an existing token", async () => {
-    await saveToken("old-token");
-    await saveToken("new-token");
-
-    await expect(getStoredToken()).resolves.toBe("new-token");
+    await expect(getAccessToken()).resolves.toBe("argos_oat_access");
     await expect(readFile(getConfigPath(), "utf8")).resolves.toBe(
-      JSON.stringify({ token: "new-token" }, null, 2),
+      JSON.stringify({ oauth: tokens }, null, 2),
     );
+  });
+
+  test("overwrites an existing token set", async () => {
+    await saveOAuthTokens(tokenSet({ accessToken: "old" }));
+    await saveOAuthTokens(tokenSet({ accessToken: "new" }));
+
+    await expect(getAccessToken()).resolves.toBe("new");
+  });
+
+  test("still honors a legacy personal access token", async () => {
+    const configPath = getConfigPath();
+    await mkdir(dirname(configPath), { recursive: true });
+    await writeFile(configPath, JSON.stringify({ token: "arp_legacy" }));
+
+    await expect(getAccessToken()).resolves.toBe("arp_legacy");
+  });
+
+  test("refreshes an expired access token and persists the rotation", async () => {
+    await saveOAuthTokens(
+      tokenSet({ accessToken: "stale", expiresAt: Date.now() - 1000 }),
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "argos_oat_fresh",
+          refresh_token: "argos_ort_rotated",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "profile",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getAccessToken()).resolves.toBe("argos_oat_fresh");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const credentials = await getStoredCredentials();
+    expect(credentials.oauth?.refreshToken).toBe("argos_ort_rotated");
+  });
+
+  test("warns and returns undefined when refresh fails", async () => {
+    await saveOAuthTokens(tokenSet({ expiresAt: Date.now() - 1000 }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 400 })),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(getAccessToken()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
   });
 
   test("ignores invalid JSON config files", async () => {
@@ -72,23 +129,23 @@ describe("auth token storage", () => {
     await mkdir(dirname(configPath), { recursive: true });
     await writeFile(configPath, "{not-json");
 
-    await expect(getStoredToken()).resolves.toBeUndefined();
+    await expect(getAccessToken()).resolves.toBeUndefined();
     expect(warn).toHaveBeenCalledWith(
       "Warning: Config file is invalid and has been cleared. Run `argos login` again.",
     );
   });
 
-  test("ignores config files without a token", async () => {
+  test("ignores config files without credentials", async () => {
     const configPath = getConfigPath();
     await mkdir(dirname(configPath), { recursive: true });
     await writeFile(configPath, JSON.stringify({ other: "value" }));
 
-    await expect(getStoredToken()).resolves.toBeUndefined();
+    await expect(getAccessToken()).resolves.toBeUndefined();
   });
 
-  test("removes the stored token", async () => {
-    await saveToken("argos-token");
-    await removeToken();
+  test("clears stored credentials", async () => {
+    await saveOAuthTokens(tokenSet());
+    await clearStoredCredentials();
 
     await expect(readFile(getConfigPath(), "utf8")).resolves.toBe(
       JSON.stringify({}, null, 2),

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -1,6 +1,8 @@
-import { readFile, writeFile, mkdir, rename, unlink } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+import { refreshTokenSet, type OAuthTokenSet } from "./lib/oauth";
 
 function getConfigPaths() {
   const configDir = resolve(homedir(), ".config", "argos-ci");
@@ -8,8 +10,34 @@ function getConfigPaths() {
 }
 
 type Config = {
+  /**
+   * Legacy long-lived personal access token from a pre-OAuth `argos login`.
+   * Still honored so existing installs keep working until the next login.
+   */
   token?: string;
+  /** OAuth token set from the current `argos login` flow. */
+  oauth?: OAuthTokenSet;
 };
+
+function parseOAuthTokenSet(value: unknown): OAuthTokenSet | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.accessToken === "string" &&
+    typeof record.refreshToken === "string" &&
+    typeof record.expiresAt === "number"
+  ) {
+    return {
+      accessToken: record.accessToken,
+      refreshToken: record.refreshToken,
+      expiresAt: record.expiresAt,
+      scope: typeof record.scope === "string" ? record.scope : "",
+    };
+  }
+  return undefined;
+}
 
 function parseConfig(raw: string): Config | null {
   let parsed: unknown;
@@ -24,16 +52,15 @@ function parseConfig(raw: string): Config | null {
   }
 
   const record = parsed as Record<string, unknown>;
-
-  if (!("token" in record) || record.token === undefined) {
-    return {};
+  const config: Config = {};
+  if (typeof record.token === "string") {
+    config.token = record.token;
   }
-
-  if (typeof record.token !== "string") {
-    return null;
+  const oauth = parseOAuthTokenSet(record.oauth);
+  if (oauth) {
+    config.oauth = oauth;
   }
-
-  return { token: record.token };
+  return config;
 }
 
 async function clearConfig(): Promise<void> {
@@ -79,16 +106,52 @@ async function writeConfig(config: Config): Promise<void> {
   await rename(tmpPath, configPath);
 }
 
-export async function getStoredToken(): Promise<string | undefined> {
-  const config = await readConfig();
-  return config?.token;
+/** Persist the OAuth token set from a successful login or refresh. */
+export async function saveOAuthTokens(tokens: OAuthTokenSet): Promise<void> {
+  await writeConfig({ oauth: tokens });
 }
 
-export async function saveToken(token: string): Promise<void> {
+/**
+ * Return a valid access token for API calls, or `undefined` when not logged in.
+ * Transparently refreshes (and persists) an expired OAuth access token, and
+ * falls back to a legacy personal access token when present.
+ */
+export async function getAccessToken(): Promise<string | undefined> {
   const config = await readConfig();
-  await writeConfig({ ...(config ?? {}), token });
+  if (!config) {
+    return undefined;
+  }
+  if (config.oauth) {
+    if (Date.now() < config.oauth.expiresAt) {
+      return config.oauth.accessToken;
+    }
+    try {
+      const tokens = await refreshTokenSet(config.oauth.refreshToken);
+      await saveOAuthTokens(tokens);
+      return tokens.accessToken;
+    } catch {
+      console.warn(
+        "Warning: Your Argos session has expired. Run `argos login` again.",
+      );
+      return undefined;
+    }
+  }
+  return config.token;
 }
 
-export async function removeToken(): Promise<void> {
+/** Read the stored credentials without refreshing (used by `logout`). */
+export async function getStoredCredentials(): Promise<{
+  legacyToken?: string;
+  oauth?: OAuthTokenSet;
+}> {
+  const config = await readConfig();
+  return {
+    legacyToken: config?.token,
+    oauth: config?.oauth,
+  };
+}
+
+/** Remove all stored credentials. */
+export async function clearStoredCredentials(): Promise<void> {
   await writeConfig({});
 }

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -130,6 +130,11 @@ export async function getAccessToken(): Promise<string | undefined> {
       await saveOAuthTokens(tokens);
       return tokens.accessToken;
     } catch (err) {
+      // A still-valid legacy personal access token is a usable fallback when
+      // the OAuth refresh cannot complete.
+      if (config.token) {
+        return config.token;
+      }
       if (err instanceof OAuthTokenError) {
         // The server rejected the refresh token — the session is really gone.
         console.warn(

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
-import { refreshTokenSet, type OAuthTokenSet } from "./lib/oauth";
+import { OAuthTokenError, refreshTokenSet, type OAuthTokenSet } from "./lib/oauth";
 
 function getConfigPaths() {
   const configDir = resolve(homedir(), ".config", "argos-ci");
@@ -129,10 +129,19 @@ export async function getAccessToken(): Promise<string | undefined> {
       const tokens = await refreshTokenSet(config.oauth.refreshToken);
       await saveOAuthTokens(tokens);
       return tokens.accessToken;
-    } catch {
-      console.warn(
-        "Warning: Your Argos session has expired. Run `argos login` again.",
-      );
+    } catch (err) {
+      if (err instanceof OAuthTokenError) {
+        // The server rejected the refresh token — the session is really gone.
+        console.warn(
+          "Warning: Your Argos session has expired. Run `argos login` again.",
+        );
+      } else {
+        // Transient failure (offline, DNS, timeout): don't claim the session
+        // expired, and keep the stored tokens so a later retry can succeed.
+        console.warn(
+          "Warning: Could not reach Argos to refresh your session. Check your connection and try again.",
+        );
+      }
       return undefined;
     }
   }

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -2,7 +2,11 @@ import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
-import { OAuthTokenError, refreshTokenSet, type OAuthTokenSet } from "./lib/oauth";
+import {
+  OAuthTokenError,
+  refreshTokenSet,
+  type OAuthTokenSet,
+} from "./lib/oauth";
 
 function getConfigPaths() {
   const configDir = resolve(homedir(), ".config", "argos-ci");

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -52,6 +52,16 @@ function parseConfig(raw: string): Config | null {
   }
 
   const record = parsed as Record<string, unknown>;
+  // A present-but-non-string `token` means a corrupted config; treat it as
+  // invalid so the caller clears the file and prompts a re-login, rather than
+  // silently ignoring it.
+  if (
+    "token" in record &&
+    record.token !== undefined &&
+    typeof record.token !== "string"
+  ) {
+    return null;
+  }
   const config: Config = {};
   if (typeof record.token === "string") {
     config.token = record.token;

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,15 +1,15 @@
-import type { Command } from "commander";
+import { randomBytes } from "node:crypto";
 import { createServer } from "node:http";
-import { createHash, randomBytes } from "node:crypto";
+import type { Command } from "commander";
 import open from "open";
-import { createClient } from "@argos-ci/api-client";
-import { saveToken } from "../auth";
 
-const APP_BASE_URL =
-  process.env["ARGOS_APP_BASE_URL"] ?? "https://app.argos-ci.com/";
-
-const API_BASE_URL =
-  process.env["ARGOS_API_BASE_URL"] ?? "https://api.argos-ci.com/v2/";
+import { saveOAuthTokens } from "../auth";
+import {
+  buildAuthorizeUrl,
+  exchangeAuthorizationCode,
+  generatePkce,
+  getAppBaseUrl,
+} from "../lib/oauth";
 
 const LOGIN_CLI_SUCCESS_ROUTE = `/auth/cli/success`;
 
@@ -31,7 +31,7 @@ function color(text: string, code: number) {
   if (!process.stderr.isTTY || process.env["NO_COLOR"]) {
     return text;
   }
-  return `\u001B[${code}m${text}\u001B[0m`;
+  return `\x1b[${code}m${text}\x1b[0m`;
 }
 
 const successColor = (text: string) => color(text, 32);
@@ -61,7 +61,7 @@ function startCallbackServer(): Promise<{
     };
 
     const server = createServer((req, res) => {
-      const url = new URL(req.url ?? "/", "http://localhost");
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
 
       if (url.pathname !== "/callback") {
         res.writeHead(404, { Connection: "close" });
@@ -101,7 +101,7 @@ function startCallbackServer(): Promise<{
       }
 
       res.writeHead(302, {
-        Location: new URL(LOGIN_CLI_SUCCESS_ROUTE, APP_BASE_URL).href,
+        Location: new URL(LOGIN_CLI_SUCCESS_ROUTE, getAppBaseUrl()).href,
         Connection: "close",
       });
       res.end(() => {
@@ -130,10 +130,7 @@ export function loginCommand(program: Command) {
     .description("Log in to Argos by opening your browser")
     .action(async () => {
       const state = randomBytes(16).toString("hex");
-      const codeVerifier = randomBytes(32).toString("base64url");
-      const codeChallenge = createHash("sha256")
-        .update(codeVerifier)
-        .digest("base64url");
+      const { codeVerifier, codeChallenge } = generatePkce();
 
       let port: number;
       let waitForCallback: () => Promise<CallbackResult>;
@@ -148,16 +145,20 @@ export function loginCommand(program: Command) {
         process.exit(1);
       }
 
-      const loginUrl = new URL("/auth/cli", APP_BASE_URL);
-      loginUrl.searchParams.set("port", port.toString());
-      loginUrl.searchParams.set("state", state);
-      loginUrl.searchParams.set("pkce", codeChallenge);
+      // Loopback redirect (RFC 8252): the registered `argos-cli` redirect URIs
+      // match this host regardless of the ephemeral port.
+      const redirectUri = `http://127.0.0.1:${port}/callback`;
+      const authorizeUrl = buildAuthorizeUrl({
+        redirectUri,
+        state,
+        codeChallenge,
+      });
 
       console.log("\nOpening browser for authentication…");
-      console.log(`If the browser doesn't open, visit:\n  ${loginUrl.href}\n`);
+      console.log(`If the browser doesn't open, visit:\n  ${authorizeUrl}\n`);
 
       if (process.env["ARGOS_CLI_DISABLE_BROWSER"] !== "1") {
-        await open(loginUrl.href).catch((err) => {
+        await open(authorizeUrl).catch((err) => {
           console.warn(
             warningColor(
               `Warning: Failed to open browser — ${err instanceof Error ? err.message : String(err)}`,
@@ -190,25 +191,24 @@ export function loginCommand(program: Command) {
         process.exit(1);
       }
 
-      const client = createClient({ baseUrl: API_BASE_URL });
-
-      const { data, error } = await client.POST("/auth/cli/token", {
-        body: {
+      try {
+        const tokens = await exchangeAuthorizationCode({
           code: result.code,
-          code_verifier: codeVerifier,
-        },
-      });
-
-      if (error || !data?.token) {
+          codeVerifier,
+          redirectUri,
+        });
+        await saveOAuthTokens(tokens);
+      } catch (err) {
         console.error(
           errorColor(
-            "Error: Authentication failed. Please run `argos login` again.",
+            `Error: Authentication failed${
+              err instanceof Error ? ` — ${err.message}` : ""
+            }. Please run \`argos login\` again.`,
           ),
         );
         process.exit(1);
       }
 
-      await saveToken(data.token);
       console.log(successColor("Logged in to Argos successfully."));
     });
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -27,16 +27,18 @@ const CALLBACK_ERROR_HTML = `<!DOCTYPE html><html lang="en">
 
 type CallbackResult = { code: string; state: string };
 
-function color(text: string, code: number) {
-  if (!process.stderr.isTTY || process.env["NO_COLOR"]) {
+function color(text: string, code: number, isTTY: boolean | undefined) {
+  if (!isTTY || process.env["NO_COLOR"]) {
     return text;
   }
   return `\x1b[${code}m${text}\x1b[0m`;
 }
 
-const successColor = (text: string) => color(text, 32);
-const warningColor = (text: string) => color(text, 33);
-const errorColor = (text: string) => color(text, 31);
+// Colors are gated on the stream each message is written to: success/info go to
+// stdout via console.log, warnings/errors to stderr via console.warn/error.
+const successColor = (text: string) => color(text, 32, process.stdout.isTTY);
+const warningColor = (text: string) => color(text, 33, process.stderr.isTTY);
+const errorColor = (text: string) => color(text, 31, process.stderr.isTTY);
 
 function startCallbackServer(): Promise<{
   port: number;

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -1,17 +1,23 @@
 import type { Command } from "commander";
-import { getStoredToken, removeToken } from "../auth";
+
+import { clearStoredCredentials, getStoredCredentials } from "../auth";
+import { revokeToken } from "../lib/oauth";
 
 export function logoutCommand(program: Command) {
   program
     .command("logout")
     .description("Log out from Argos")
     .action(async () => {
-      const existing = await getStoredToken();
-      if (!existing) {
+      const { legacyToken, oauth } = await getStoredCredentials();
+      if (!legacyToken && !oauth) {
         console.log("No token found. You are already logged out.");
         return;
       }
-      await removeToken();
+      if (oauth) {
+        // Best-effort server-side revocation (invalidates the access tokens too).
+        await revokeToken(oauth.refreshToken);
+      }
+      await clearStoredCredentials();
       console.log("Logged out from Argos.");
     });
 }

--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -104,6 +104,12 @@ async function postToken(
       data?.error_description ?? data?.error ?? `HTTP ${response.status}`;
     throw new Error(message);
   }
+  // A response without a refresh token would be persisted as a token set with
+  // `refreshToken: undefined`, which `parseOAuthTokenSet` later rejects — the
+  // whole OAuth block would be silently dropped and the user logged out.
+  if (typeof data.refresh_token !== "string" || data.refresh_token === "") {
+    throw new Error("Token endpoint response is missing a refresh token.");
+  }
   return data;
 }
 

--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -39,6 +39,21 @@ export type OAuthTokenSet = {
   scope: string;
 };
 
+/**
+ * A token endpoint request that reached the server and was rejected by it
+ * (non-2xx / OAuth error), as opposed to a transient network failure. Lets
+ * callers tell "your session is gone, log in again" from "the network is down".
+ */
+export class OAuthTokenError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "OAuthTokenError";
+  }
+}
+
 type TokenEndpointResponse = {
   access_token: string;
   refresh_token: string;
@@ -102,7 +117,7 @@ async function postToken(
   if (!response.ok || !data?.access_token) {
     const message =
       data?.error_description ?? data?.error ?? `HTTP ${response.status}`;
-    throw new Error(message);
+    throw new OAuthTokenError(message, data?.error);
   }
   // A response without a refresh token would be persisted as a token set with
   // `refreshToken: undefined`, which `parseOAuthTokenSet` later rejects — the

--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -110,6 +110,12 @@ async function postToken(
   if (typeof data.refresh_token !== "string" || data.refresh_token === "") {
     throw new Error("Token endpoint response is missing a refresh token.");
   }
+  // A missing/non-numeric `expires_in` would make `expiresAt` NaN, which passes
+  // the `typeof === "number"` check on read but makes `Date.now() < expiresAt`
+  // always false — forcing a token refresh on every single command.
+  if (typeof data.expires_in !== "number" || !Number.isFinite(data.expires_in)) {
+    throw new Error("Token endpoint response is missing a valid expiry.");
+  }
   return data;
 }
 

--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -128,7 +128,10 @@ async function postToken(
   // A missing/non-numeric `expires_in` would make `expiresAt` NaN, which passes
   // the `typeof === "number"` check on read but makes `Date.now() < expiresAt`
   // always false — forcing a token refresh on every single command.
-  if (typeof data.expires_in !== "number" || !Number.isFinite(data.expires_in)) {
+  if (
+    typeof data.expires_in !== "number" ||
+    !Number.isFinite(data.expires_in)
+  ) {
     throw new Error("Token endpoint response is missing a valid expiry.");
   }
   return data;

--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -1,0 +1,151 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * OAuth 2.1 client configuration and helpers for the `argos login` flow
+ * (Authorization Code + PKCE with a loopback redirect, RFC 8252).
+ *
+ * The authorization server is the Argos app origin; endpoints and token
+ * validation are implemented in the main Argos repo (`apps/backend/src/oauth`).
+ */
+
+/** First-party public client id, seeded in the Argos database. */
+export const OAUTH_CLIENT_ID = "argos-cli";
+
+/**
+ * Scopes requested by `argos login`, covering the CLI's user actions (identity,
+ * projects, reviews, comments). Build upload keeps using a project token.
+ */
+export const OAUTH_SCOPES = [
+  "profile",
+  "projects:read",
+  "projects:write",
+  "reviews:write",
+  "comments:read",
+  "comments:write",
+] as const;
+
+/** Refresh a bit early so a token never expires mid-request. */
+const EXPIRY_SKEW_MS = 60 * 1000;
+
+export function getAppBaseUrl(): string {
+  return process.env["ARGOS_APP_BASE_URL"] ?? "https://app.argos-ci.com/";
+}
+
+export type OAuthTokenSet = {
+  accessToken: string;
+  refreshToken: string;
+  /** Epoch milliseconds at which the access token should be considered expired. */
+  expiresAt: number;
+  scope: string;
+};
+
+type TokenEndpointResponse = {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  expires_in: number;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+};
+
+function toTokenSet(data: TokenEndpointResponse): OAuthTokenSet {
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: Date.now() + data.expires_in * 1000 - EXPIRY_SKEW_MS,
+    scope: data.scope ?? "",
+  };
+}
+
+/** Generate a PKCE `code_verifier` and its S256 `code_challenge`. */
+export function generatePkce(): {
+  codeVerifier: string;
+  codeChallenge: string;
+} {
+  const codeVerifier = randomBytes(32).toString("base64url");
+  const codeChallenge = createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url");
+  return { codeVerifier, codeChallenge };
+}
+
+/** Build the `/oauth/authorize` URL to open in the browser. */
+export function buildAuthorizeUrl(params: {
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+}): string {
+  const url = new URL("/oauth/authorize", getAppBaseUrl());
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", OAUTH_CLIENT_ID);
+  url.searchParams.set("redirect_uri", params.redirectUri);
+  url.searchParams.set("scope", OAUTH_SCOPES.join(" "));
+  url.searchParams.set("state", params.state);
+  url.searchParams.set("code_challenge", params.codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  return url.href;
+}
+
+async function postToken(
+  body: Record<string, string>,
+): Promise<TokenEndpointResponse> {
+  const url = new URL("/oauth/token", getAppBaseUrl());
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+  const data = (await response
+    .json()
+    .catch(() => null)) as TokenEndpointResponse | null;
+  if (!response.ok || !data?.access_token) {
+    const message =
+      data?.error_description ?? data?.error ?? `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return data;
+}
+
+/** Exchange an authorization code for a token set (`grant_type=authorization_code`). */
+export async function exchangeAuthorizationCode(params: {
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+}): Promise<OAuthTokenSet> {
+  return toTokenSet(
+    await postToken({
+      grant_type: "authorization_code",
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      client_id: OAUTH_CLIENT_ID,
+      code_verifier: params.codeVerifier,
+    }),
+  );
+}
+
+/** Rotate a refresh token for a new token set (`grant_type=refresh_token`). */
+export async function refreshTokenSet(
+  refreshToken: string,
+): Promise<OAuthTokenSet> {
+  return toTokenSet(
+    await postToken({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: OAUTH_CLIENT_ID,
+    }),
+  );
+}
+
+/** Best-effort token revocation (RFC 7009); never throws. */
+export async function revokeToken(token: string): Promise<void> {
+  const url = new URL("/oauth/revoke", getAppBaseUrl());
+  await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      token,
+      client_id: OAUTH_CLIENT_ID,
+    }).toString(),
+  }).catch(() => {});
+}

--- a/packages/cli/src/lib/target.ts
+++ b/packages/cli/src/lib/target.ts
@@ -1,5 +1,5 @@
 import type { ArgosAPIClient } from "@argos-ci/api-client";
-import { getStoredToken } from "../auth";
+import { getAccessToken } from "../auth";
 import { createApiClient, unwrap } from "./api";
 import {
   parseBuildReferenceOrFail,
@@ -44,7 +44,7 @@ export type ProjectTarget = ProjectPath & {
  */
 export async function resolveToken(options: TargetOptions): Promise<string> {
   const token =
-    options.token || process.env["ARGOS_TOKEN"] || (await getStoredToken());
+    options.token || process.env["ARGOS_TOKEN"] || (await getAccessToken());
   if (!token) {
     fail(
       "No Argos token found. Use --token, set ARGOS_TOKEN, or run `argos login`.",


### PR DESCRIPTION
## Summary

Replaces the bespoke personal-access-token login with a standards-based **OAuth 2.1 Authorization Code + PKCE loopback flow** (RFC 8252) against the Argos OAuth server (companion PR on **argos-ci/argos**).

- `argos login` opens `/oauth/authorize`, receives the code on a loopback callback, and exchanges it at `/oauth/token` (`src/commands/login.ts`, `src/lib/oauth.ts`).
- Stores an access + refresh token set and refreshes transparently before expiry (`src/auth.ts`); `resolveToken` uses it for every command.
- `argos logout` revokes the refresh token server-side.
- Legacy personal access tokens (and `--token` / `ARGOS_TOKEN`) keep working.

## Testing

- `tsc`, `eslint`, the `tsdown` build, and the CLI test suite (including refresh-rotation) pass.

Requires the Argos OAuth server — see the companion PR on **argos-ci/argos**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
