### PR TITLE
fix: don't fail the upload when the branch is not on origin

### DIFF
--- a/packages/core/src/ci-environment/git.test.ts
+++ b/packages/core/src/ci-environment/git.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   branch,
   getMergeBaseCommitSha,
@@ -77,6 +77,88 @@ describe("#getMergeBaseCommitSha (command injection)", () => {
     }
 
     expect(existsSync(markerFile)).toBe(false);
+  });
+});
+
+describe("#getMergeBaseCommitSha (refs missing on origin)", () => {
+  let cwd: string;
+  let root: string;
+  let repoDir: string;
+  /** SHA of the tip of `main`, pushed to origin — the expected merge base. */
+  let mainSha: string;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    root = mkdtempSync(join(tmpdir(), "argos-git-missing-ref-test-"));
+    repoDir = join(root, "repo");
+
+    const bareDir = join(root, "origin.git");
+    execFileSync("git", ["init", "--bare", bareDir]);
+    execFileSync("git", ["init", repoDir]);
+    const git = (...args: string[]) =>
+      execFileSync("git", ["-C", repoDir, ...args]);
+    git("remote", "add", "origin", bareDir);
+    git("config", "user.email", "test@argos-ci.com");
+    git("config", "user.name", "Argos Test");
+
+    // `main` has two commits and is pushed to origin.
+    git("commit", "--allow-empty", "-m", "commit 0");
+    git("commit", "--allow-empty", "-m", "commit 1");
+    git("branch", "-M", "main");
+    git("push", "origin", "main");
+    mainSha = git("rev-parse", "HEAD").toString().trim();
+
+    // `feature` branches off `main` with one commit, and is NOT pushed —
+    // the state of a first local run on a feature branch.
+    git("checkout", "-b", "feature");
+    git("commit", "--allow-empty", "-m", "feature commit");
+
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.chdir(repoDir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    warn.mockRestore();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("falls back to the local ref when the head branch is not on origin", async () => {
+    const sha = await getMergeBaseCommitSha({ base: "main", head: "feature" });
+    expect(sha).toBe(mainSha);
+    // A branch not pushed yet is expected: no warning.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the head ref exists neither on origin nor locally", async () => {
+    const sha = await getMergeBaseCommitSha({ base: "main", head: "ghost" });
+    expect(sha).toBe(null);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the base ref exists neither on origin nor locally", async () => {
+    const sha = await getMergeBaseCommitSha({ base: "ghost", head: "main" });
+    expect(sha).toBe(null);
+  });
+
+  it("falls back to the local history and warns when origin is unreachable", async () => {
+    execFileSync("git", [
+      "-C",
+      repoDir,
+      "remote",
+      "set-url",
+      "origin",
+      join(root, "nonexistent.git"),
+    ]);
+    const sha = await getMergeBaseCommitSha({ base: "main", head: "feature" });
+    expect(sha).toBe(mainSha);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to fetch "feature"'),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to fetch "main"'),
+    );
   });
 });
 

--- a/packages/core/src/ci-environment/git.ts
+++ b/packages/core/src/ci-environment/git.ts
@@ -162,38 +162,139 @@ function checkIsExecError(
 }
 
 /**
+ * Check whether a git fetch error means the requested ref does not exist on
+ * the remote, e.g. a branch that has not been pushed to origin yet.
+ */
+function checkIsMissingRemoteRefError(error: unknown): boolean {
+  return getGitErrorOutput(error)
+    .toLowerCase()
+    .includes("couldn't find remote ref");
+}
+
+/**
+ * Check that a ref exists in the local repository and points to a commit.
+ */
+function checkLocalRefExists(ref: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ref usable in the merge-base computation.
+ */
+type MergeBaseRef = {
+  /**
+   * Ref to pass to `git merge-base`, or `null` when the ref is unavailable
+   * both on origin and locally.
+   */
+  ref: string | null;
+  /** Whether fetching again with a greater depth can deepen the history. */
+  fetchable: boolean;
+};
+
+/**
+ * Fetch a ref from origin to make it available for the merge-base computation.
+ *
+ * When the fetch fails, fall back to the history available locally instead of
+ * failing the whole upload — the merge base is only used to find the baseline
+ * and a build without baseline is better than no build at all:
+ * - When the ref is missing on origin (e.g. a branch not pushed yet, common on
+ *   a first local run), prefer the local ref, which is the exact state being
+ *   built. Expected, so only logged in debug mode.
+ * - For other failures (network, authentication…), prefer the target of a
+ *   previous fetch (the freshest known remote state) and surface a warning.
+ */
+async function fetchMergeBaseRef(input: {
+  ref: string;
+  depth: number;
+  target: string;
+}): Promise<MergeBaseRef> {
+  try {
+    await gitFetch(input);
+    return { ref: input.target, fetchable: true };
+  } catch (error) {
+    const isMissingRemoteRef = checkIsMissingRemoteRefError(error);
+    if (isMissingRemoteRef) {
+      debug(
+        `Ref "${input.ref}" not found on origin, falling back to local history`,
+        getGitErrorOutput(error),
+      );
+    } else {
+      console.warn(
+        `Argos failed to fetch "${input.ref}" from origin, falling back to the local history to find the merge base.`,
+      );
+      debug(`git fetch failed for "${input.ref}"`, getGitErrorOutput(error));
+    }
+    const candidates = isMissingRemoteRef
+      ? [input.ref, input.target]
+      : [input.target, input.ref];
+    const ref = candidates.find((ref) => checkLocalRefExists(ref)) ?? null;
+    return { ref, fetchable: false };
+  }
+}
+
+/**
  * Get the merge base commit SHA.
  * Fetch both base and head with depth and then run merge base.
  * Try to find a merge base with a depth of 1000 max.
+ *
+ * Never fails when a ref can't be fetched from origin: falls back to the local
+ * history and returns `null` when no merge base can be found, which resolves
+ * to a build without baseline (see `resolveBaseline`).
  */
 export async function getMergeBaseCommitSha(input: {
   base: string;
   head: string;
 }): Promise<string | null> {
-  let depth = 200;
-
   const argosBaseRef = `argos/${input.base}`;
   const argosHeadRef = `argos/${input.head}`;
 
-  while (depth < 1000) {
-    await gitFetch({ ref: input.head, depth, target: argosHeadRef });
-    await gitFetch({ ref: input.base, depth, target: argosBaseRef });
-    const mergeBase = gitMergeBase({
-      base: argosBaseRef,
-      head: argosHeadRef,
-    });
+  let head: MergeBaseRef | null = null;
+  let base: MergeBaseRef | null = null;
+
+  for (let depth = 200; depth < 1000; depth += 200) {
+    if (!head || head.fetchable) {
+      head = await fetchMergeBaseRef({
+        ref: input.head,
+        depth,
+        target: argosHeadRef,
+      });
+    }
+    if (!base || base.fetchable) {
+      base = await fetchMergeBaseRef({
+        ref: input.base,
+        depth,
+        target: argosBaseRef,
+      });
+    }
+
+    // A ref unavailable both on origin and locally: no merge base can be found.
+    if (!head.ref || !base.ref) {
+      debug(
+        `No usable ref for "${!head.ref ? input.head : input.base}", no merge base`,
+      );
+      return null;
+    }
+
+    const mergeBase = gitMergeBase({ base: base.ref, head: head.ref });
     if (mergeBase) {
       return mergeBase;
     }
-    depth += 200;
+
+    // No ref can be deepened: fetching again would not bring more history.
+    if (!head.fetchable && !base.fetchable) {
+      break;
+    }
   }
 
-  if (isDebugEnabled) {
-    const headShas = listShas(argosHeadRef);
-    const baseShas = listShas(argosBaseRef);
-    debug(
-      `No merge base found for ${input.head} and ${input.base} with depth ${depth}`,
-    );
+  if (isDebugEnabled && head?.ref && base?.ref) {
+    const headShas = listShas(head.ref);
+    const baseShas = listShas(base.ref);
+    debug(`No merge base found for ${input.head} and ${input.base}`);
     debug(
       `Found ${headShas.length} commits in ${input.head}: ${headShas.join(", ")}`,
     );

--- a/packages/core/src/ci-environment/git.ts
+++ b/packages/core/src/ci-environment/git.ts
@@ -176,7 +176,12 @@ function checkIsMissingRemoteRefError(error: unknown): boolean {
  */
 function checkLocalRefExists(ref: string): boolean {
   try {
-    execFileSync("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]);
+    execFileSync("git", [
+      "rev-parse",
+      "--verify",
+      "--quiet",
+      `${ref}^{commit}`,
+    ]);
     return true;
   } catch {
     return false;

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -9,7 +9,13 @@ import type {
  * Configuration for the Argos Vitest reporter.
  * @see https://js-sdk-reference.argos-ci.com/interfaces/UploadParameters.html
  */
-export type ArgosReporterConfig = UploadParameters;
+export interface ArgosReporterConfig extends UploadParameters {
+  /**
+   * If true, the reporter will not fail the test run when the upload fails.
+   * @default false
+   */
+  ignoreUploadFailures?: boolean;
+}
 
 /**
  * Options passed when calling `argosScreenshot` from a browser test.

--- a/packages/vitest/src/reporter.test.ts
+++ b/packages/vitest/src/reporter.test.ts
@@ -34,6 +34,9 @@ function argosConfig(
 
 describe("ArgosReporter", () => {
   let log: ReturnType<typeof vi.spyOn>;
+  let error: ReturnType<typeof vi.spyOn>;
+  let warn: ReturnType<typeof vi.spyOn>;
+  let savedExitCode: typeof process.exitCode;
 
   beforeEach(() => {
     upload.mockReset();
@@ -43,9 +46,14 @@ describe("ArgosReporter", () => {
     readConfig.mockReset();
     readConfig.mockResolvedValue(argosConfig());
     log = vi.spyOn(console, "log").mockImplementation(() => {});
+    error = vi.spyOn(console, "error").mockImplementation(() => {});
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
   });
 
   afterEach(() => {
+    process.exitCode = savedExitCode;
     vi.restoreAllMocks();
   });
 
@@ -78,11 +86,52 @@ describe("ArgosReporter", () => {
     });
   });
 
-  it("propagates upload failures", async () => {
+  it("reports upload failures and fails the run without throwing", async () => {
+    // A rejection from the reporter hook would surface in Vitest as an
+    // "Unhandled Error" without failing the run: the reporter must catch it
+    // and fail the run through the process exit code instead.
     upload.mockRejectedValue(new Error("upload failed"));
     const reporter = new ArgosReporter({ buildName: "test" });
     reporter.onInit(createVitest({}));
-    await expect(reporter.onTestRunEnd()).rejects.toThrow("upload failed");
+    await expect(reporter.onTestRunEnd()).resolves.toBeUndefined();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("Error while creating the Argos build"),
+    );
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "upload failed" }),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does not fail the run on upload failure with `ignoreUploadFailures`", async () => {
+    upload.mockRejectedValue(new Error("upload failed"));
+    const reporter = new ArgosReporter({
+      buildName: "test",
+      ignoreUploadFailures: true,
+    });
+    reporter.onInit(createVitest({}));
+    await expect(reporter.onTestRunEnd()).resolves.toBeUndefined();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("Error while creating the Argos build"),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("ignoreUploadFailures"),
+    );
+    expect(process.exitCode).toBe(undefined);
+  });
+
+  it("does not pass `ignoreUploadFailures` to upload", async () => {
+    const reporter = new ArgosReporter({
+      buildName: "test",
+      ignoreUploadFailures: true,
+    });
+    reporter.onInit(createVitest({}));
+    await reporter.onTestRunEnd();
+    expect(upload).toHaveBeenCalledWith({
+      files: ["**/*.png", "**/*.aria.yml", "**/*.snapshot.*"],
+      ignore: ["**/*.argos.json"],
+      buildName: "test",
+    });
   });
 
   it("does not upload in watch mode", async () => {
@@ -122,14 +171,18 @@ describe("ArgosReporter", () => {
     );
   });
 
-  it("throws when sharding without ARGOS_PARALLEL_NONCE", async () => {
+  it("fails the run when sharding without ARGOS_PARALLEL_NONCE", async () => {
     readConfig.mockResolvedValue(argosConfig({ parallelNonce: null }));
     const reporter = new ArgosReporter({ buildName: "test" });
     reporter.onInit(createVitest({ shard: { index: 1, count: 4 } }));
-    await expect(reporter.onTestRunEnd()).rejects.toThrow(
-      "ARGOS_PARALLEL_NONCE",
-    );
+    await expect(reporter.onTestRunEnd()).resolves.toBeUndefined();
     expect(upload).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("ARGOS_PARALLEL_NONCE"),
+      }),
+    );
+    expect(process.exitCode).toBe(1);
   });
 
   it("lets ARGOS_PARALLEL_TOTAL/INDEX override the shard values", async () => {

--- a/packages/vitest/src/reporter.ts
+++ b/packages/vitest/src/reporter.ts
@@ -60,24 +60,40 @@ export class ArgosReporter implements Reporter {
     if (this.vitest.config.watch) {
       return;
     }
-    // Auto-detect `vitest --shard=<index>/<count>` and map it to Argos parallel
-    // options, so users only need `ARGOS_PARALLEL_NONCE`.
-    const parallel = await getParallelFromConfig(this.vitest.config);
-    const res = await upload({
-      // Default to uploading screenshots, ARIA snapshots and `argosSnapshot`
-      // files. Without this, `upload` only matches images
-      // (`**/*.{png,jpg,jpeg}`), so the `.aria.yml` files produced by
-      // `ariaSnapshot: true` and the `.snapshot.*` files produced by
-      // `argosSnapshot` would be skipped.
-      files: ["**/*.png", "**/*.aria.yml", "**/*.snapshot.*"],
-      // The `.snapshot.*` glob would otherwise also match the `.argos.json`
-      // metadata sidecars written next to each snapshot.
-      ignore: ["**/*.argos.json"],
-      // Auto-detected from the shard config; an explicit `parallel` in the
-      // reporter config still wins (spread below).
-      parallel: parallel ?? undefined,
-      ...this.config,
-    });
-    console.log(`✅ Argos build created: ${res.build.url}`);
+    const { ignoreUploadFailures, ...uploadParameters } = this.config;
+    try {
+      // Auto-detect `vitest --shard=<index>/<count>` and map it to Argos parallel
+      // options, so users only need `ARGOS_PARALLEL_NONCE`.
+      const parallel = await getParallelFromConfig(this.vitest.config);
+      const res = await upload({
+        // Default to uploading screenshots, ARIA snapshots and `argosSnapshot`
+        // files. Without this, `upload` only matches images
+        // (`**/*.{png,jpg,jpeg}`), so the `.aria.yml` files produced by
+        // `ariaSnapshot: true` and the `.snapshot.*` files produced by
+        // `argosSnapshot` would be skipped.
+        files: ["**/*.png", "**/*.aria.yml", "**/*.snapshot.*"],
+        // The `.snapshot.*` glob would otherwise also match the `.argos.json`
+        // metadata sidecars written next to each snapshot.
+        ignore: ["**/*.argos.json"],
+        // Auto-detected from the shard config; an explicit `parallel` in the
+        // reporter config still wins (spread below).
+        parallel: parallel ?? undefined,
+        ...uploadParameters,
+      });
+      console.log(`✅ Argos build created: ${res.build.url}`);
+    } catch (error) {
+      // Vitest decides the exit code before reporters run `onTestRunEnd`, so
+      // an error thrown here would surface as an "Unhandled Error" without
+      // failing the run (exit code 0). Report it and fail the run explicitly.
+      console.error(`❌ Error while creating the Argos build`);
+      console.error(error);
+      if (ignoreUploadFailures) {
+        console.warn(
+          "⚠️ Upload failure ignored due to the `ignoreUploadFailures` option",
+        );
+      } else {
+        process.exitCode = 1;
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes [ARG-472](https://linear.app/argos/issue/ARG-472/first-local-run-fails-on-a-feature-branch): running the upload locally from a branch that isn't pushed yet killed the run with `fatal: couldn't find remote ref <branch>` — and the process still exited 0, so users saw green tests and no build.

## core: merge-base resolution never fails the upload

`getMergeBaseCommitSha` was the only link in the baseline resolution chain that could throw: it fetched the head/base refs without catching failures. Fetch failures now fall back to the local history:

- **Ref missing on origin** (branch not pushed yet — the first-local-run case): use the local ref, which is the exact state being built. Expected case, debug log only. In the common scenario (base branch on origin, feature branch local), the merge base is still resolved correctly, so the build even gets a proper baseline instead of the no-baseline fallback.
- **Other failures** (network, auth…): keep the freshest previously-fetched state when available, otherwise the local ref, and print a warning so misconfigurations stay visible.
- **Ref unavailable both on origin and locally**: resolve to `null` → build without baseline, as `resolveBaseline` and `listAncestorCommits` already handle.

## vitest: upload failures fail the run instead of exiting 0

Vitest decides the exit code before reporters run `onTestRunEnd`, so a throwing reporter surfaced as an "Unhandled Error" while the process exited 0. The reporter now catches upload errors, reports them and sets `process.exitCode = 1`. A new `ignoreUploadFailures` option (mirroring the Playwright reporter) opts out of failing the run.

## Test plan

- [x] New unit tests: unpushed head branch resolves the merge base from the local ref, ghost refs resolve to `null` without throwing, unreachable origin falls back to local history with a warning
- [x] New unit tests: reporter failure path sets exit code 1, `ignoreUploadFailures` keeps it unset and is not forwarded to `upload()`
- [x] Reproduced the ARG-472 scenario end to end (bare origin, unpushed `poc-argos` branch): merge base resolved, no crash
- [x] `check-types`, `lint`, full unit suites of `core` (116) and `vitest` (45) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)