### PR TITLE
feat(playwright): warn when recommended Chromium launch options are missing

### DIFF
--- a/examples/storybook-test-runner/README.md
+++ b/examples/storybook-test-runner/README.md
@@ -24,6 +24,6 @@ Read [Argos documentations](https://argos-ci.com/docs) or explore [Storybook Tes
 ## Links
 
 - [Quickstart with Argos + Storybook Test Runner](https://argos-ci.com/docs/quickstart/storybook-quickstart/storybook-test-runner-quickstart)
-- [Storybook SDK Reference](https://argos-ci.com/docs/sdks-reference/storybook)
+- [Storybook SDK Reference](https://argos-ci.com/docs/reference/storybook)
 - [Official Argos Docs](https://argos-ci.com/docs)
 - [Discord](https://argos-ci.com/discord)

--- a/examples/storybook-vitest/README.md
+++ b/examples/storybook-vitest/README.md
@@ -24,6 +24,6 @@ Read [Argos documentations](https://argos-ci.com/docs) or explore [Storybook Tes
 ## Links
 
 - [Quickstart with Argos + Storybook + Vitest](https://argos-ci.com/docs/quickstart/storybook-quickstart)
-- [Storybook SDK Reference](https://argos-ci.com/docs/sdks-reference/storybook)
+- [Storybook SDK Reference](https://argos-ci.com/docs/reference/storybook)
 - [Official Argos Docs](https://argos-ci.com/docs)
 - [Discord](https://argos-ci.com/discord)

--- a/examples/storybook-vitest/vite.config.js
+++ b/examples/storybook-vitest/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
         })
       
         // The plugin will capture screenshots of your stories and upload them to Argos.
-        // See options at: https://argos-ci.com/docs/sdks-reference/storybook
+        // See options at: https://argos-ci.com/docs/reference/storybook
         argosVitestPlugin({
           // Upload to Argos on CI only.
           uploadToArgos: !!process.env.CI,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ Interact with and upload screenshots to [argos-ci.com](https://argos-ci.com) fro
 [![npm dm](https://img.shields.io/npm/dm/@argos-ci/cli.svg)](https://www.npmjs.com/package/@argos-ci/cli)
 [![npm dt](https://img.shields.io/npm/dt/@argos-ci/cli.svg)](https://www.npmjs.com/package/@argos-ci/cli)
 
-Visit the [Argos CLI documentation](https://argos-ci.com/docs/sdks-reference/argos-command-line-interface-cli) for the full command reference and more.
+Visit the [Argos CLI documentation](https://argos-ci.com/docs/reference/argos-command-line-interface-cli) for the full command reference and more.
 
 ## Installation
 
@@ -41,5 +41,5 @@ npx @argos-ci/cli --help
 
 ## Links
 
-- [Official CLI Docs](https://argos-ci.com/docs/sdks-reference/argos-command-line-interface-cli)
+- [Official CLI Docs](https://argos-ci.com/docs/reference/argos-command-line-interface-cli)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/core"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/argos-command-line-interface-cli",
+  "homepage": "https://argos-ci.com/docs/reference/argos-command-line-interface-cli",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -17,7 +17,7 @@ Node.js SDK for visual testing with Argos. It powers the Argos CLI and the highe
 [![npm dm](https://img.shields.io/npm/dm/@argos-ci/core.svg)](https://www.npmjs.com/package/@argos-ci/core)
 [![npm dt](https://img.shields.io/npm/dt/@argos-ci/core.svg)](https://www.npmjs.com/package/@argos-ci/core)
 
-Visit the [Node.js SDK documentation](https://argos-ci.com/docs/sdks-reference/node.js-sdk) for guides, the API reference, and more.
+Visit the [Node.js SDK documentation](https://argos-ci.com/docs/reference/node.js-sdk) for guides, the API reference, and more.
 
 ## Installation
 
@@ -46,6 +46,6 @@ console.log(`Build created: ${build.url}`);
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/node.js-sdk)
+- [Official SDK Docs](https://argos-ci.com/docs/reference/node.js-sdk)
 - [API Reference](https://js-sdk-reference.argos-ci.com)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/core"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/node.js-sdk",
+  "homepage": "https://argos-ci.com/docs/reference/node.js-sdk",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -17,7 +17,7 @@
 
 Capture stable Argos screenshots from your [Cypress](https://www.cypress.io/) tests.
 
-Visit the [Cypress SDK documentation](https://argos-ci.com/docs/sdks-reference/cypress) for guides, the API reference, and more.
+Visit the [Cypress SDK documentation](https://argos-ci.com/docs/reference/cypress) for guides, the API reference, and more.
 
 ## Installation
 
@@ -69,6 +69,6 @@ describe("Homepage", () => {
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/cypress)
+- [Official SDK Docs](https://argos-ci.com/docs/reference/cypress)
 - [Quickstart](https://argos-ci.com/docs/quickstart/cypress-quickstart)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/cypress"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/cypress",
+  "homepage": "https://argos-ci.com/docs/reference/cypress",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -57,7 +57,7 @@ declare global {
       /**
        * Stabilize the UI and takes a screenshot of the application under test.
        *
-       * @see https://argos-ci.com/docs/sdks-reference/cypress
+       * @see https://argos-ci.com/docs/reference/cypress
        * @example
        *    cy.argosScreenshot("my-screenshot")
        *    cy.get(".post").argosScreenshot()

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -17,7 +17,7 @@
 
 Capture stable Argos screenshots from your [Playwright](https://playwright.dev/) tests, and report failure screenshots and traces to Argos.
 
-Visit the [Playwright SDK documentation](https://argos-ci.com/docs/sdks-reference/playwright) for guides, the API reference, and more.
+Visit the [Playwright SDK documentation](https://argos-ci.com/docs/reference/playwright) for guides, the API reference, and more.
 
 ## Installation
 
@@ -65,6 +65,6 @@ test("screenshot homepage", async ({ page }) => {
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/playwright)
+- [Official SDK Docs](https://argos-ci.com/docs/reference/playwright)
 - [Quickstart](https://argos-ci.com/docs/quickstart/playwright-quickstart)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/playwright"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/playwright",
+  "homepage": "https://argos-ci.com/docs/reference/playwright",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },

--- a/packages/playwright/playwright.config.ts
+++ b/packages/playwright/playwright.config.ts
@@ -10,7 +10,12 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          args: ["--disable-lcd-text", "--font-render-hinting=none"],
+        },
+      },
     },
   ],
   reporter: [

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -76,6 +76,47 @@ function checkIsDynamicBuildName(
   return Boolean(typeof buildName === "object" && buildName);
 }
 
+/**
+ * Chromium launch arguments recommended to stabilize font rendering
+ * and get consistent Argos screenshots.
+ */
+const RECOMMENDED_CHROMIUM_ARGS = [
+  "--disable-lcd-text",
+  "--font-render-hinting=none",
+];
+
+/**
+ * Warn if the Playwright config is missing the recommended Chromium launch
+ * options used to stabilize screenshots.
+ */
+function checkLaunchOptions(config: FullConfig) {
+  for (const project of config.projects) {
+    // These flags only apply to Chromium. The browser defaults to Chromium
+    // when `browserName` is not set.
+    const browserName = project.use.browserName ?? "chromium";
+    if (browserName !== "chromium") {
+      continue;
+    }
+
+    const args = project.use.launchOptions?.args ?? [];
+    const missing = RECOMMENDED_CHROMIUM_ARGS.filter(
+      (arg) => !args.includes(arg),
+    );
+
+    if (missing.length > 0) {
+      const projectLabel = project.name || "default";
+      console.warn(
+        chalk.yellow(
+          `⚠️  Argos: Playwright project "${projectLabel}" is missing recommended launchOptions args: ${missing.join(
+            ", ",
+          )}.\n` +
+            `   Add them to stabilize font rendering and get consistent screenshots. See https://argos-ci.com/docs/reference/playwright`,
+        ),
+      );
+    }
+  }
+}
+
 export function createArgosReporterOptions<T extends string[]>(
   options: ArgosReporterOptions<T>,
 ): ArgosReporterOptions<T> {
@@ -161,6 +202,7 @@ class ArgosReporter implements Reporter {
   onBegin(config: FullConfig) {
     debug("ArgosReporter:onBegin");
     this.playwrightConfig = config;
+    checkLaunchOptions(config);
   }
 
   async onTestEnd(test: TestCase, result: TestResult) {

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -133,7 +133,7 @@ export type ArgosScreenshotOptions = {
  *
  * @example
  *    argosScreenshot(page, "my-screenshot")
- * @see https://argos-ci.com/docs/sdks-reference/playwright
+ * @see https://argos-ci.com/docs/reference/playwright
  */
 export async function argosScreenshot(
   /**

--- a/packages/puppeteer/README.md
+++ b/packages/puppeteer/README.md
@@ -17,11 +17,11 @@
 
 Capture stable Argos screenshots from your [Puppeteer](https://github.com/puppeteer/puppeteer) tests.
 
-Visit the [Puppeteer SDK documentation](https://argos-ci.com/docs/sdks-reference/puppeteer) for guides, the API reference, and more.
+Visit the [Puppeteer SDK documentation](https://argos-ci.com/docs/reference/puppeteer) for guides, the API reference, and more.
 
 ## Installation
 
-Install the SDK alongside the [Argos CLI](https://argos-ci.com/docs/sdks-reference/argos-command-line-interface-cli), which uploads the screenshots to Argos:
+Install the SDK alongside the [Argos CLI](https://argos-ci.com/docs/reference/argos-command-line-interface-cli), which uploads the screenshots to Argos:
 
 ```sh
 npm install --save-dev @argos-ci/puppeteer @argos-ci/cli
@@ -50,6 +50,6 @@ npx @argos-ci/cli upload ./screenshots
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/puppeteer)
+- [Official SDK Docs](https://argos-ci.com/docs/reference/puppeteer)
 - [Quickstart](https://argos-ci.com/docs/quickstart/puppeteer-quickstart)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/puppeteer"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/puppeteer",
+  "homepage": "https://argos-ci.com/docs/reference/puppeteer",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -231,7 +231,7 @@ ${reasons.map((reason) => `- ${reason}`).join("\n")}
  *
  * @example
  *    argosScreenshot(page, "my-screenshot")
- * @see https://argos-ci.com/docs/sdks-reference/puppeteer
+ * @see https://argos-ci.com/docs/reference/puppeteer
  */
 export async function argosScreenshot(
   /**

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -17,7 +17,7 @@
 
 Capture and review visual changes of your [Storybook](https://storybook.js.org/) stories with Argos. It runs your stories in a real browser and uploads a screenshot of each one to Argos in your CI.
 
-Visit the [Storybook SDK documentation](https://argos-ci.com/docs/sdks-reference/storybook) for guides, the API reference, and more.
+Visit the [Storybook SDK documentation](https://argos-ci.com/docs/reference/storybook) for guides, the API reference, and more.
 
 ## Installation
 
@@ -61,6 +61,6 @@ export const Example: Story = {
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/storybook)
+- [Official SDK Docs](https://argos-ci.com/docs/reference/storybook)
 - [Quickstart](https://argos-ci.com/docs/quickstart/storybook-quickstart)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/storybook"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/storybook",
+  "homepage": "https://argos-ci.com/docs/reference/storybook",
   "keywords": [
     "storybook",
     "storybook-addon",

--- a/packages/storybook/src/test-runner.ts
+++ b/packages/storybook/src/test-runner.ts
@@ -20,7 +20,7 @@ const DEFAULT_PLAYWRIGHT_VIEWPORT_SIZE = { width: 1280, height: 720 };
  * Stabilize the UI and takes a screenshot of the application under test.
  *
  * @example argosScreenshot(page, context, options)
- * @see https://argos-ci.com/docs/sdks-reference/playwright
+ * @see https://argos-ci.com/docs/reference/playwright
  */
 export async function argosScreenshot(
   /**

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -17,7 +17,7 @@
 
 Capture Argos screenshots directly from your [Vitest browser tests](https://vitest.dev/guide/browser/).
 
-Visit the [Vitest SDK documentation](https://argos-ci.com/docs/sdks-reference/vitest) for guides, API and more.
+Visit the [Vitest SDK documentation](https://argos-ci.com/docs/reference/vitest) for guides, API and more.
 
 ## Installation
 
@@ -140,6 +140,6 @@ when `uploadToArgos` is enabled.
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/vitest)
+- [Official SDK Docs](https://argos-ci.com/docs/reference/vitest)
 - [Quickstart](https://argos-ci.com/docs/quickstart/vitest-quickstart)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/vitest"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/vitest",
+  "homepage": "https://argos-ci.com/docs/reference/vitest",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -17,11 +17,11 @@
 
 Capture stable Argos screenshots from your [WebdriverIO](https://webdriver.io) tests.
 
-Visit the [WebdriverIO SDK documentation](https://argos-ci.com/docs/sdks-reference/webdriverio) for guides, the API reference, and more.
+Visit the [WebdriverIO SDK documentation](https://argos-ci.com/docs/reference/webdriverio) for guides, the API reference, and more.
 
 ## Installation
 
-Install the SDK alongside the [Argos CLI](https://argos-ci.com/docs/sdks-reference/argos-command-line-interface-cli), which uploads the screenshots to Argos:
+Install the SDK alongside the [Argos CLI](https://argos-ci.com/docs/reference/argos-command-line-interface-cli), which uploads the screenshots to Argos:
 
 ```sh
 npm install --save-dev @argos-ci/webdriverio @argos-ci/cli
@@ -50,6 +50,6 @@ npx @argos-ci/cli upload ./screenshots
 
 ## Links
 
-- [Official SDK Docs](https://argos-ci.com/docs/sdks-reference/webdriverio)
+- [Official SDK Docs](https://argos-ci.com/docs/reference/webdriverio)
 - [Quickstart](https://argos-ci.com/docs/quickstart/webdriverio-quickstart)
 - [Discord](https://argos-ci.com/discord)

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/argos-ci/argos-javascript.git",
     "directory": "packages/webdriverio"
   },
-  "homepage": "https://argos-ci.com/docs/sdks-reference/webdriverio",
+  "homepage": "https://argos-ci.com/docs/reference/webdriverio",
   "bugs": {
     "url": "https://github.com/argos-ci/argos-javascript/issues"
   },


### PR DESCRIPTION
## What

Adds a startup check to the Argos Playwright reporter: on `onBegin`, it inspects the resolved Playwright config and warns when a Chromium project is missing the recommended launch args used to stabilize font rendering:

```
--disable-lcd-text
--font-render-hinting=none
```

The check:
- Reads `config.projects[].use.launchOptions.args` from the fully-resolved `FullConfig`.
- Only applies to Chromium projects (defaults to Chromium when `browserName` is unset), since these are Chromium-only flags.
- Lists exactly which flags are missing, per project, with a link to the docs.

## Also in this PR

- Adds the recommended `launchOptions.args` to the package's own `playwright.config.ts`.
- Updates all documentation links from `/docs/sdks-reference/` to `/docs/reference/` across packages and examples (the separate `js-sdk-reference.argos-ci.com` API-reference host is left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)