### PR TITLE
feat: expose a baseName option to set fallback baselines

### DIFF
--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -632,7 +632,15 @@ export interface components {
         ScreenshotInput: {
             key: string;
             name: string;
-            baseName?: string | null;
+            /**
+             * @description Name(s) to compare this screenshot against, instead of its own name. An array is tried in order: the first name that exists in the baseline wins, which lets a new screenshot fall back to an existing one.
+             * @example home.png
+             * @example [
+             *       "home-variant-b.png",
+             *       "home.png"
+             *     ]
+             */
+            baseName?: (string | string[]) | null;
             parentName?: string | null;
             metadata?: {
                 /**

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -172,7 +172,7 @@ interface Screenshot {
   optimizedPath: string;
   metadata: ScreenshotMetadata | null;
   threshold: number | null;
-  baseName: string | null;
+  baseName: string | string[] | null;
   pwTrace: {
     path: string;
     hash: string;

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -10,6 +10,7 @@ import { getGlobalScript } from "@argos-ci/browser";
 import {
   getMetadataPath,
   getScreenshotName,
+  normalizeBaseNames,
   type ScreenshotMetadata,
   validateThreshold,
 } from "@argos-ci/util/browser";
@@ -35,6 +36,23 @@ type ArgosScreenshotOptions = Partial<
    * @default 0.5
    */
   threshold?: number;
+
+  /**
+   * Name, or list of names, to compare this screenshot against instead of its
+   * own name. A list is tried in order and the first name found in the baseline
+   * build wins, which lets a brand new screenshot fall back to an existing one
+   * rather than showing up as added.
+   *
+   * The screenshot's own name is not implicitly included: list it first to keep
+   * comparing against itself when it exists.
+   *
+   * @example
+   *    // Compare "home-variant-b" against itself, or against "home" if it is new.
+   *    cy.argosScreenshot("home-variant-b", {
+   *      baseName: ["home-variant-b", "home"],
+   *    })
+   */
+  baseName?: string | string[];
 
   /**
    * Wait for the UI to stabilize before taking the screenshot.
@@ -177,7 +195,15 @@ Cypress.Commands.add(
   "argosScreenshot",
   { prevSubject: ["optional", "element", "window", "document"] },
   (subject, name, options = {}) => {
-    const { viewports, argosCSS: _argosCSS, tag, ...cypressOptions } = options;
+    const {
+      viewports,
+      argosCSS: _argosCSS,
+      tag,
+      baseName,
+      ...cypressOptions
+    } = options;
+
+    const baseNames = normalizeBaseNames(baseName);
     if (!name) {
       throw new Error("The `name` argument is required.");
     }
@@ -192,7 +218,7 @@ Cypress.Commands.add(
 
     const afterAll = beforeAll(options);
 
-    function stabilizeAndScreenshot(name: string) {
+    function stabilizeAndScreenshot(name: string, baseNames: string[] | null) {
       waitForReadiness(options);
       const afterEach = beforeEach(options);
       waitForReadiness(options);
@@ -248,6 +274,10 @@ Cypress.Commands.add(
 
         metadata.transient = {};
 
+        if (baseNames) {
+          metadata.transient.baseName = baseNames;
+        }
+
         if (tag) {
           metadata.tags = Array.isArray(tag) ? tag : [tag];
         }
@@ -267,8 +297,12 @@ Cypress.Commands.add(
       for (const viewport of viewports) {
         const viewportSize = resolveViewport(viewport);
         cy.viewport(viewportSize.width, viewportSize.height);
+        // The viewport suffix is part of the name, so the baselines need it too.
         stabilizeAndScreenshot(
           getScreenshotName(name, { viewportWidth: viewportSize.width }),
+          baseNames?.map((baseName) =>
+            getScreenshotName(baseName, { viewportWidth: viewportSize.width }),
+          ) ?? null,
         );
       }
 
@@ -278,7 +312,7 @@ Cypress.Commands.add(
         Cypress.config("viewportHeight"),
       );
     } else {
-      stabilizeAndScreenshot(name);
+      stabilizeAndScreenshot(name, baseNames);
     }
 
     afterAll();

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -15,6 +15,7 @@ import {
 import {
   getMetadataPath,
   getScreenshotName,
+  normalizeBaseNames,
   validateThreshold,
   writeMetadata,
   type ScreenshotMetadata,
@@ -86,6 +87,23 @@ export type ArgosScreenshotOptions = {
    * @default 0.5
    */
   threshold?: number;
+
+  /**
+   * Name, or list of names, to compare this screenshot against instead of its
+   * own name. A list is tried in order and the first name found in the baseline
+   * build wins, which lets a brand new screenshot fall back to an existing one
+   * rather than showing up as added.
+   *
+   * The screenshot's own name is not implicitly included: list it first to keep
+   * comparing against itself when it exists.
+   *
+   * @example
+   *    // Compare "home-variant-b" against itself, or against "home" if it is new.
+   *    argosScreenshot(page, "home-variant-b", {
+   *      baseName: ["home-variant-b", "home"],
+   *    })
+   */
+  baseName?: string | string[];
 
   /**
    * Folder where the screenshots will be saved if not using the Argos reporter.
@@ -160,8 +178,11 @@ export async function argosScreenshot(
     root = DEFAULT_SCREENSHOT_ROOT,
     ariaSnapshot,
     disableHover = true,
+    baseName,
     ...playwrightOptions
   } = options;
+
+  const baseNames = normalizeBaseNames(baseName);
 
   if (!handler) {
     throw new Error("A Playwright `handler` object is required.");
@@ -194,8 +215,11 @@ export async function argosScreenshot(
   const context = getStabilizationContext(options);
   const afterAll = await beforeAll(handler, context, { disableHover });
 
-  const stabilizeAndScreenshot = async (name: string) => {
-    const names = getSnapshotNames(name, testInfo);
+  const stabilizeAndScreenshot = async (
+    name: string,
+    baseNames: string[] | null,
+  ) => {
+    const names = getSnapshotNames(name, testInfo, baseNames);
     const { path: screenshotPath, metadata } = await getPathAndMetadata({
       handler,
       extension: PNG_EXTENSION,
@@ -249,10 +273,10 @@ export async function argosScreenshot(
           ...metadata,
           transient: {
             parentName: `${names.name}${PNG_EXTENSION}`,
-            ...(metadata.transient.baseName
+            ...(names.baseNames
               ? {
-                  baseName: screenshotToSnapshotPath(
-                    metadata.transient.baseName,
+                  baseName: names.baseNames.map((baseName) =>
+                    screenshotToSnapshotPath(`${baseName}${PNG_EXTENSION}`),
                   ),
                 }
               : {}),
@@ -326,8 +350,12 @@ export async function argosScreenshot(
     for (const viewport of viewports) {
       const viewportSize = resolveViewport(viewport);
       await setViewportSize(handler, viewportSize);
+      // The viewport suffix is part of the name, so the baselines need it too.
       const attachments = await stabilizeAndScreenshot(
         getScreenshotName(name, { viewportWidth: viewportSize.width }),
+        baseNames?.map((baseName) =>
+          getScreenshotName(baseName, { viewportWidth: viewportSize.width }),
+        ) ?? null,
       );
       allAttachments.push(...attachments);
     }
@@ -338,7 +366,7 @@ export async function argosScreenshot(
     }
     await setViewportSize(handler, originalViewportSize);
   } else {
-    const attachments = await stabilizeAndScreenshot(name);
+    const attachments = await stabilizeAndScreenshot(name, baseNames);
     allAttachments.push(...attachments);
   }
 

--- a/packages/playwright/src/util.test.ts
+++ b/packages/playwright/src/util.test.ts
@@ -162,24 +162,61 @@ describe("getSnapshotNames", () => {
 
   it("prefixes the name with the project name", () => {
     const names = getSnapshotNames("hero", createMockTestInfo("chromium"));
-    expect(names).toEqual({ name: "chromium/hero", baseName: null });
+    expect(names).toEqual({ name: "chromium/hero", baseNames: null });
   });
 
   it("does not prefix the name when the project name is empty", () => {
     // No `projects` configured in the Playwright config: the project name is
     // empty. Prefixing would produce an absolute path (`/hero`).
     const names = getSnapshotNames("hero", createMockTestInfo(""));
-    expect(names).toEqual({ name: "hero", baseName: null });
+    expect(names).toEqual({ name: "hero", baseNames: null });
   });
 
   it("returns the bare name when there is no test info", () => {
     const names = getSnapshotNames("hero", null);
-    expect(names).toEqual({ name: "hero", baseName: null });
+    expect(names).toEqual({ name: "hero", baseNames: null });
   });
 
   it("handles repeated tests with an empty project name", () => {
     const names = getSnapshotNames("hero", createMockTestInfo("", 2));
-    expect(names).toEqual({ name: "hero repeat-2", baseName: "hero" });
+    expect(names).toEqual({ name: "hero repeat-2", baseNames: ["hero"] });
+  });
+
+  it("prefixes the base names with the project name", () => {
+    const names = getSnapshotNames(
+      "home-variant-b",
+      createMockTestInfo("chromium"),
+      ["home-variant-b", "home"],
+    );
+    expect(names).toEqual({
+      name: "chromium/home-variant-b",
+      baseNames: ["chromium/home-variant-b", "chromium/home"],
+    });
+  });
+
+  it("keeps the base names when there is no test info", () => {
+    const names = getSnapshotNames("home-variant-b", null, ["home"]);
+    expect(names).toEqual({
+      name: "home-variant-b",
+      baseNames: ["home"],
+    });
+  });
+
+  it("ignores an empty list of base names", () => {
+    const names = getSnapshotNames("hero", createMockTestInfo("chromium"), []);
+    expect(names).toEqual({ name: "chromium/hero", baseNames: null });
+  });
+
+  it("lets the base names win over the implicit repeat baseline", () => {
+    const names = getSnapshotNames(
+      "home-variant-b",
+      createMockTestInfo("", 2),
+      ["home-variant-b", "home"],
+    );
+    expect(names).toEqual({
+      name: "home-variant-b repeat-2",
+      baseNames: ["home-variant-b", "home"],
+    });
   });
 });
 

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -153,7 +153,11 @@ export function getViewportSize(page: Page) {
 
 type SnapshotNames = {
   name: string;
-  baseName: string | null;
+  /**
+   * Names to compare against, in priority order, or `null` to compare against
+   * `name` itself.
+   */
+  baseNames: string[] | null;
 };
 
 /**
@@ -175,27 +179,31 @@ export async function setViewportSize(page: Page, viewportSize: ViewportSize) {
 export function getSnapshotNames(
   name: string,
   testInfo: TestInfo | null,
+  baseNames?: string[] | null,
 ): SnapshotNames {
-  if (testInfo) {
-    // The project name is empty when no `projects` are configured in the
-    // Playwright config. In that case we must not prefix the name, otherwise it
-    // becomes an absolute path (e.g. `/my-screenshot`) and `path.resolve(root,
-    // name)` resolves it to the filesystem root.
-    const projectName = testInfo.project.name
-      ? `${testInfo.project.name}/${name}`
-      : name;
+  // The project name is empty when no `projects` are configured in the
+  // Playwright config. In that case we must not prefix the name, otherwise it
+  // becomes an absolute path (e.g. `/my-screenshot`) and `path.resolve(root,
+  // name)` resolves it to the filesystem root.
+  const prefix = testInfo?.project.name ? `${testInfo.project.name}/` : "";
+  const prefixedName = `${prefix}${name}`;
+  // User-provided names live in the same namespace as the snapshot name, so
+  // they get the same project prefix.
+  const prefixedBaseNames =
+    baseNames && baseNames.length > 0
+      ? baseNames.map((baseName) => `${prefix}${baseName}`)
+      : null;
 
-    if (testInfo.repeatEachIndex > 0) {
-      return {
-        name: `${projectName} repeat-${testInfo.repeatEachIndex}`,
-        baseName: projectName,
-      };
-    }
-
-    return { name: projectName, baseName: null };
+  if (testInfo && testInfo.repeatEachIndex > 0) {
+    return {
+      name: `${prefixedName} repeat-${testInfo.repeatEachIndex}`,
+      // A repeat has no baseline of its own, so it compares against the
+      // non-repeated snapshot — unless the user named its baselines.
+      baseNames: prefixedBaseNames ?? [prefixedName],
+    };
   }
 
-  return { name, baseName: null };
+  return { name: prefixedName, baseNames: prefixedBaseNames };
 }
 
 /**
@@ -227,10 +235,8 @@ export async function prepare(args: {
   ]);
 }
 
-type ScreenshotMetadataWithBaseName = ScreenshotMetadata & {
-  transient: Partial<NonNullable<ScreenshotMetadata["transient"]>> & {
-    baseName: string;
-  };
+type ScreenshotMetadataWithTransient = ScreenshotMetadata & {
+  transient: NonNullable<ScreenshotMetadata["transient"]>;
 };
 
 /**
@@ -244,7 +250,7 @@ export async function getPathAndMetadata(args: {
   root: string;
   useArgosReporter: boolean;
 }): Promise<{
-  metadata: ScreenshotMetadataWithBaseName;
+  metadata: ScreenshotMetadataWithTransient;
   path: string;
 }> {
   const { handler, testInfo, names, extension, root, useArgosReporter } = args;
@@ -302,12 +308,14 @@ export async function getPathAndMetadata(args: {
 
   metadata.transient = {};
 
-  if (names.baseName) {
-    metadata.transient.baseName = `${names.baseName}${extension}`;
+  if (names.baseNames) {
+    metadata.transient.baseName = names.baseNames.map(
+      (baseName) => `${baseName}${extension}`,
+    );
   }
 
   return {
-    metadata: metadata as ScreenshotMetadataWithBaseName,
+    metadata: metadata as ScreenshotMetadataWithTransient,
     path,
   };
 }

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -14,6 +14,7 @@ import {
 import {
   type ScreenshotMetadata,
   getScreenshotName,
+  normalizeBaseNames,
   readVersionFromPackage,
   validateThreshold,
   writeMetadata,
@@ -68,6 +69,23 @@ export type ArgosScreenshotOptions = Omit<
    * @default 0.5
    */
   threshold?: number;
+
+  /**
+   * Name, or list of names, to compare this screenshot against instead of its
+   * own name. A list is tried in order and the first name found in the baseline
+   * build wins, which lets a brand new screenshot fall back to an existing one
+   * rather than showing up as added.
+   *
+   * The screenshot's own name is not implicitly included: list it first to keep
+   * comparing against itself when it exists.
+   *
+   * @example
+   *    // Compare "home-variant-b" against itself, or against "home" if it is new.
+   *    argosScreenshot(page, "home-variant-b", {
+   *      baseName: ["home-variant-b", "home"],
+   *    })
+   */
+  baseName?: string | string[];
 
   /**
    * Wait for the UI to stabilize before taking the screenshot.
@@ -251,8 +269,11 @@ export async function argosScreenshot(
     element,
     viewports,
     argosCSS: _argosCSS,
+    baseName,
     ...puppeteerOptions
   } = options;
+
+  const baseNames = normalizeBaseNames(baseName);
   if (!page) {
     throw new Error("A Puppeteer `page` object is required.");
   }
@@ -269,7 +290,9 @@ export async function argosScreenshot(
   const afterAll = await beforeAll(page, options);
   const fullPage = checkIsFullPage(options);
 
-  async function collectMetadata(): Promise<ScreenshotMetadata> {
+  async function collectMetadata(
+    baseNames: string[] | null,
+  ): Promise<ScreenshotMetadata> {
     const [
       colorScheme,
       mediaType,
@@ -315,6 +338,10 @@ export async function argosScreenshot(
 
     metadata.transient = {};
 
+    if (baseNames) {
+      metadata.transient.baseName = baseNames;
+    }
+
     if (options?.tag) {
       metadata.tags = Array.isArray(options.tag) ? options.tag : [options.tag];
     }
@@ -327,14 +354,17 @@ export async function argosScreenshot(
     return metadata;
   }
 
-  async function stabilizeAndScreenshot(name: string) {
+  async function stabilizeAndScreenshot(
+    name: string,
+    baseNames: string[] | null,
+  ) {
     await waitForReadiness(page, options);
     const afterEach = await beforeEach(page, options);
     await waitForReadiness(page, options);
 
     const [screenshotPath, metadata] = await Promise.all([
       getScreenshotPath(name),
-      collectMetadata(),
+      collectMetadata(baseNames),
     ]);
 
     await writeMetadata(screenshotPath, metadata);
@@ -375,14 +405,18 @@ export async function argosScreenshot(
     for (const viewport of viewports) {
       const viewportSize = resolveViewport(viewport);
       await setViewportSize(page, viewportSize);
+      // The viewport suffix is part of the name, so the baselines need it too.
       await stabilizeAndScreenshot(
         getScreenshotName(name, { viewportWidth: viewportSize.width }),
+        baseNames?.map((baseName) =>
+          getScreenshotName(baseName, { viewportWidth: viewportSize.width }),
+        ) ?? null,
       );
     }
     // Restore the original viewport
     await setViewportSize(page, originalViewport);
   } else {
-    await stabilizeAndScreenshot(name);
+    await stabilizeAndScreenshot(name, baseNames);
   }
 
   await afterAll();

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -40,6 +40,7 @@
   "scripts": {
     "build": "tsdown",
     "check-types": "tsc",
+    "test": "vitest run src",
     "check-format": "prettier --check --ignore-unknown --ignore-path=../../.gitignore --ignore-path=../../.prettierignore .",
     "lint": "eslint ."
   },

--- a/packages/util/src/base-name.test.ts
+++ b/packages/util/src/base-name.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBaseNames } from "./base-name";
+
+describe("normalizeBaseNames", () => {
+  it("wraps a single name in a list", () => {
+    expect(normalizeBaseNames("home.png")).toEqual(["home.png"]);
+  });
+
+  it("keeps a list as-is, preserving order", () => {
+    expect(normalizeBaseNames(["home-variant-b.png", "home.png"])).toEqual([
+      "home-variant-b.png",
+      "home.png",
+    ]);
+  });
+
+  it("returns null when nothing is provided", () => {
+    expect(normalizeBaseNames(undefined)).toBeNull();
+    expect(normalizeBaseNames(null)).toBeNull();
+    expect(normalizeBaseNames("")).toBeNull();
+    expect(normalizeBaseNames([])).toBeNull();
+  });
+
+  it("drops empty names", () => {
+    expect(normalizeBaseNames(["", "home.png", ""])).toEqual(["home.png"]);
+    expect(normalizeBaseNames([""])).toBeNull();
+  });
+});

--- a/packages/util/src/base-name.ts
+++ b/packages/util/src/base-name.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalize the user-facing `baseName` option — a single name or an ordered
+ * list of candidates — into a list, or `null` when nothing was provided.
+ */
+export function normalizeBaseNames(
+  baseName: string | string[] | undefined | null,
+): string[] | null {
+  if (!baseName) {
+    return null;
+  }
+  const names = Array.isArray(baseName) ? baseName : [baseName];
+  const validNames = names.filter((name) => name !== "");
+  return validNames.length > 0 ? validNames : null;
+}

--- a/packages/util/src/browser.ts
+++ b/packages/util/src/browser.ts
@@ -1,4 +1,5 @@
 export { getMetadataPath } from "./metadata";
 export type { ScreenshotMetadata } from "./metadata";
+export * from "./base-name";
 export * from "./name";
 export * from "./threshold";

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./base-name";
 export * from "./fs";
 export * from "./git";
 export * from "./introspection";

--- a/packages/util/src/metadata.ts
+++ b/packages/util/src/metadata.ts
@@ -92,8 +92,12 @@ export type ScreenshotMetadata = {
   transient?: {
     /** Threshold configured for this screenshot. */
     threshold?: number;
-    /** Override the name to find the comparison baseline. */
-    baseName?: string;
+    /**
+     * Name(s) used to find the comparison baseline, instead of the snapshot's
+     * own name. Several names are tried in order: the first one that exists in
+     * the baseline wins.
+     */
+    baseName?: string | string[];
     /** Name of the parent screenshot. */
     parentName?: string;
   };

--- a/packages/vitest/src/command.ts
+++ b/packages/vitest/src/command.ts
@@ -4,7 +4,7 @@ import {
   type ArgosAttachment,
 } from "@argos-ci/playwright";
 import { resolveViewport, type ViewportSize } from "@argos-ci/browser";
-import { getScreenshotName } from "@argos-ci/util";
+import { getScreenshotName, normalizeBaseNames } from "@argos-ci/util";
 import type {
   ArgosVitestPluginOptions,
   VitestScreenshotOptions,
@@ -41,6 +41,7 @@ export const createArgosScreenshotCommand = (
     }
 
     const merged: ArgosVitestPluginOptions = { ...pluginOptions, ...options };
+    const baseNames = normalizeBaseNames(merged.baseName);
     const fullPage = merged.fullPage ?? false;
     const fitWidth = !fullPage;
 
@@ -74,7 +75,15 @@ export const createArgosScreenshotCommand = (
           const shot = await screenshotFrame(
             ctx,
             getScreenshotName(name, { viewportWidth: size.width }),
-            merged,
+            {
+              ...merged,
+              // The viewports loop is reimplemented here rather than delegated
+              // to the Playwright SDK, so the viewport suffix has to be applied
+              // to the baselines as well as to the name.
+              baseName: baseNames?.map((baseName) =>
+                getScreenshotName(baseName, { viewportWidth: size.width }),
+              ),
+            },
             // Keep the fixed viewport width, only grow the height to fit.
             { fitWidth: false },
           );

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -63,6 +63,23 @@ export interface VitestScreenshotOptions {
   threshold?: number;
 
   /**
+   * Name, or list of names, to compare this screenshot against instead of its
+   * own name. A list is tried in order and the first name found in the baseline
+   * build wins, which lets a brand new screenshot fall back to an existing one
+   * rather than showing up as added.
+   *
+   * The screenshot's own name is not implicitly included: list it first to keep
+   * comparing against itself when it exists.
+   *
+   * @example
+   *    // Compare "home-variant-b" against itself, or against "home" if it is new.
+   *    argosScreenshot("home-variant-b", {
+   *      baseName: ["home-variant-b", "home"],
+   *    })
+   */
+  baseName?: string | string[];
+
+  /**
    * Tag or array of tags to attach to the screenshot.
    */
   tag?: string | string[];


### PR DESCRIPTION
Closes ARG-327. Requires argos-ci/argos#2395 to be deployed.

## Description

Exposes a `baseName` option on `argosScreenshot` — a name, or a list of names in priority order — naming what the screenshot is compared against instead of its own name. Argos picks the first name present in the baseline build, so a variant of an existing screenshot shows a diff on its first run rather than being reported as added.

```ts
// Compare "home-variant-b" against itself, or against "home" if it is new.
await argosScreenshot(page, "home-variant-b", {
  baseName: ["home-variant-b", "home"],
});
```

Supported in **Playwright**, **Puppeteer**, **Cypress** and **Vitest**, and carried to the API through `transient.baseName`, which now accepts an array.

## Notes for review

**Name namespacing.** The candidates live in the same namespace as the screenshot name, so they get the same treatment — otherwise they'd never match:
- the Playwright **project prefix** (`chromium/home`) is applied to each candidate;
- the **`viewports` suffix** (`home vw-1280`) is applied to each candidate. Vitest reimplements the viewports loop itself rather than delegating to the Playwright SDK, so it applies the suffix on its own side too.

**`repeatEach` composition.** `baseName` was already used internally to point a `hero repeat-2` screenshot at `hero`. User-provided names now replace that implicit baseline, which is why listing your own name first matters. Covered by new `getSnapshotNames` tests.

**`argosAriaSnapshot`** does not take the option, matching how `threshold` is handled there. The ARIA sidecar still derives its own `baseName` from the screenshot's candidates.

**Drive-by:** `packages/util` had test files (`name.test.ts`, `metadata-io.test.ts`) but no `test` script, so none of them ever ran in CI. Added one — they pass, and it also covers the new `normalizeBaseNames` helper.

**`packages/api-client/src/schema.ts`** is generated from the deployed OpenAPI spec, which doesn't have this field yet. I generated the spec from the argos branch locally and hand-applied only the `ScreenshotInput.baseName` hunk, so the next full regeneration is a no-op for it.

## Type of changes

`enhancement`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally (18/18 turbo test tasks, eslint, prettier, tsc)
- [x] I have added tests if needed
- [x] My changes requires a change to the documentation
- [x] I have updated the documentation accordingly (argos-ci/docs PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)