### PR TITLE
feat(cli): add test and test-comment commands

### DIFF
--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -24,6 +24,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/accounts/{accountSlug}/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List an account's projects
+         * @description List the projects of an account that are visible to the authenticated user, most recently active first. Results are paginated. The token must be scoped to the account.
+         */
+        get: operations["listProjects"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/builds": {
         parameters: {
             query?: never;
@@ -233,7 +253,7 @@ export interface paths {
         };
         /**
          * Get the current user
-         * @description Retrieve the user associated with the personal access token used to authenticate the request.
+         * @description Retrieve the user associated with the token used to authenticate the request, with the accounts (personal and teams) the token can access. Account slugs are the `owner` used in other API paths.
          */
         get: operations["getMe"];
         put?: never;
@@ -333,9 +353,9 @@ export interface paths {
         };
         /**
          * List a project's builds
-         * @description List the builds of a project, most recent first. Results are paginated. Use `distinctName` to return only the latest build per name and commit.
+         * @description List the builds of a project, most recent first. Results are paginated. Use `search` to match builds by name, branch or commit, and `distinctName` to return only the latest build per name and commit.
          */
-        get: operations["getProjectBuilds"];
+        get: operations["listBuilds"];
         put?: never;
         post?: never;
         delete?: never;
@@ -477,15 +497,15 @@ export interface paths {
         };
         /**
          * List the comments on a build
-         * @description List the comments on a build, with pagination.
+         * @description List the comments on a build.
          */
-        get: operations["listComments"];
+        get: operations["listBuildComments"];
         put?: never;
         /**
          * Post a comment (or reply) on a build
          * @description Post a comment on a build. Start a new thread, reply to an existing one with `threadId`, optionally anchor the comment to a screenshot diff, or attach it to your pending review with `addToReview`.
          */
-        post: operations["createComment"];
+        post: operations["createBuildComment"];
         delete?: never;
         options?: never;
         head?: never;
@@ -503,21 +523,21 @@ export interface paths {
          * Get a single comment on a build
          * @description Retrieve a single comment on a build by its ID.
          */
-        get: operations["getComment"];
+        get: operations["getBuildComment"];
         put?: never;
         post?: never;
         /**
          * Delete a comment on a build
          * @description Delete a comment on a build. Only the comment's author can delete it.
          */
-        delete: operations["deleteComment"];
+        delete: operations["deleteBuildComment"];
         options?: never;
         head?: never;
         /**
          * Update a comment on a build
          * @description Update the body of a comment on a build. Only the comment's author can edit it.
          */
-        patch: operations["updateComment"];
+        patch: operations["updateBuildComment"];
         trace?: never;
     };
     "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/reactions": {
@@ -530,15 +550,15 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Add an emoji reaction to a comment
-         * @description Add an emoji reaction to a comment on behalf of the authenticated user.
+         * Add an emoji reaction to a comment on a build
+         * @description Add an emoji reaction to a comment on a build, on behalf of the authenticated user.
          */
-        post: operations["addCommentReaction"];
+        post: operations["addBuildCommentReaction"];
         /**
-         * Remove an emoji reaction from a comment
-         * @description Remove an emoji reaction previously added by the authenticated user from a comment.
+         * Remove an emoji reaction from a comment on a build
+         * @description Remove an emoji reaction previously added by the authenticated user from a comment on a build.
          */
-        delete: operations["removeCommentReaction"];
+        delete: operations["removeBuildCommentReaction"];
         options?: never;
         head?: never;
         patch?: never;
@@ -554,10 +574,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Mark a comment thread as resolved
-         * @description Mark a comment thread as resolved.
+         * Mark a build comment thread as resolved
+         * @description Mark a comment thread on a build as resolved.
          */
-        post: operations["resolveCommentThread"];
+        post: operations["resolveBuildCommentThread"];
         delete?: never;
         options?: never;
         head?: never;
@@ -574,10 +594,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Reopen a resolved comment thread
-         * @description Reopen a previously resolved comment thread.
+         * Reopen a resolved build comment thread
+         * @description Reopen a previously resolved comment thread on a build.
          */
-        post: operations["unresolveCommentThread"];
+        post: operations["unresolveBuildCommentThread"];
         delete?: never;
         options?: never;
         head?: never;
@@ -594,15 +614,195 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Subscribe to a comment thread's notifications
-         * @description Subscribe the authenticated user to a comment thread to receive notifications about new replies.
+         * Subscribe to a build comment thread's notifications
+         * @description Subscribe the authenticated user to a comment thread on a build to receive notifications about new replies.
          */
-        post: operations["subscribeCommentThread"];
+        post: operations["subscribeBuildCommentThread"];
         /**
-         * Unsubscribe from a comment thread's notifications
-         * @description Unsubscribe the authenticated user from a comment thread's notifications.
+         * Unsubscribe from a build comment thread's notifications
+         * @description Unsubscribe the authenticated user from a build comment thread's notifications.
          */
-        delete: operations["unsubscribeCommentThread"];
+        delete: operations["unsubscribeBuildCommentThread"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a test and its flakiness metrics
+         * @description Get a test with its flakiness metrics over a period: how many builds ran it, how many times it changed, and how stable and consistent those changes were. The metrics also come bucketed over time, so you can tell a test that has always been flaky from one that started recently. Pair it with `listTestChanges` to see what actually keeps changing.
+         */
+        get: operations["getTest"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a test's changes
+         * @description List the distinct changes a test produced over a period, the ones that came back most often first. Each change is one exact visual difference, with how many times it reappeared, whether it is ignored, and the diff of its latest occurrence — so you can look at what moved. A change that keeps reappearing while nothing in the UI changed is a flaky one: fix what makes it unstable, or silence it with `ignoreChange`.
+         */
+        get: operations["listTestChanges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/comments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the comments on a test
+         * @description List the comments on a test.
+         */
+        get: operations["listTestComments"];
+        put?: never;
+        /**
+         * Post a comment (or reply) on a test
+         * @description Post a comment on a test. Start a new thread, or reply to an existing one with `threadId`.
+         */
+        post: operations["createTestComment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a single comment on a test
+         * @description Retrieve a single comment on a test by its ID.
+         */
+        get: operations["getTestComment"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a comment on a test
+         * @description Delete a comment on a test. Only the comment's author can delete it.
+         */
+        delete: operations["deleteTestComment"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a comment on a test
+         * @description Update the body of a comment on a test. Only the comment's author can edit it.
+         */
+        patch: operations["updateTestComment"];
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/reactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Add an emoji reaction to a comment on a test
+         * @description Add an emoji reaction to a comment on a test, on behalf of the authenticated user.
+         */
+        post: operations["addTestCommentReaction"];
+        /**
+         * Remove an emoji reaction from a comment on a test
+         * @description Remove an emoji reaction previously added by the authenticated user from a comment on a test.
+         */
+        delete: operations["removeTestCommentReaction"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mark a test comment thread as resolved
+         * @description Mark a comment thread on a test as resolved.
+         */
+        post: operations["resolveTestCommentThread"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/unresolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reopen a resolved test comment thread
+         * @description Reopen a previously resolved comment thread on a test.
+         */
+        post: operations["unresolveTestCommentThread"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/subscription": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Subscribe to a test comment thread's notifications
+         * @description Subscribe the authenticated user to a comment thread on a test to receive notifications about new replies.
+         */
+        post: operations["subscribeTestCommentThread"];
+        /**
+         * Unsubscribe from a test comment thread's notifications
+         * @description Unsubscribe the authenticated user from a test comment thread's notifications.
+         */
+        delete: operations["unsubscribeTestCommentThread"];
         options?: never;
         head?: never;
         patch?: never;
@@ -764,6 +964,15 @@ export interface components {
          * @example 42
          */
         BuildNumber: string;
+        /** @description The ID of the comment */
+        CommentId: string;
+        /** @description ID of any comment in the thread */
+        ThreadCommentId: string;
+        /**
+         * @description The test identifier, as returned in a diff's `test.id`
+         * @example WEB-xf23d
+         */
+        TestId: string;
         AccountAnalytics: {
             screenshots: {
                 series: {
@@ -825,10 +1034,36 @@ export interface components {
                 message: string;
             }[];
         };
+        /** @description Page information */
+        PageInfo: {
+            /** @description Total number of items */
+            total: number;
+            /** @description Current page number */
+            page: number;
+            /** @description Number of items per page */
+            perPage: number;
+        };
+        /** @description Project */
+        Project: {
+            id: string;
+            account: components["schemas"]["Account"];
+            name: string;
+            defaultBaseBranch: string;
+            hasRemoteContentAccess: boolean;
+        };
+        /** @description Account */
+        Account: {
+            id: string;
+            slug: string;
+        };
         /** @description Build */
         Build: {
             id: components["schemas"]["BuildId"];
-            number: components["schemas"]["BuildNumberOutput"];
+            /**
+             * @description The build number
+             * @example 42
+             */
+            number: number;
             /** @description The head reference of the build */
             head: components["schemas"]["BuildGitReference"];
             /** @description The base reference of the build */
@@ -900,33 +1135,22 @@ export interface components {
             /** @description The branch name */
             branch: string;
         };
-        /** @description A user. */
-        User: {
+        /** @description The authenticated user. */
+        Me: {
             id: string;
             slug: string;
             name: string | null;
+            /** @description The accounts this token can access: the personal account and the teams selected when the token was created or authorized. */
+            accounts: components["schemas"]["MeAccount"][];
         };
-        /** @description Project */
-        Project: {
+        /** @description An account (personal or team) accessible to the token. */
+        MeAccount: {
             id: string;
-            account: components["schemas"]["Account"];
-            name: string;
-            defaultBaseBranch: string;
-            hasRemoteContentAccess: boolean;
-        };
-        /** @description Account */
-        Account: {
-            id: string;
+            /** @description Account slug, used as the `owner` in API paths. */
             slug: string;
-        };
-        /** @description Page information */
-        PageInfo: {
-            /** @description Total number of items */
-            total: number;
-            /** @description Current page number */
-            page: number;
-            /** @description Number of items per page */
-            perPage: number;
+            name: string | null;
+            /** @enum {string} */
+            type: "user" | "team";
         };
         /** @description Snapshot diff */
         SnapshotDiff: {
@@ -1226,10 +1450,19 @@ export interface components {
             /** @description Date the review was created. */
             date: string;
         };
-        /** @description A comment posted on a build. */
+        /** @description A user. */
+        User: {
+            id: string;
+            slug: string;
+            name: string | null;
+        };
+        /** @description A comment posted on a build or on a test. */
         Comment: {
             id: string;
-            buildId: string;
+            /** @description Build this comment is posted on, null when it is posted on a test. */
+            buildId: string | null;
+            /** @description Test this comment is posted on, null when it is posted on a build. */
+            testId: string | null;
             /** @description Root comment ID when this comment is a reply. */
             threadId: string | null;
             /** @description Rich-text JSON content of the comment. */
@@ -1268,11 +1501,87 @@ export interface components {
                 users: components["schemas"]["User"][];
             }[];
         };
+        /** @description A test with its flakiness metrics, both aggregated and over time, and when it first and last changed. */
+        TestDetails: {
+            /** @description Unique identifier of the test */
+            id: string;
+            /** @description Name of the test */
+            name: string;
+            /** @description Name of the build the test belongs to */
+            buildName: string;
+            metrics: components["schemas"]["TestMetrics"];
+            status: components["schemas"]["TestStatus"];
+            /**
+             * Format: date-time
+             * @description When Argos first saw this test.
+             */
+            createdAt: string;
+            /**
+             * Format: uri
+             * @description URL of the test in Argos.
+             */
+            url: string;
+            /** @description The test's metrics bucketed over the requested period, oldest first. Use it to tell a test that has always been flaky from one that only started recently. */
+            series: components["schemas"]["TestMetricsDataPoint"][];
+            /** @description The first time this test ever changed, whatever the period. Null when it never changed. */
+            firstSeenChange: components["schemas"]["TestChangeOccurrence"] | null;
+            /** @description The last time this test changed, whatever the period. Null when it never changed. */
+            lastSeenChange: components["schemas"]["TestChangeOccurrence"] | null;
+        };
         /**
-         * @description The build number
-         * @example 42
+         * @description `ongoing` when the test still runs — it showed up in the latest build of its build name. `removed` when it did not, so it was deleted, renamed or skipped.
+         * @enum {string}
          */
-        BuildNumberOutput: unknown;
+        TestStatus: "ongoing" | "removed";
+        /** @description One bucket of a test's metrics over time. The bucket size is derived from the requested period. */
+        TestMetricsDataPoint: {
+            /**
+             * Format: date-time
+             * @description Start of the time bucket.
+             */
+            date: string;
+            /** @description Number of builds in which the test ran in this bucket. */
+            total: number;
+            /** @description Number of times the test changed in this bucket. */
+            changes: number;
+            /** @description Number of those changes that were seen only once. */
+            uniqueChanges: number;
+        };
+        /** @description A single appearance of a change, in the build that saw it. */
+        TestChangeOccurrence: {
+            /**
+             * Format: date-time
+             * @description When the diff was captured.
+             */
+            date: string;
+            /** @description Public URL of the diff image. Null when the image is no longer available. */
+            url: string | null;
+            /**
+             * @description Number of the build that captured the diff.
+             * @example 42
+             */
+            buildNumber: number;
+            /**
+             * Format: uri
+             * @description URL of that build in Argos.
+             */
+            buildUrl: string;
+        };
+        /** @description One distinct change of a test: an exact visual difference, with how often it came back over the period. A change that keeps reappearing while nothing in the UI changed is a flaky one. */
+        TestChange: {
+            /** @description Unique identifier of the change (a test + fingerprint pair). Use it with the ignore/unignore endpoints. */
+            id: string;
+            /** @description Whether this change is currently ignored. Ignored changes no longer require review and are automatically approved. */
+            ignored: boolean;
+            /** @description Number of times this change has been seen over the metrics period. A high count for a recurring change is a strong flakiness signal. */
+            occurrences: number;
+            /** @description The first time this change was seen over the period. */
+            firstSeen: components["schemas"]["TestChangeOccurrence"];
+            /** @description The last time this change was seen over the period. */
+            lastSeen: components["schemas"]["TestChangeOccurrence"];
+            /** @description The diff captured the last time the change was seen, with the baseline and the captured snapshot, so you can look at what moved. */
+            diff: components["schemas"]["SnapshotDiff"];
+        };
     };
     responses: never;
     parameters: never;
@@ -1323,6 +1632,73 @@ export interface operations {
             };
             /** @description Unauthorized */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listProjects: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Slug of the account to list projects for. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of projects */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["Project"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2151,7 +2527,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["User"];
+                    "application/json": components["schemas"]["Me"];
                 };
             };
             /** @description Unauthorized */
@@ -2427,7 +2803,7 @@ export interface operations {
             };
         };
     };
-    getProjectBuilds: {
+    listBuilds: {
         parameters: {
             query?: {
                 /** @description Number of items per page (max 100) */
@@ -2436,6 +2812,8 @@ export interface operations {
                 page?: string;
                 head?: string;
                 headSha?: components["schemas"]["Sha1Hash"];
+                /** @description Search builds by name, branch (substring) or commit (prefix). */
+                search?: string;
                 /** @description Only return the latest builds created, unique by name and commit. */
                 distinctName?: string;
             };
@@ -3039,7 +3417,7 @@ export interface operations {
             };
         };
     };
-    listComments: {
+    listBuildComments: {
         parameters: {
             query?: never;
             header?: never;
@@ -3053,7 +3431,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Build comments, oldest first. Replies carry a threadId pointing at their root comment. */
+            /** @description Comments, oldest first. Replies carry a threadId pointing at their root comment. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -3109,7 +3487,7 @@ export interface operations {
             };
         };
     };
-    createComment: {
+    createBuildComment: {
         parameters: {
             query?: never;
             header?: never;
@@ -3206,7 +3584,7 @@ export interface operations {
             };
         };
     };
-    getComment: {
+    getBuildComment: {
         parameters: {
             query?: never;
             header?: never;
@@ -3216,7 +3594,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description The ID of the comment */
-                commentId: string;
+                commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
         };
@@ -3278,7 +3656,7 @@ export interface operations {
             };
         };
     };
-    deleteComment: {
+    deleteBuildComment: {
         parameters: {
             query?: never;
             header?: never;
@@ -3288,7 +3666,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description The ID of the comment */
-                commentId: string;
+                commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
         };
@@ -3350,7 +3728,7 @@ export interface operations {
             };
         };
     };
-    updateComment: {
+    updateBuildComment: {
         parameters: {
             query?: never;
             header?: never;
@@ -3360,7 +3738,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description The ID of the comment */
-                commentId: string;
+                commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
         };
@@ -3431,7 +3809,7 @@ export interface operations {
             };
         };
     };
-    addCommentReaction: {
+    addBuildCommentReaction: {
         parameters: {
             query?: never;
             header?: never;
@@ -3441,7 +3819,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description The ID of the comment */
-                commentId: string;
+                commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
         };
@@ -3510,7 +3888,7 @@ export interface operations {
             };
         };
     };
-    removeCommentReaction: {
+    removeBuildCommentReaction: {
         parameters: {
             query: {
                 /** @description The emoji reaction to remove. */
@@ -3523,7 +3901,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description The ID of the comment */
-                commentId: string;
+                commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
         };
@@ -3585,7 +3963,7 @@ export interface operations {
             };
         };
     };
-    resolveCommentThread: {
+    resolveBuildCommentThread: {
         parameters: {
             query?: never;
             header?: never;
@@ -3595,7 +3973,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description ID of any comment in the thread */
-                commentId: string;
+                commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
         };
@@ -3657,7 +4035,7 @@ export interface operations {
             };
         };
     };
-    unresolveCommentThread: {
+    unresolveBuildCommentThread: {
         parameters: {
             query?: never;
             header?: never;
@@ -3667,7 +4045,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description ID of any comment in the thread */
-                commentId: string;
+                commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
         };
@@ -3729,7 +4107,7 @@ export interface operations {
             };
         };
     };
-    subscribeCommentThread: {
+    subscribeBuildCommentThread: {
         parameters: {
             query?: never;
             header?: never;
@@ -3739,7 +4117,7 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description ID of any comment in the thread */
-                commentId: string;
+                commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
         };
@@ -3801,7 +4179,7 @@ export interface operations {
             };
         };
     };
-    unsubscribeCommentThread: {
+    unsubscribeBuildCommentThread: {
         parameters: {
             query?: never;
             header?: never;
@@ -3811,7 +4189,962 @@ export interface operations {
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
                 /** @description ID of any comment in the thread */
-                commentId: string;
+                commentId: components["schemas"]["ThreadCommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unsubscribed — returns the root comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTest: {
+        parameters: {
+            query?: {
+                /** @description Period over which the test flakiness metrics are computed. */
+                metricsPeriod?: "LAST_24_HOURS" | "LAST_3_DAYS" | "LAST_7_DAYS" | "LAST_30_DAYS" | "LAST_90_DAYS";
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The test and its flakiness metrics */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TestDetails"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listTestChanges: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+                /** @description Period over which the test flakiness metrics are computed. */
+                metricsPeriod?: "LAST_24_HOURS" | "LAST_3_DAYS" | "LAST_7_DAYS" | "LAST_30_DAYS" | "LAST_90_DAYS";
+                /** @description Restrict the changes to the ones currently ignored (`true`) or to the ones still under review (`false`). Omit it to get both. */
+                ignored?: "true" | "false";
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of the test's changes */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["TestChange"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listTestComments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Comments, oldest first. Replies carry a threadId pointing at their root comment. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"][];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createTestComment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Comment content. Either Markdown text or the JSON representation of a rich-text document. */
+                    body: string | {
+                        [key: string]: unknown;
+                    };
+                    /** @description Root comment ID to reply to. */
+                    threadId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Comment created successfully — returns the comment */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTestComment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description The ID of the comment */
+                commentId: components["schemas"]["CommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTestComment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description The ID of the comment */
+                commentId: components["schemas"]["CommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Comment deleted successfully — returns the comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    updateTestComment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description The ID of the comment */
+                commentId: components["schemas"]["CommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Comment content. Either Markdown text or the JSON representation of a rich-text document. */
+                    body: string | {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Comment updated successfully — returns the comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    addTestCommentReaction: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description The ID of the comment */
+                commentId: components["schemas"]["CommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The emoji to react with. */
+                    emoji: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Reaction added — returns the comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    removeTestCommentReaction: {
+        parameters: {
+            query: {
+                /** @description The emoji reaction to remove. */
+                emoji: string;
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description The ID of the comment */
+                commentId: components["schemas"]["CommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Reaction removed — returns the comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    resolveTestCommentThread: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description ID of any comment in the thread */
+                commentId: components["schemas"]["ThreadCommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Thread resolved — returns the root comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    unresolveTestCommentThread: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description ID of any comment in the thread */
+                commentId: components["schemas"]["ThreadCommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Thread reopened — returns the root comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    subscribeTestCommentThread: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description ID of any comment in the thread */
+                commentId: components["schemas"]["ThreadCommentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscribed — returns the root comment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Comment"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    unsubscribeTestCommentThread: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+                /** @description ID of any comment in the thread */
+                commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
         };

--- a/packages/cli/e2e/test.test.ts
+++ b/packages/cli/e2e/test.test.ts
@@ -1,0 +1,234 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, test } from "vitest";
+
+import { getRequiredEnv, run, type CommandError } from "./utils";
+
+const userAccessToken = getRequiredEnv("USER_ACCESS_TOKEN");
+const projectToken = getRequiredEnv("ARGOS_TOKEN");
+const buildNumber = process.env.ARGOS_BUILD_NUMBER || "27748";
+
+const baseEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  HOME: mkdtempSync(join(tmpdir(), "argos-cli-e2e-")),
+  ARGOS_API_BASE_URL: process.env.ARGOS_API_BASE_URL,
+  ARGOS_TOKEN: "",
+  ARGOS_PROJECT: "",
+};
+
+function expectRunToFail(
+  args: string[],
+  overrideEnv?: NodeJS.ProcessEnv,
+): CommandError {
+  try {
+    run(args, { ...baseEnv, ...overrideEnv });
+  } catch (error) {
+    return error as CommandError;
+  }
+  throw new Error(
+    `Expected command to fail: node bin/argos-cli.js ${args.join(" ")}`,
+  );
+}
+
+let projectPath: string;
+/** A test id taken from the seeded build's diffs, when one carries a test. */
+let testId: string | null = null;
+
+beforeAll(() => {
+  const build = JSON.parse(
+    run(["build", "get", buildNumber, "--json"], {
+      ...baseEnv,
+      ARGOS_TOKEN: projectToken,
+    }).stdout,
+  );
+  const match = build.url.match(
+    /app\.argos-ci\.(?:com|dev(?::\d+)?)\/([^/?#]+)\/([^/?#]+)\/builds\//,
+  );
+  if (!match) {
+    throw new Error(`Could not parse project from build URL: ${build.url}`);
+  }
+  projectPath = `${match[1]}/${match[2]}`;
+
+  const diffs = JSON.parse(
+    run(["build", "snapshots", buildNumber, "--json"], {
+      ...baseEnv,
+      ARGOS_TOKEN: projectToken,
+    }).stdout,
+  );
+  testId =
+    diffs.find((diff: { test?: { id: string } | null }) => diff.test)?.test
+      .id ?? null;
+});
+
+describe("argos test get", () => {
+  test("fails when no token is provided", () => {
+    const error = expectRunToFail(["test", "get", "PROJECT-abc"]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("No Argos token found");
+  });
+
+  test("rejects an invalid --metrics-period value", () => {
+    const error = expectRunToFail([
+      "test",
+      "get",
+      "PROJECT-abc",
+      "--token",
+      projectToken,
+      "--metrics-period",
+      "5y",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("Allowed choices are 24h, 3d, 7d, 30d, 90d");
+  });
+
+  test("returns the test and its flakiness metrics in JSON mode", () => {
+    if (!testId) {
+      console.warn(
+        `Build #${buildNumber} has no diff carrying a test; skipping.`,
+      );
+      return;
+    }
+
+    const result = JSON.parse(
+      run(["test", "get", testId, "--token", projectToken, "--json"], baseEnv)
+        .stdout,
+    );
+    expect(result.id).toBe(testId);
+    expect(typeof result.name).toBe("string");
+    expect(["ongoing", "removed"]).toContain(result.status);
+    expect(typeof result.metrics.flakiness).toBe("number");
+    expect(Array.isArray(result.series)).toBe(true);
+  });
+
+  test("prints human-readable test output", () => {
+    if (!testId) {
+      console.warn(
+        `Build #${buildNumber} has no diff carrying a test; skipping.`,
+      );
+      return;
+    }
+
+    const output = run(
+      ["test", "get", testId, "--token", projectToken],
+      baseEnv,
+    );
+    expect(output.stdout).toContain(`Test ${testId}`);
+    expect(output.stdout).toContain("Flakiness:");
+  });
+});
+
+describe("argos test changes", () => {
+  test("rejects an invalid --ignored value", () => {
+    const error = expectRunToFail([
+      "test",
+      "changes",
+      "PROJECT-abc",
+      "--token",
+      projectToken,
+      "--ignored",
+      "maybe",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("Allowed choices are true, false");
+  });
+
+  test("lists the test's changes in JSON mode", () => {
+    if (!testId) {
+      console.warn(
+        `Build #${buildNumber} has no diff carrying a test; skipping.`,
+      );
+      return;
+    }
+
+    const changes = JSON.parse(
+      run(
+        ["test", "changes", testId, "--token", projectToken, "--json"],
+        baseEnv,
+      ).stdout,
+    );
+    expect(Array.isArray(changes)).toBe(true);
+    for (const change of changes) {
+      expect(typeof change.id).toBe("string");
+      expect(typeof change.ignored).toBe("boolean");
+      expect(typeof change.occurrences).toBe("number");
+      expect(typeof change.firstSeen.buildNumber).toBe("number");
+      expect(typeof change.lastSeen.buildNumber).toBe("number");
+      expect(typeof change.diff.status).toBe("string");
+    }
+  });
+});
+
+describe("argos test comment", () => {
+  test("fails when no project is provided", () => {
+    const error = expectRunToFail([
+      "test",
+      "comment",
+      "list",
+      "PROJECT-abc",
+      "--token",
+      userAccessToken,
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr).toContain("--project <owner/project> is required");
+  });
+
+  test("posts, edits and deletes a comment on a test", () => {
+    if (!testId) {
+      console.warn(
+        `Build #${buildNumber} has no diff carrying a test; skipping.`,
+      );
+      return;
+    }
+
+    const withAuth = (args: string[]) => [
+      ...args,
+      "--token",
+      userAccessToken,
+      "--project",
+      projectPath,
+      "--json",
+    ];
+
+    const created = JSON.parse(
+      run(
+        withAuth([
+          "test",
+          "comment",
+          "create",
+          testId,
+          "--body",
+          "Posted by the CLI e2e suite.",
+        ]),
+        baseEnv,
+      ).stdout,
+    );
+    expect(created.text).toContain("Posted by the CLI e2e suite.");
+
+    const listed = JSON.parse(
+      run(withAuth(["test", "comment", "list", testId]), baseEnv).stdout,
+    );
+    expect(
+      listed.some((comment: { id: string }) => comment.id === created.id),
+    ).toBe(true);
+
+    const edited = JSON.parse(
+      run(
+        withAuth([
+          "test",
+          "comment",
+          "edit",
+          testId,
+          created.id,
+          "--body",
+          "Edited by the CLI e2e suite.",
+        ]),
+        baseEnv,
+      ).stdout,
+    );
+    expect(edited.text).toContain("Edited by the CLI e2e suite.");
+
+    // Leave the test clean: the suite runs against a shared project.
+    run(withAuth(["test", "comment", "delete", testId, created.id]), baseEnv);
+  });
+});

--- a/packages/cli/src/commands/change/_action.ts
+++ b/packages/cli/src/commands/change/_action.ts
@@ -53,8 +53,10 @@ export function defineChangeAction(opts: {
           options: BaseCommandOptions & MetricsPeriodOption,
         ) => {
           try {
-            const { client, owner, project } =
-              await resolveProjectTarget(options);
+            const { client, owner, project } = await resolveProjectTarget(
+              options,
+              { auth: "user" },
+            );
             const result = await opts.perform({
               client,
               owner,

--- a/packages/cli/src/commands/test/changes.ts
+++ b/packages/cli/src/commands/test/changes.ts
@@ -1,0 +1,99 @@
+import { Option, type Command } from "commander";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { unwrap } from "../../lib/api";
+import { formatTestChanges } from "../../lib/format";
+import { handleCliError, output, type BaseCommandOptions } from "../../lib/run";
+import { resolveProjectTarget, type ProjectTarget } from "../../lib/target";
+import {
+  jsonOption,
+  metricsPeriodOption,
+  testProjectPathOption,
+  toMetricsPeriod,
+  tokenOption,
+  type MetricsPeriod,
+  type MetricsPeriodOption,
+} from "../../options";
+
+type TestChange = ArgosAPISchema.components["schemas"]["TestChange"];
+
+const PER_PAGE = 100;
+
+/** The two values the API's `ignored` filter accepts. */
+type IgnoredFilter = "true" | "false";
+
+const IGNORED_CHOICES = ["true", "false"] as const satisfies IgnoredFilter[];
+
+const ignoredOption = new Option(
+  "--ignored <boolean>",
+  "Only the changes currently ignored (`true`) or only the ones still under review (`false`)",
+).choices(IGNORED_CHOICES);
+
+/** Fetch every change of a test, following pagination. */
+async function fetchAllChanges(
+  target: ProjectTarget,
+  testId: string,
+  options: {
+    metricsPeriod: MetricsPeriod;
+    ignored?: IgnoredFilter | undefined;
+  },
+): Promise<TestChange[]> {
+  const { client, owner, project } = target;
+  const results: TestChange[] = [];
+  for (let page = 1; ; page++) {
+    const data = unwrap(
+      await client.GET("/projects/{owner}/{project}/tests/{testId}/changes", {
+        params: {
+          path: { owner, project, testId },
+          query: {
+            page: String(page),
+            perPage: String(PER_PAGE),
+            metricsPeriod: options.metricsPeriod,
+            ...(options.ignored ? { ignored: options.ignored } : {}),
+          },
+        },
+      }),
+    );
+    results.push(...data.results);
+    if (results.length >= data.pageInfo.total || data.results.length === 0) {
+      break;
+    }
+  }
+  return results;
+}
+
+export function registerTestChanges(test: Command) {
+  test
+    .command("changes")
+    .description(
+      "List the distinct changes a test produced over a period, most frequent first",
+    )
+    .argument(
+      "<testId>",
+      "Test ID, taken from a diff's `test.id` (see `argos build snapshots`)",
+    )
+    .addOption(ignoredOption)
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(metricsPeriodOption)
+    .addOption(jsonOption)
+    .action(
+      async (
+        testId: string,
+        options: BaseCommandOptions &
+          MetricsPeriodOption & { ignored?: IgnoredFilter },
+      ) => {
+        try {
+          const target = await resolveProjectTarget(options, {
+            auth: "project",
+          });
+          const changes = await fetchAllChanges(target, testId, {
+            metricsPeriod: toMetricsPeriod(options.metricsPeriod),
+            ignored: options.ignored,
+          });
+          output(changes, options, formatTestChanges);
+        } catch (error) {
+          handleCliError(error, "project");
+        }
+      },
+    );
+}

--- a/packages/cli/src/commands/test/comment/_action.ts
+++ b/packages/cli/src/commands/test/comment/_action.ts
@@ -1,0 +1,71 @@
+import type { Command } from "commander";
+import type { ArgosAPIClient, ArgosAPISchema } from "@argos-ci/api-client";
+import { formatComment } from "../../../lib/format";
+import {
+  handleCliError,
+  output,
+  type BaseCommandOptions,
+} from "../../../lib/run";
+import { resolveProjectTarget } from "../../../lib/target";
+import {
+  jsonOption,
+  testProjectPathOption,
+  tokenOption,
+} from "../../../options";
+
+type Comment = ArgosAPISchema.components["schemas"]["Comment"];
+
+export type TestCommentActionContext = {
+  client: ArgosAPIClient;
+  owner: string;
+  project: string;
+  testId: string;
+  commentId: string;
+};
+
+/**
+ * Register a `test comment <name> <testId> <commentId>` command that runs
+ * `perform` and prints the returned comment. Used for the single-comment actions
+ * that share the same shape (get, delete, resolve, subscribe, …), mirroring
+ * `defineCommentAction` on the build side.
+ */
+export function defineTestCommentAction(opts: {
+  name: string;
+  description: string;
+  perform: (ctx: TestCommentActionContext) => Promise<Comment>;
+}) {
+  return (comment: Command) => {
+    comment
+      .command(opts.name)
+      .description(opts.description)
+      .argument("<testId>", "Test ID, taken from a diff's `test.id`")
+      .argument("<commentId>", "ID of the comment")
+      .addOption(tokenOption)
+      .addOption(testProjectPathOption)
+      .addOption(jsonOption)
+      .action(
+        async (
+          testId: string,
+          commentId: string,
+          options: BaseCommandOptions,
+        ) => {
+          try {
+            const { client, owner, project } = await resolveProjectTarget(
+              options,
+              { auth: "user" },
+            );
+            const result = await opts.perform({
+              client,
+              owner,
+              project,
+              testId,
+              commentId,
+            });
+            output(result, options, formatComment);
+          } catch (error) {
+            handleCliError(error, "user");
+          }
+        },
+      );
+  };
+}

--- a/packages/cli/src/commands/test/comment/create.ts
+++ b/packages/cli/src/commands/test/comment/create.ts
@@ -1,0 +1,57 @@
+import type { Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { resolveBody } from "../../../lib/body";
+import { formatComment } from "../../../lib/format";
+import {
+  handleCliError,
+  output,
+  type BaseCommandOptions,
+} from "../../../lib/run";
+import { resolveProjectTarget } from "../../../lib/target";
+import {
+  jsonOption,
+  testProjectPathOption,
+  tokenOption,
+} from "../../../options";
+
+type TestCommentCreateOptions = BaseCommandOptions & {
+  body?: string;
+  bodyFile?: string;
+  replyTo?: string;
+};
+
+export function registerTestCommentCreate(comment: Command) {
+  comment
+    .command("create")
+    .description("Post a comment (or reply) on a test")
+    .argument("<testId>", "Test ID, taken from a diff's `test.id`")
+    .option("--body <markdown>", "Markdown body of the comment")
+    .option("--body-file <path>", "Read the comment body from a Markdown file")
+    .option(
+      "--reply-to <threadId>",
+      "Reply to an existing thread (its root comment ID)",
+    )
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(jsonOption)
+    .action(async (testId: string, options: TestCommentCreateOptions) => {
+      try {
+        const { client, owner, project } = await resolveProjectTarget(options, {
+          auth: "user",
+        });
+        const body = await resolveBody(options, { required: true });
+        const result = unwrap(
+          await client.POST(
+            "/projects/{owner}/{project}/tests/{testId}/comments",
+            {
+              params: { path: { owner, project, testId } },
+              body: { body: body as string, threadId: options.replyTo },
+            },
+          ),
+        );
+        output(result, options, formatComment);
+      } catch (error) {
+        handleCliError(error, "user");
+      }
+    });
+}

--- a/packages/cli/src/commands/test/comment/delete.ts
+++ b/packages/cli/src/commands/test/comment/delete.ts
@@ -1,0 +1,14 @@
+import { unwrap } from "../../../lib/api";
+import { defineTestCommentAction } from "./_action";
+
+export const registerTestCommentDelete = defineTestCommentAction({
+  name: "delete",
+  description: "Delete a comment on a test (author or project admin)",
+  perform: async ({ client, owner, project, testId, commentId }) =>
+    unwrap(
+      await client.DELETE(
+        "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}",
+        { params: { path: { owner, project, testId, commentId } } },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/test/comment/edit.ts
+++ b/packages/cli/src/commands/test/comment/edit.ts
@@ -1,0 +1,60 @@
+import type { Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { resolveBody } from "../../../lib/body";
+import { formatComment } from "../../../lib/format";
+import {
+  handleCliError,
+  output,
+  type BaseCommandOptions,
+} from "../../../lib/run";
+import { resolveProjectTarget } from "../../../lib/target";
+import {
+  jsonOption,
+  testProjectPathOption,
+  tokenOption,
+} from "../../../options";
+
+type TestCommentEditOptions = BaseCommandOptions & {
+  body?: string;
+  bodyFile?: string;
+};
+
+export function registerTestCommentEdit(comment: Command) {
+  comment
+    .command("edit")
+    .description("Update the body of a comment on a test (author only)")
+    .argument("<testId>", "Test ID, taken from a diff's `test.id`")
+    .argument("<commentId>", "ID of the comment")
+    .option("--body <markdown>", "New Markdown body of the comment")
+    .option("--body-file <path>", "Read the new body from a Markdown file")
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(jsonOption)
+    .action(
+      async (
+        testId: string,
+        commentId: string,
+        options: TestCommentEditOptions,
+      ) => {
+        try {
+          const { client, owner, project } = await resolveProjectTarget(
+            options,
+            { auth: "user" },
+          );
+          const body = await resolveBody(options, { required: true });
+          const result = unwrap(
+            await client.PATCH(
+              "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}",
+              {
+                params: { path: { owner, project, testId, commentId } },
+                body: { body: body as string },
+              },
+            ),
+          );
+          output(result, options, formatComment);
+        } catch (error) {
+          handleCliError(error, "user");
+        }
+      },
+    );
+}

--- a/packages/cli/src/commands/test/comment/get.ts
+++ b/packages/cli/src/commands/test/comment/get.ts
@@ -1,0 +1,14 @@
+import { unwrap } from "../../../lib/api";
+import { defineTestCommentAction } from "./_action";
+
+export const registerTestCommentGet = defineTestCommentAction({
+  name: "get",
+  description: "Fetch a single comment on a test",
+  perform: async ({ client, owner, project, testId, commentId }) =>
+    unwrap(
+      await client.GET(
+        "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}",
+        { params: { path: { owner, project, testId, commentId } } },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/test/comment/index.ts
+++ b/packages/cli/src/commands/test/comment/index.ts
@@ -1,0 +1,29 @@
+import type { Command } from "commander";
+import { registerTestCommentCreate } from "./create";
+import { registerTestCommentDelete } from "./delete";
+import { registerTestCommentEdit } from "./edit";
+import { registerTestCommentGet } from "./get";
+import { registerTestCommentList } from "./list";
+import { registerTestCommentReact } from "./react";
+import { registerTestCommentResolve } from "./resolve";
+import { registerTestCommentSubscribe } from "./subscribe";
+import { registerTestCommentUnreact } from "./unreact";
+import { registerTestCommentUnresolve } from "./unresolve";
+import { registerTestCommentUnsubscribe } from "./unsubscribe";
+
+export function registerTestComment(test: Command) {
+  const comment = test
+    .command("comment")
+    .description("List, post, and act on comments left on a test");
+  registerTestCommentList(comment);
+  registerTestCommentCreate(comment);
+  registerTestCommentGet(comment);
+  registerTestCommentEdit(comment);
+  registerTestCommentDelete(comment);
+  registerTestCommentResolve(comment);
+  registerTestCommentUnresolve(comment);
+  registerTestCommentReact(comment);
+  registerTestCommentUnreact(comment);
+  registerTestCommentSubscribe(comment);
+  registerTestCommentUnsubscribe(comment);
+}

--- a/packages/cli/src/commands/test/comment/list.ts
+++ b/packages/cli/src/commands/test/comment/list.ts
@@ -1,0 +1,40 @@
+import type { Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { formatComments } from "../../../lib/format";
+import {
+  handleCliError,
+  output,
+  type BaseCommandOptions,
+} from "../../../lib/run";
+import { resolveProjectTarget } from "../../../lib/target";
+import {
+  jsonOption,
+  testProjectPathOption,
+  tokenOption,
+} from "../../../options";
+
+export function registerTestCommentList(comment: Command) {
+  comment
+    .command("list")
+    .description("List the comments on a test")
+    .argument("<testId>", "Test ID, taken from a diff's `test.id`")
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(jsonOption)
+    .action(async (testId: string, options: BaseCommandOptions) => {
+      try {
+        const { client, owner, project } = await resolveProjectTarget(options, {
+          auth: "user",
+        });
+        const result = unwrap(
+          await client.GET(
+            "/projects/{owner}/{project}/tests/{testId}/comments",
+            { params: { path: { owner, project, testId } } },
+          ),
+        );
+        output(result, options, formatComments);
+      } catch (error) {
+        handleCliError(error, "user");
+      }
+    });
+}

--- a/packages/cli/src/commands/test/comment/react.ts
+++ b/packages/cli/src/commands/test/comment/react.ts
@@ -1,0 +1,53 @@
+import type { Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { formatComment } from "../../../lib/format";
+import {
+  handleCliError,
+  output,
+  type BaseCommandOptions,
+} from "../../../lib/run";
+import { resolveProjectTarget } from "../../../lib/target";
+import {
+  jsonOption,
+  testProjectPathOption,
+  tokenOption,
+} from "../../../options";
+
+export function registerTestCommentReact(comment: Command) {
+  comment
+    .command("react")
+    .description("Add an emoji reaction to a comment on a test")
+    .argument("<testId>", "Test ID, taken from a diff's `test.id`")
+    .argument("<commentId>", "ID of the comment")
+    .argument("<emoji>", "Emoji to react with")
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(jsonOption)
+    .action(
+      async (
+        testId: string,
+        commentId: string,
+        emoji: string,
+        options: BaseCommandOptions,
+      ) => {
+        try {
+          const { client, owner, project } = await resolveProjectTarget(
+            options,
+            { auth: "user" },
+          );
+          const result = unwrap(
+            await client.POST(
+              "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/reactions",
+              {
+                params: { path: { owner, project, testId, commentId } },
+                body: { emoji },
+              },
+            ),
+          );
+          output(result, options, formatComment);
+        } catch (error) {
+          handleCliError(error, "user");
+        }
+      },
+    );
+}

--- a/packages/cli/src/commands/test/comment/resolve.ts
+++ b/packages/cli/src/commands/test/comment/resolve.ts
@@ -1,0 +1,14 @@
+import { unwrap } from "../../../lib/api";
+import { defineTestCommentAction } from "./_action";
+
+export const registerTestCommentResolve = defineTestCommentAction({
+  name: "resolve",
+  description: "Mark a comment thread on a test as resolved",
+  perform: async ({ client, owner, project, testId, commentId }) =>
+    unwrap(
+      await client.POST(
+        "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/resolve",
+        { params: { path: { owner, project, testId, commentId } } },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/test/comment/subscribe.ts
+++ b/packages/cli/src/commands/test/comment/subscribe.ts
@@ -1,0 +1,14 @@
+import { unwrap } from "../../../lib/api";
+import { defineTestCommentAction } from "./_action";
+
+export const registerTestCommentSubscribe = defineTestCommentAction({
+  name: "subscribe",
+  description: "Follow a comment thread on a test to get notified of replies",
+  perform: async ({ client, owner, project, testId, commentId }) =>
+    unwrap(
+      await client.POST(
+        "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/subscription",
+        { params: { path: { owner, project, testId, commentId } } },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/test/comment/unreact.ts
+++ b/packages/cli/src/commands/test/comment/unreact.ts
@@ -1,0 +1,55 @@
+import type { Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { formatComment } from "../../../lib/format";
+import {
+  handleCliError,
+  output,
+  type BaseCommandOptions,
+} from "../../../lib/run";
+import { resolveProjectTarget } from "../../../lib/target";
+import {
+  jsonOption,
+  testProjectPathOption,
+  tokenOption,
+} from "../../../options";
+
+export function registerTestCommentUnreact(comment: Command) {
+  comment
+    .command("unreact")
+    .description("Remove your emoji reaction from a comment on a test")
+    .argument("<testId>", "Test ID, taken from a diff's `test.id`")
+    .argument("<commentId>", "ID of the comment")
+    .argument("<emoji>", "Emoji to react with")
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(jsonOption)
+    .action(
+      async (
+        testId: string,
+        commentId: string,
+        emoji: string,
+        options: BaseCommandOptions,
+      ) => {
+        try {
+          const { client, owner, project } = await resolveProjectTarget(
+            options,
+            { auth: "user" },
+          );
+          const result = unwrap(
+            await client.DELETE(
+              "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/reactions",
+              {
+                params: {
+                  path: { owner, project, testId, commentId },
+                  query: { emoji },
+                },
+              },
+            ),
+          );
+          output(result, options, formatComment);
+        } catch (error) {
+          handleCliError(error, "user");
+        }
+      },
+    );
+}

--- a/packages/cli/src/commands/test/comment/unresolve.ts
+++ b/packages/cli/src/commands/test/comment/unresolve.ts
@@ -1,0 +1,14 @@
+import { unwrap } from "../../../lib/api";
+import { defineTestCommentAction } from "./_action";
+
+export const registerTestCommentUnresolve = defineTestCommentAction({
+  name: "unresolve",
+  description: "Reopen a resolved comment thread on a test",
+  perform: async ({ client, owner, project, testId, commentId }) =>
+    unwrap(
+      await client.POST(
+        "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/unresolve",
+        { params: { path: { owner, project, testId, commentId } } },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/test/comment/unsubscribe.ts
+++ b/packages/cli/src/commands/test/comment/unsubscribe.ts
@@ -1,0 +1,14 @@
+import { unwrap } from "../../../lib/api";
+import { defineTestCommentAction } from "./_action";
+
+export const registerTestCommentUnsubscribe = defineTestCommentAction({
+  name: "unsubscribe",
+  description: "Stop following a comment thread on a test",
+  perform: async ({ client, owner, project, testId, commentId }) =>
+    unwrap(
+      await client.DELETE(
+        "/projects/{owner}/{project}/tests/{testId}/comments/{commentId}/subscription",
+        { params: { path: { owner, project, testId, commentId } } },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/test/get.ts
+++ b/packages/cli/src/commands/test/get.ts
@@ -1,0 +1,53 @@
+import type { Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatTest } from "../../lib/format";
+import { handleCliError, output, type BaseCommandOptions } from "../../lib/run";
+import { resolveProjectTarget } from "../../lib/target";
+import {
+  jsonOption,
+  metricsPeriodOption,
+  testProjectPathOption,
+  toMetricsPeriod,
+  tokenOption,
+  type MetricsPeriodOption,
+} from "../../options";
+
+export function registerTestGet(test: Command) {
+  test
+    .command("get")
+    .description("Fetch a test and its flakiness metrics")
+    .argument(
+      "<testId>",
+      "Test ID, taken from a diff's `test.id` (see `argos build snapshots`)",
+    )
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(metricsPeriodOption)
+    .addOption(jsonOption)
+    .action(
+      async (
+        testId: string,
+        options: BaseCommandOptions & MetricsPeriodOption,
+      ) => {
+        try {
+          const { client, owner, project } = await resolveProjectTarget(
+            options,
+            { auth: "project" },
+          );
+          const result = unwrap(
+            await client.GET("/projects/{owner}/{project}/tests/{testId}", {
+              params: {
+                path: { owner, project, testId },
+                query: {
+                  metricsPeriod: toMetricsPeriod(options.metricsPeriod),
+                },
+              },
+            }),
+          );
+          output(result, options, formatTest);
+        } catch (error) {
+          handleCliError(error, "project");
+        }
+      },
+    );
+}

--- a/packages/cli/src/commands/test/index.ts
+++ b/packages/cli/src/commands/test/index.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+import { registerTestChanges } from "./changes";
+import { registerTestComment } from "./comment";
+import { registerTestGet } from "./get";
+
+export function testCommand(program: Command) {
+  const test = program
+    .command("test")
+    .description(
+      "Inspect a test's flakiness and the changes that keep coming back",
+    );
+  registerTestGet(test);
+  registerTestChanges(test);
+  registerTestComment(test);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { whoamiCommand } from "./commands/whoami";
 import { createProjectCommand } from "./commands/create-project";
 import { analyticsCommand } from "./commands/analytics";
 import { changeCommand } from "./commands/change";
+import { testCommand } from "./commands/test";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -41,6 +42,7 @@ whoamiCommand(program);
 createProjectCommand(program);
 analyticsCommand(program);
 changeCommand(program);
+testCommand(program);
 
 if (!process.argv.slice(2).length) {
   program.outputHelp();

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -4,6 +4,10 @@ type Build = ArgosAPISchema.components["schemas"]["Build"];
 type SnapshotDiff = ArgosAPISchema.components["schemas"]["SnapshotDiff"];
 type SnapshotDiffStatus = SnapshotDiff["status"];
 type TestMetrics = ArgosAPISchema.components["schemas"]["TestMetrics"];
+type TestDetails = ArgosAPISchema.components["schemas"]["TestDetails"];
+type TestChange = ArgosAPISchema.components["schemas"]["TestChange"];
+type TestChangeOccurrence =
+  ArgosAPISchema.components["schemas"]["TestChangeOccurrence"];
 type Change = ArgosAPISchema.components["schemas"]["Change"];
 type BuildReview = ArgosAPISchema.components["schemas"]["BuildReview"];
 type Comment = ArgosAPISchema.components["schemas"]["Comment"];
@@ -139,6 +143,52 @@ export function formatSnapshots(diffs: SnapshotDiff[], build: Build): string {
     `Summary: ${formatSnapshotSummary(diffs)}`,
     "",
     ...diffs.flatMap((diff) => [...formatSnapshotDiff(diff, build), ""]),
+  ]
+    .slice(0, -1)
+    .join("\n");
+}
+
+/** When and where a change was captured, on one line. */
+function formatOccurrence(occurrence: TestChangeOccurrence): string {
+  return `${occurrence.date} in build #${occurrence.buildNumber}`;
+}
+
+export function formatTest(test: TestDetails): string {
+  const lines = [
+    `Test ${test.id} [${test.status}]`,
+    `Name: ${test.name}`,
+    `Build name: ${test.buildName}`,
+    `Flakiness: ${formatFlakiness(test.metrics)}`,
+    `Builds: ${test.metrics.total}`,
+    `Changes: ${test.metrics.changes} (${test.metrics.uniqueChanges} seen only once)`,
+  ];
+  if (test.firstSeenChange) {
+    lines.push(`First change: ${formatOccurrence(test.firstSeenChange)}`);
+  }
+  if (test.lastSeenChange) {
+    lines.push(`Last change: ${formatOccurrence(test.lastSeenChange)}`);
+  }
+  lines.push(`URL: ${test.url}`);
+  return lines.join("\n");
+}
+
+export function formatTestChanges(changes: TestChange[]): string {
+  if (changes.length === 0) {
+    return "No changes found.";
+  }
+  return [
+    `Changes (${changes.length})`,
+    "",
+    ...changes.flatMap((change) => [
+      `${change.id}${change.ignored ? " [ignored]" : ""}`,
+      `  Occurrences: ${change.occurrences}`,
+      `  First seen: ${formatOccurrence(change.firstSeen)}`,
+      `  Last seen: ${formatOccurrence(change.lastSeen)}`,
+      `  Mask: ${formatValue(change.diff.url)}`,
+      `  Base file: ${formatValue(change.diff.base?.url)}`,
+      `  Head file: ${formatValue(change.diff.head?.url)}`,
+      "",
+    ]),
   ]
     .slice(0, -1)
     .join("\n");

--- a/packages/cli/src/lib/target.ts
+++ b/packages/cli/src/lib/target.ts
@@ -110,16 +110,26 @@ export async function resolveBuildTarget(
  * Resolve a project-scoped command target: an authenticated client and the
  * `owner`/`project` pair every project endpoint needs. The project path comes
  * from `--project owner/project` or the `ARGOS_PROJECT` environment variable.
+ *
+ * With `auth: "project"` a missing project path falls back to the token's own
+ * project, the way {@link resolveBuildTarget} does — that only resolves for a
+ * project token, so read-only commands work out of the box in CI. `auth: "user"`
+ * requires the path, since a personal access token is not bound to a project.
  */
 export async function resolveProjectTarget(
   options: TargetOptions,
+  { auth }: { auth: AuthMode },
 ): Promise<ProjectTarget> {
   const client = createApiClient(await resolveToken(options));
   const projectPath = options.project || process.env["ARGOS_PROJECT"];
-  if (!projectPath) {
+  if (projectPath) {
+    return { client, ...parseProjectPathOrFail(projectPath) };
+  }
+  if (auth === "user") {
     fail(
       "--project <owner/project> is required. Pass it or set ARGOS_PROJECT.",
     );
   }
-  return { client, ...parseProjectPathOrFail(projectPath) };
+  const project = unwrap(await client.GET("/project"));
+  return { client, owner: project.account.slug, project: project.name };
 }

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -44,6 +44,11 @@ export const changeProjectPathOption = new Option(
   "Project the change belongs to, in owner/project format. Also ARGOS_PROJECT",
 );
 
+export const testProjectPathOption = new Option(
+  "--project <owner/project>",
+  "Project the test belongs to, in owner/project format. Also ARGOS_PROJECT. Optional with a project token, which already identifies its project",
+);
+
 /** API values accepted by the `metricsPeriod` query parameter. */
 export type MetricsPeriod =
   | "LAST_24_HOURS"

--- a/skills/argos-cli/SKILL.md
+++ b/skills/argos-cli/SKILL.md
@@ -2,8 +2,9 @@
 name: argos-cli
 description: >
   Operate Argos visual testing from the terminal with the `argos` CLI — inspect
-  builds and snapshot diffs, submit reviews, post comments, ignore flaky test
-  changes, fetch analytics, upload screenshots, and manage CI builds. Use
+  builds and snapshot diffs, submit reviews, post comments, inspect a test's
+  flakiness and its recurring changes, ignore flaky test changes, fetch
+  analytics, upload screenshots, and manage CI builds. Use
   whenever running `argos` commands or working with Argos builds, snapshots,
   flakiness, or visual-regression reviews from a shell, script, or CI pipeline.
   Load before running `argos` — it covers the token model and JSON output
@@ -13,7 +14,7 @@ metadata:
   author: argos-ci
   homepage: https://argos-ci.com
   source: https://github.com/argos-ci/argos-javascript
-argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project owner/project` for build-number refs on review/comment commands and for every `change` command.
+argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project owner/project` for build-number refs on review/comment commands, for every `change` command, and for `test` commands unless the token is a project token.
 ---
 
 # Argos CLI
@@ -35,15 +36,18 @@ A `<buildReference>` is a build number (e.g. `72652`) or a full build URL. With 
 number, add `--project owner/project`; a URL already contains it. A `<changeId>`
 is not a build ref: it comes from a diff's `change.id` and does **not** carry the
 account, so every `change` command needs `--project owner/project` (or
-`ARGOS_PROJECT`).
+`ARGOS_PROJECT`). A `<testId>` comes from a diff's `test.id` and carries the
+project name but not the account, so `test` commands need the same
+`--project`/`ARGOS_PROJECT` — except with a project token, which already
+identifies its own project.
 
 Two token types — pick by command:
 
-| Commands                                                           | Token                       | Resolution order                            |
-| ------------------------------------------------------------------ | --------------------------- | ------------------------------------------- |
-| `build get`, `build snapshots`                                     | Project token               | `--token` › `ARGOS_TOKEN`                   |
-| `review *`, `comment *`, `change *`, `analytics`, `create-project` | Personal access token (PAT) | `--token` › `ARGOS_TOKEN` › `argos login`   |
-| `upload`, `finalize`, `skip`, `deploy`                             | CI / project token          | `--token` › `ARGOS_TOKEN` (or tokenless CI) |
+| Commands                                                                             | Token                       | Resolution order                            |
+| ------------------------------------------------------------------------------------ | --------------------------- | ------------------------------------------- |
+| `build get`, `build snapshots`, `test get`, `test changes`                           | Project token               | `--token` › `ARGOS_TOKEN`                   |
+| `review *`, `comment *`, `test comment *`, `change *`, `analytics`, `create-project` | Personal access token (PAT) | `--token` › `ARGOS_TOKEN` › `argos login`   |
+| `upload`, `finalize`, `skip`, `deploy`                                               | CI / project token          | `--token` › `ARGOS_TOKEN` (or tokenless CI) |
 
 Project tokens read build data but **cannot** review, comment, or ignore
 changes — those need a PAT. If no suitable token is available, ask the user. For
@@ -55,7 +59,8 @@ acting. `argos login` is for interactive humans, not CI.
 - **Inspect** — `build get <ref>` · `build snapshots <ref> [--needs-review] [--metrics-period 24h|3d|7d|30d|90d]`
 - **Review** — `review list <ref>` · `review create <ref> --event <approve|reject|comment> [--body <md>]` · `review dismiss <ref> <reviewId>`
 - **Comment** — `comment list <ref>` · `comment create <ref> --body <md> [--reply-to <id>] [--diff <id>] [--draft]` · `comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <ref> <id>` · `comment react|unreact <ref> <id> <emoji>`
-- **Flakiness** — `change ignore <changeId> --project owner/project` · `change unignore <changeId> --project owner/project`
+- **Flakiness** — `test get <testId>` · `test changes <testId> [--ignored true|false] [--metrics-period …]` · `change ignore <changeId> --project owner/project` · `change unignore <changeId> --project owner/project`
+- **Test comments** — `test comment list|create <testId>` · `test comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <testId> <id>` · `test comment react|unreact <testId> <id> <emoji>`
 - **Account** — `analytics --account <slug>` · `create-project <name> --account <slug>` · `whoami`
 - **CI** — `upload <dir>` · `finalize` · `skip` · `deploy <dir>`
 - **Auth** — `login` · `logout`
@@ -82,6 +87,17 @@ Ignored changes stop requiring review and are auto-approved on future builds:
 ARGOS_TOKEN=<project-token> argos build snapshots <ref> --json   # read each diff's change.id + occurrences
 argos change ignore <changeId> --token <pat> --project owner/project
 # revert: argos change unignore <changeId> --token <pat> --project owner/project
+```
+
+Diagnose a flaky test before deciding whether to fix it or ignore it. `test get`
+reports how flaky it is; `test changes` lists the distinct changes most-frequent
+first, each with the diff, baseline and head image URLs to look at:
+
+```bash
+ARGOS_TOKEN=<project-token> argos test get <testId> --json          # flakiness, stability, consistency, series
+ARGOS_TOKEN=<project-token> argos test changes <testId> --json      # occurrences + diff/base/head URLs per change
+# a change with occurrences > 1 that nothing in the UI explains is flaky:
+argos change ignore <changeId> --token <pat> --project owner/project
 ```
 
 Upload screenshots in CI:


### PR DESCRIPTION
Wraps the Argos API endpoints the CLI had no command for, so a flaky test can be diagnosed from the terminal — or by a coding agent — instead of only from the test page. Companion to ARG-310, which exposes `getTest` / `listTestChanges` in the API and puts a copyable agent prompt on the test page; that prompt points at these commands first.

## New commands

```bash
argos test get <testId>       # flakiness metrics over a period, aggregated + bucketed, first/last change
argos test changes <testId>   # distinct changes, most frequent first, with diff/baseline/head image URLs
argos test comment <verb>     # the eleven verbs the build-scoped `comment` group already has, on a test
```

- `test changes` follows pagination like `build snapshots` does, and `--ignored true|false` narrows the list to ignored or still-reviewable changes.
- `test comment` mirrors `comment`: `list`, `create`, `get`, `edit`, `delete`, `resolve`, `unresolve`, `react`, `unreact`, `subscribe`, `unsubscribe`.

## Auth

`resolveProjectTarget` now takes an explicit auth mode, mirroring `resolveBuildTarget`:

- `test get` / `test changes` are read-only, so a missing `--project` falls back to the token's own project. They work in CI with nothing but `ARGOS_TOKEN`.
- `test comment *` requires `--project owner/project` (or `ARGOS_PROJECT`), since a personal access token is not bound to a single project.

The one existing caller (`change`) is unchanged in behaviour — it just passes `auth: "user"` explicitly now.

## api-client schema

Regenerated, which also picks up the six test-comment paths: they were already merged in the API but had not reached the published spec yet.

## Verification

- `check-types`, `check-format`, `lint` and `test` pass.
- Every new command was run against a local API with seeded data: `test get`, `test changes` (plus `--ignored` and an invalid value), and all eleven comment verbs end to end, along with the no-token / missing-`--project` / unknown-id error paths.
- Added `packages/cli/e2e/test.test.ts` following the existing e2e conventions.

## Follow-up

The command reference in the docs repo (`docs/sdks-reference/argos-command-line-interface-cli.md`) still needs the new sections; `skills/argos-cli/SKILL.md` is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)