### PR TITLE
feat(cli): expose team, project, test and review management

### DIFF
--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4,6 +4,30 @@
  */
 
 export interface paths {
+    "/accounts/{accountSlug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get an account
+         * @description Retrieve an account with its plan and current-period usage. Use it to watch screenshot consumption against the plan before it runs over.
+         */
+        get: operations["getAccount"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update a team's defaults
+         * @description Change the role given to users that join a team through its invite link or a verified email domain. Requires administrator access to the team.
+         */
+        patch: operations["updateAccount"];
+        trace?: never;
+    };
     "/accounts/{accountSlug}/analytics": {
         parameters: {
             query?: never;
@@ -38,6 +62,158 @@ export interface paths {
         get: operations["listProjects"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/accounts/{accountSlug}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a team's members
+         * @description List the members of a team, with their role. Requires administrator access to the team.
+         */
+        get: operations["listAccountMembers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/accounts/{accountSlug}/members/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove a member
+         * @description Remove a user from a team. Requires administrator access to the team. The last member of a team cannot be removed; removing the second-to-last one promotes the remaining member to owner.
+         */
+        delete: operations["removeAccountMember"];
+        options?: never;
+        head?: never;
+        /**
+         * Change a member's role
+         * @description Change the role of an existing team member. Requires administrator access to the team.
+         */
+        patch: operations["setAccountMemberLevel"];
+        trace?: never;
+    };
+    "/accounts/{accountSlug}/invites": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List pending invites
+         * @description List the pending invitations to join a team, most recent first. Requires administrator access to the team.
+         */
+        get: operations["listAccountInvites"];
+        put?: never;
+        /**
+         * Invite members
+         * @description Invite people to a team by email. Each invited address receives an email with a link to join. Re-inviting an address that already has a pending invite refreshes it. Requires administrator access to the team.
+         */
+        post: operations["createAccountInvites"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/accounts/{accountSlug}/invites/{inviteId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Cancel an invite
+         * @description Cancel a pending invitation, invalidating its link. Requires administrator access to the team.
+         */
+        delete: operations["cancelAccountInvite"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/accounts/{accountSlug}/domains": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a team's email domains
+         * @description List the email domains a team is open to. Requires administrator access to the team.
+         */
+        get: operations["listTeamDomains"];
+        put?: never;
+        /**
+         * Open a team to an email domain
+         * @description Add an email domain to a team, so anyone signing up with a verified address on it joins automatically. Requires administrator access to the team, and you must yourself hold a verified address on the domain — a team can only be opened to a domain its administrator demonstrably belongs to. Public email providers are refused.
+         */
+        post: operations["addTeamDomain"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/accounts/{accountSlug}/domains/{domain}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Close a team to an email domain
+         * @description Remove an email domain from a team. New sign-ups on it no longer join automatically; members who already joined stay. Requires administrator access to the team.
+         */
+        delete: operations["removeTeamDomain"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/accounts/{accountSlug}/invite-link/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset the invite link
+         * @description Rotate the team's shared invite link, invalidating the previous one. Anyone holding the old link can no longer use it to join. Requires administrator access to the team.
+         */
+        post: operations["resetAccountInviteLink"];
         delete?: never;
         options?: never;
         head?: never;
@@ -341,6 +517,142 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
+        /**
+         * Update a project
+         * @description Update a project's settings. Only the fields present in the request are changed. Requires administrator access to the project.
+         */
+        patch: operations["updateProject"];
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/automation-rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a project's automation rules
+         * @description List the automation rules of a project, most recent first. Requires administrator access to the project.
+         */
+        get: operations["listAutomationRules"];
+        put?: never;
+        /**
+         * Create an automation rule
+         * @description Create an automation rule on a project. Requires administrator access to the project. Action targets must belong to the project's account.
+         */
+        post: operations["createAutomationRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/automation-rules/{ruleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get an automation rule
+         * @description Retrieve a single automation rule. Requires administrator access to the project.
+         */
+        get: operations["getAutomationRule"];
+        /**
+         * Update an automation rule
+         * @description Replace an automation rule's definition. Requires administrator access to the project. The whole definition is replaced, so send the events, conditions and actions you want the rule to end up with.
+         */
+        put: operations["updateAutomationRule"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/automation-rules/{ruleId}/deactivate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Deactivate an automation rule
+         * @description Stop a rule from firing. Rules are never deleted — a deactivated one keeps its run history, which is what tells you why something fired. Requires administrator access to the project.
+         */
+        post: operations["deactivateAutomationRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/contributors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a project's contributors
+         * @description List the users explicitly granted access to a project, with their level. Team owners and members are not listed — they reach every project through their team role. The authenticated user comes first when they are one of them.
+         */
+        get: operations["listProjectContributors"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/contributors/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Grant a contributor access to a project
+         * @description Grant a user access to a project, or change the level they already hold. Requires administrator access to the project. Only meaningful for team contributors: owners and members already reach every project.
+         */
+        put: operations["setProjectContributor"];
+        post?: never;
+        /**
+         * Revoke a contributor's access
+         * @description Revoke a user's access to a project. Requires administrator access to the project, except when removing yourself — a contributor can always walk away from a project.
+         */
+        delete: operations["removeProjectContributor"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/transfer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Transfer a project
+         * @description Move a project to another account, optionally renaming it. The token must be scoped to both accounts, and the acting user must administer the project as well as the account receiving it.
+         */
+        post: operations["transferProject"];
+        delete?: never;
+        options?: never;
+        head?: never;
         patch?: never;
         trace?: never;
     };
@@ -463,6 +775,82 @@ export interface paths {
          */
         post: operations["createReview"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/builds/{buildNumber}/reviewers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a build's requested reviewers
+         * @description List the users currently requested to review a build.
+         */
+        get: operations["listBuildReviewers"];
+        put?: never;
+        /**
+         * Request reviewers on a build
+         * @description Ask users to review a build. Each newly-requested reviewer is notified. Idempotent: users already requested are left untouched and not notified again. Users without access to the project are ignored, and you cannot request yourself.
+         */
+        post: operations["addBuildReviewers"];
+        /**
+         * Cancel review requests on a build
+         * @description Cancel the review requests standing on a build. Removing a user that was not requested is a no-op.
+         */
+        delete: operations["removeBuildReviewers"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/builds/{buildNumber}/subscription": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Subscribe to a build
+         * @description Start receiving notifications about a build — new comments, reviews, and status changes. Clears a previous explicit unsubscription.
+         */
+        post: operations["subscribeBuild"];
+        /**
+         * Unsubscribe from a build
+         * @description Stop receiving notifications about a build. Recorded as an intentional unsubscription, so Argos will not auto-subscribe you to it again.
+         */
+        delete: operations["unsubscribeBuild"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests/{testId}/subscription": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Subscribe to a test
+         * @description Start receiving notifications about a test — new comments and the changes it produces. Clears a previous explicit unsubscription.
+         */
+        post: operations["subscribeTest"];
+        /**
+         * Unsubscribe from a test
+         * @description Stop receiving notifications about a test. Recorded as an intentional unsubscription, so Argos will not auto-subscribe you to it again.
+         */
+        delete: operations["unsubscribeTest"];
         options?: never;
         head?: never;
         patch?: never;
@@ -623,6 +1011,90 @@ export interface paths {
          * @description Unsubscribe the authenticated user from a build comment thread's notifications.
          */
         delete: operations["unsubscribeBuildCommentThread"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/tests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a project's tests
+         * @description List the tests currently running in a project, flakiest first. A test is listed when it appeared in the latest reference build of its build name — tests that were deleted, renamed or skipped drop out. Use it to find what to stabilise: the first page is the project's flakiness backlog.
+         */
+        get: operations["listTests"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a project's deployments
+         * @description List a project's deployments, most recent first. Use `environment` to keep only the production ones — the deployments that answer "what is live right now?".
+         */
+        get: operations["listProjectDeployments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/domain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a project's deployment domain
+         * @description Retrieve the domain the project's production deployments are served on.
+         */
+        get: operations["getProjectDomain"];
+        /**
+         * Set a project's deployment domain
+         * @description Set the domain the project's production deployments are served on. Requires administrator access to the project. Only domains under the Argos deployments domain are accepted, and reserved slugs are refused.
+         */
+        put: operations["updateProjectDomain"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{owner}/{project}/ignored-changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a project's ignored changes
+         * @description List the changes currently ignored in a project, most recently ignored first. Use it to audit what has been silenced and to unignore anything that should be reviewed again.
+         */
+        get: operations["listIgnoredChanges"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -812,6 +1284,16 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * @description Role given to users that join a team through its invite link or a verified email domain.
+         * @enum {string}
+         */
+        TeamDefaultUserLevel: "member" | "contributor";
+        /**
+         * @description Role of a user on a team. Owners administer the team, members see every project, contributors only the projects they are added to.
+         * @enum {string}
+         */
+        TeamUserLevel: "owner" | "member" | "contributor";
         /** @description SHA1 hash */
         Sha1Hash: string;
         GitBranch: string;
@@ -960,19 +1442,161 @@ export interface components {
             };
         };
         /**
+         * @description When to post the summary check on a pull request: `always`, `never`, or `auto` (only once the project has a baseline).
+         * @enum {string}
+         */
+        SummaryCheck: "always" | "never" | "auto";
+        /**
+         * @description Access level given to team members that are not explicit contributors on the project. `null` means they get no access.
+         * @enum {string}
+         */
+        ProjectUserLevel: "admin" | "reviewer" | "viewer";
+        /** @description How flaky changes are ignored on a project. */
+        IgnoreConfig: {
+            /** @description Whether changes can be ignored on this project. */
+            enabled: boolean;
+            /** @description Auto-ignore settings, `null` when auto-ignore is off. */
+            autoIgnore: {
+                /** @description Number of times a change must reappear before it is ignored automatically. */
+                changes: number;
+            } | null;
+        };
+        /**
+         * @description Who can reach the project's deployments: anyone (`public`), anyone with the domain (`domain-private`), or team members only (`private`, teams only).
+         * @enum {string}
+         */
+        DeploymentAuth: "public" | "domain-private" | "private";
+        /**
+         * @description An event an automation rule can react to.
+         * @enum {string}
+         */
+        AutomationEvent: "build.completed" | "build.reviewed";
+        /** @description A condition narrowing when a rule fires. Conditions are combined with AND; wrap one in `{ not: … }` to negate it, or `{ glob: … }` to match a branch by pattern. */
+        AutomationCondition: (({
+            /** @constant */
+            type: "build-branch";
+            value: string;
+        } | {
+            /** @constant */
+            type: "build-conclusion";
+            value: ("no-changes" | "changes-detected") | null;
+        } | {
+            /** @constant */
+            type: "build-mode";
+            value: ("ci" | "monitoring") | null;
+        } | {
+            /** @constant */
+            type: "build-name";
+            value: string;
+        } | {
+            /** @constant */
+            type: "build-type";
+            value: ("reference" | "check" | "orphan" | "skipped") | null;
+        }) | {
+            glob: {
+                /** @constant */
+                type: "build-branch";
+                value: string;
+            };
+        }) | {
+            not: ({
+                /** @constant */
+                type: "build-branch";
+                value: string;
+            } | {
+                /** @constant */
+                type: "build-conclusion";
+                value: ("no-changes" | "changes-detected") | null;
+            } | {
+                /** @constant */
+                type: "build-mode";
+                value: ("ci" | "monitoring") | null;
+            } | {
+                /** @constant */
+                type: "build-name";
+                value: string;
+            } | {
+                /** @constant */
+                type: "build-type";
+                value: ("reference" | "check" | "orphan" | "skipped") | null;
+            }) | {
+                glob: {
+                    /** @constant */
+                    type: "build-branch";
+                    value: string;
+                };
+            };
+        };
+        /** @description An action to run. Slack channels are addressed by `slackId` when known, otherwise by `name`; Teams and Discord by the id of a webhook registered on the project's account. */
+        AutomationActionInput: {
+            /** @constant */
+            type: "sendSlackMessage";
+            payload: {
+                /** @default  */
+                slackId: string;
+                name: string;
+            };
+        } | {
+            /** @constant */
+            type: "sendMsTeamsMessage";
+            payload: {
+                webhookId: string;
+            };
+        } | {
+            /** @constant */
+            type: "sendDiscordMessage";
+            payload: {
+                webhookId: string;
+            };
+        };
+        /**
          * @description The build number
          * @example 42
          */
         BuildNumber: string;
-        /** @description The ID of the comment */
-        CommentId: string;
-        /** @description ID of any comment in the thread */
-        ThreadCommentId: string;
         /**
          * @description The test identifier, as returned in a diff's `test.id`
          * @example WEB-xf23d
          */
         TestId: string;
+        /** @description The public ID of the comment (e.g. `comment-xf23d`) */
+        CommentId: string;
+        /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
+        ThreadCommentId: string;
+        /** @description An account with its plan and current-period usage, to watch consumption against the plan. */
+        AccountDetails: {
+            id: string;
+            slug: string;
+            name: string | null;
+            /** @enum {string} */
+            type: "user" | "team";
+            /** @description The account's plan, `null` when it has none. */
+            plan: {
+                name: string;
+                includedScreenshots: number;
+            } | null;
+            /** @description Start of the current billing period. */
+            periodStartDate: string | null;
+            /** @description End of the current billing period. */
+            periodEndDate: string | null;
+            /** @description Screenshots used since the start of the current period. */
+            currentPeriodScreenshots: number;
+            /** @description Screenshots included in the plan for a period. */
+            includedScreenshots: number;
+            /** @description Used screenshots over included screenshots. Above `1` the account is over its plan and pays for the extra. */
+            consumptionRatio: number;
+            /** @description Cost accrued so far this period for screenshots beyond the plan, in the subscription's currency. */
+            additionalScreenshotsCost: number;
+            /** @description Role given to users joining through the invite link or a verified domain. `null` on a personal account. */
+            defaultUserLevel: components["schemas"]["TeamDefaultUserLevel"] | null;
+        };
+        /** @description Error response */
+        Error: {
+            error: string;
+            details?: {
+                message: string;
+            }[];
+        };
         AccountAnalytics: {
             screenshots: {
                 series: {
@@ -1027,13 +1651,6 @@ export interface components {
                 }[];
             };
         };
-        /** @description Error response */
-        Error: {
-            error: string;
-            details?: {
-                message: string;
-            }[];
-        };
         /** @description Page information */
         PageInfo: {
             /** @description Total number of items */
@@ -1050,11 +1667,68 @@ export interface components {
             name: string;
             defaultBaseBranch: string;
             hasRemoteContentAccess: boolean;
+            /** @description Glob matching the branches whose builds are approved automatically. */
+            autoApprovedBranchGlob: string;
+            /** @description Glob matching the branches whose deployments are treated as production. */
+            deploymentProductionBranchGlob: string;
+            /** @description Whether the project is private. Resolved from the linked repository unless overridden. */
+            private: boolean;
+            summaryCheck: components["schemas"]["SummaryCheck"];
+            /** @description Whether Argos comments on pull requests. */
+            prCommentEnabled: boolean;
+            /** @description Whether builds can authenticate with a GitHub Actions OIDC token instead of a project token. */
+            githubActionsOidcEnabled: boolean;
+            /** @description Whether builds from forked pull requests can be uploaded without a token. */
+            tokenlessAuthEnabled: boolean;
+            /** @description Whether deployments are served for this project. */
+            deploymentEnabled: boolean;
+            deploymentAuth: components["schemas"]["DeploymentAuth"];
+            defaultUserLevel: components["schemas"]["ProjectUserLevel"] | null;
+            ignoreConfig: components["schemas"]["IgnoreConfigOutput"];
         };
         /** @description Account */
         Account: {
             id: string;
             slug: string;
+        };
+        /** @description A member of a team. */
+        TeamMember: {
+            /** @description Identifier of the membership, not of the user. */
+            id: string;
+            user: components["schemas"]["User"];
+            level: components["schemas"]["TeamUserLevel"];
+        };
+        /** @description A user. */
+        User: {
+            id: string;
+            slug: string;
+            name: string | null;
+        };
+        /** @description A pending invitation to join a team. */
+        TeamInvite: {
+            id: string;
+            /** Format: email */
+            email: string;
+            level: components["schemas"]["TeamUserLevel"];
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            expiresAt: string;
+            /** @description Whether the invite is past its expiry date. Expired invites stay listed until they are cancelled or re-sent. */
+            expired: boolean;
+        };
+        /** @description An email domain the team is open to: anyone signing up with a verified address on it joins automatically, at the team's default role. */
+        TeamDomain: {
+            domain: string;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        InviteLink: {
+            /**
+             * Format: uri
+             * @description The team's new shared invite link. Anyone with it joins at the team's default role.
+             */
+            inviteLink: string;
         };
         /** @description Build */
         Build: {
@@ -1151,6 +1825,33 @@ export interface components {
             name: string | null;
             /** @enum {string} */
             type: "user" | "team";
+        };
+        /** @description A rule that runs actions when a build event matches its conditions. */
+        AutomationRule: {
+            id: string;
+            name: string;
+            /** @description Whether the rule still fires. Deactivated rules keep their run history. */
+            active: boolean;
+            events: components["schemas"]["AutomationEvent"][];
+            conditions: components["schemas"]["AutomationConditionOutput"][];
+            /** @description The actions as stored, with their targets already resolved (a Slack channel id, a webhook id). */
+            actions: {
+                action: string;
+                actionPayload: {
+                    [key: string]: unknown;
+                };
+            }[];
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        /** @description A contributor explicitly granted access to a project. Team owners and members reach every project without appearing here. */
+        ProjectContributor: {
+            /** @description Identifier of the grant, not of the user. */
+            id: string;
+            user: components["schemas"]["User"];
+            level: components["schemas"]["ProjectUserLevel"];
         };
         /** @description Snapshot diff */
         SnapshotDiff: {
@@ -1450,14 +2151,19 @@ export interface components {
             /** @description Date the review was created. */
             date: string;
         };
-        /** @description A user. */
-        User: {
-            id: string;
-            slug: string;
-            name: string | null;
+        /** @description The review requests standing on a build. */
+        BuildReviewers: {
+            /** @description The users currently requested to review the build. */
+            reviewers: components["schemas"]["User"][];
+        };
+        /** @description A notification subscription. */
+        NotificationSubscription: {
+            /** @description Whether the authenticated user now receives notifications for this resource. */
+            subscribed: boolean;
         };
         /** @description A comment posted on a build or on a test. */
         Comment: {
+            /** @description Public ID of the comment (e.g. `comment-xf23d`) — the one the app links to, and the one every endpoint taking a comment ID expects. */
             id: string;
             /** @description Build this comment is posted on, null when it is posted on a test. */
             buildId: string | null;
@@ -1500,6 +2206,24 @@ export interface components {
                 /** @description The users who reacted with this emoji. */
                 users: components["schemas"]["User"][];
             }[];
+        };
+        /** @description A test with its flakiness metrics over the requested period. Fetch the test itself for its history and the changes behind the score. */
+        TestSummary: components["schemas"]["Test"];
+        /** @description A project's production deployment domain. */
+        ProjectDomain: {
+            /** @description The project's production deployment domain, `null` when deployments are disabled or no domain is set. */
+            domain: string | null;
+        };
+        /** @description A change currently ignored in a project: it no longer requires review and is approved automatically. */
+        IgnoredChange: {
+            /** @description Identifier of the ignored change, accepted by the unignore endpoint. */
+            id: string;
+            /** @description The test the ignored change belongs to. */
+            test: {
+                id: string;
+                name: string;
+                buildName: string;
+            };
         };
         /** @description A test with its flakiness metrics, both aggregated and over time, and when it first and last changed. */
         TestDetails: {
@@ -1582,6 +2306,72 @@ export interface components {
             /** @description The diff captured the last time the change was seen, with the baseline and the captured snapshot, so you can look at what moved. */
             diff: components["schemas"]["SnapshotDiff"];
         };
+        /** @description How flaky changes are ignored on a project. */
+        IgnoreConfigOutput: {
+            /** @description Whether changes can be ignored on this project. */
+            enabled: boolean;
+            /** @description Auto-ignore settings, `null` when auto-ignore is off. */
+            autoIgnore: {
+                /** @description Number of times a change must reappear before it is ignored automatically. */
+                changes: number;
+            } | null;
+        };
+        /** @description A condition narrowing when a rule fires. Conditions are combined with AND; wrap one in `{ not: … }` to negate it, or `{ glob: … }` to match a branch by pattern. */
+        AutomationConditionOutput: (({
+            /** @constant */
+            type: "build-branch";
+            value: string;
+        } | {
+            /** @constant */
+            type: "build-conclusion";
+            value: ("no-changes" | "changes-detected") | null;
+        } | {
+            /** @constant */
+            type: "build-mode";
+            value: ("ci" | "monitoring") | null;
+        } | {
+            /** @constant */
+            type: "build-name";
+            value: string;
+        } | {
+            /** @constant */
+            type: "build-type";
+            value: ("reference" | "check" | "orphan" | "skipped") | null;
+        }) | {
+            glob: {
+                /** @constant */
+                type: "build-branch";
+                value: string;
+            };
+        }) | {
+            not: ({
+                /** @constant */
+                type: "build-branch";
+                value: string;
+            } | {
+                /** @constant */
+                type: "build-conclusion";
+                value: ("no-changes" | "changes-detected") | null;
+            } | {
+                /** @constant */
+                type: "build-mode";
+                value: ("ci" | "monitoring") | null;
+            } | {
+                /** @constant */
+                type: "build-name";
+                value: string;
+            } | {
+                /** @constant */
+                type: "build-type";
+                value: ("reference" | "check" | "orphan" | "skipped") | null;
+            }) | {
+                glob: {
+                    /** @constant */
+                    type: "build-branch";
+                    value: string;
+                };
+            };
+        };
     };
     responses: never;
     parameters: never;
@@ -1591,6 +2381,148 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    getAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the account to retrieve. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The account with its plan and usage */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountDetails"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    updateAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    defaultUserLevel: components["schemas"]["TeamDefaultUserLevel"];
+                };
+            };
+        };
+        responses: {
+            /** @description The updated account */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountDetails"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getAccountAnalytics: {
         parameters: {
             query: {
@@ -1699,6 +2631,736 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listAccountMembers: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+                /** @description Match members on their name, slug, or email address. */
+                search?: string;
+                /** @description Restrict to the given roles, comma-separated (e.g. `owner,member`). */
+                levels?: string;
+                /** @description Ordering of the results. Defaults to `date`, most recently added first. */
+                orderBy?: "date" | "name-asc" | "name-desc";
+            };
+            header?: never;
+            path: {
+                /** @description Slug of the team to list members for. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of team members */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["TeamMember"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    removeAccountMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+                /** @description Identifier of the user to act on — the `user.id` returned by `listAccountMembers`, which is the user's account id. */
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Member removed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    setAccountMemberLevel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+                /** @description Identifier of the user to act on — the `user.id` returned by `listAccountMembers`, which is the user's account id. */
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    level: components["schemas"]["TeamUserLevel"];
+                };
+            };
+        };
+        responses: {
+            /** @description The updated membership */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TeamMember"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listAccountInvites: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+                /** @description Match invites on their email address. */
+                search?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of pending invites */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["TeamInvite"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createAccountInvites: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The people to invite. */
+                    members: {
+                        /** Format: email */
+                        email: string;
+                        level: components["schemas"]["TeamUserLevel"];
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description The invites that were created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TeamInvite"][];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    cancelAccountInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+                /** @description Identifier of the invite, as returned when listing them. */
+                inviteId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Invite cancelled */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listTeamDomains: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The team's email domains */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TeamDomain"][];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    addTeamDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The email domain, e.g. `acme.com`. */
+                    domain: string;
+                };
+            };
+        };
+        responses: {
+            /** @description The domain the team is now open to */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TeamDomain"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    removeTeamDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+                /** @description The email domain to remove. */
+                domain: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Domain removed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    resetAccountInviteLink: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Slug of the team. */
+                accountSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The new invite link */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InviteLink"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2803,6 +4465,770 @@ export interface operations {
             };
         };
     };
+    updateProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description New name for the project. Must be unique within the owning account (case-insensitive). */
+                    name?: string;
+                    /** @description Branch used as the baseline when no better one applies. `null` falls back to the repository's default branch. */
+                    defaultBaseBranch?: string | null;
+                    /** @description Glob matching the branches whose builds are approved automatically. `null` falls back to the default base branch. */
+                    autoApprovedBranchGlob?: string | null;
+                    /** @description Glob matching the branches whose deployments count as production. `null` falls back to the repository's default branch. */
+                    deploymentProductionBranchGlob?: string | null;
+                    /** @description Force the project's privacy. `null` inherits it from the linked repository. */
+                    private?: boolean | null;
+                    summaryCheck?: components["schemas"]["SummaryCheck"];
+                    /** @description Access given to team members that are not contributors on this project. `null` gives them none. */
+                    defaultUserLevel?: components["schemas"]["ProjectUserLevel"] | null;
+                    ignoreConfig?: components["schemas"]["IgnoreConfig"];
+                    deploymentEnabled?: boolean;
+                    deploymentAuth?: components["schemas"]["DeploymentAuth"];
+                    githubActionsOidcEnabled?: boolean;
+                    tokenlessAuthEnabled?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description The updated project */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listAutomationRules: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+                /** @description Restrict to rules that still fire (`true`) or to deactivated ones (`false`). Omit for both. */
+                active?: "true" | "false";
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of automation rules */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["AutomationRule"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createAutomationRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name: string;
+                    events: components["schemas"]["AutomationEvent"][];
+                    /** @default [] */
+                    conditions?: components["schemas"]["AutomationCondition"][];
+                    actions: components["schemas"]["AutomationActionInput"][];
+                };
+            };
+        };
+        responses: {
+            /** @description The created rule */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AutomationRule"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getAutomationRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description Identifier of the automation rule. */
+                ruleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The automation rule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AutomationRule"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    updateAutomationRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description Identifier of the automation rule. */
+                ruleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name: string;
+                    events: components["schemas"]["AutomationEvent"][];
+                    /** @default [] */
+                    conditions?: components["schemas"]["AutomationCondition"][];
+                    actions: components["schemas"]["AutomationActionInput"][];
+                };
+            };
+        };
+        responses: {
+            /** @description The updated rule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AutomationRule"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deactivateAutomationRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description Identifier of the automation rule. */
+                ruleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The deactivated rule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AutomationRule"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listProjectContributors: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of contributors */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["ProjectContributor"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    setProjectContributor: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description Identifier of the user — the `user.id` returned by `listAccountMembers` or `listProjectContributors`. */
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    level: components["schemas"]["ProjectUserLevel"];
+                };
+            };
+        };
+        responses: {
+            /** @description The granted access */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectContributor"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    removeProjectContributor: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description Identifier of the user — the `user.id` returned by `listAccountMembers` or `listProjectContributors`. */
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Access revoked */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    transferProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Slug of the account that will own the project. */
+                    targetAccountSlug: string;
+                    /** @description Name to give the project on the target account. Defaults to its current name, which must be free there. */
+                    name?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description The transferred project */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     listBuilds: {
         parameters: {
             query?: {
@@ -3345,6 +5771,510 @@ export interface operations {
             };
         };
     };
+    listBuildReviewers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The build number */
+                buildNumber: components["schemas"]["BuildNumber"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The users requested to review the build */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BuildReviewers"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    addBuildReviewers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The build number */
+                buildNumber: components["schemas"]["BuildNumber"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Identifiers of the users to act on — the `id` of a user as returned by `listBuildReviewers` or `getMe`. */
+                    userIds: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description The users requested to review the build */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BuildReviewers"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    removeBuildReviewers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The build number */
+                buildNumber: components["schemas"]["BuildNumber"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Identifiers of the users to act on — the `id` of a user as returned by `listBuildReviewers` or `getMe`. */
+                    userIds: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description The users still requested to review the build */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BuildReviewers"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    subscribeBuild: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The build number */
+                buildNumber: components["schemas"]["BuildNumber"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscribed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationSubscription"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    unsubscribeBuild: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The build number */
+                buildNumber: components["schemas"]["BuildNumber"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unsubscribed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationSubscription"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    subscribeTest: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscribed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationSubscription"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    unsubscribeTest: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+                /** @description The test identifier, as returned in a diff's `test.id` */
+                testId: components["schemas"]["TestId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unsubscribed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationSubscription"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     dismissReview: {
         parameters: {
             query?: never;
@@ -3506,7 +6436,7 @@ export interface operations {
                     body: string | {
                         [key: string]: unknown;
                     };
-                    /** @description Root comment ID to reply to. */
+                    /** @description Public ID of the root comment to reply to (e.g. `comment-xf23d`). */
                     threadId?: string;
                     /** @description Screenshot diff to anchor the comment to. Required when anchor is set. */
                     screenshotDiffId?: string;
@@ -3593,7 +6523,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -3665,7 +6595,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -3737,7 +6667,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -3818,7 +6748,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -3900,7 +6830,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -3972,7 +6902,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
@@ -4044,7 +6974,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
@@ -4116,7 +7046,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
@@ -4188,7 +7118,7 @@ export interface operations {
                 project: string;
                 /** @description The build number */
                 buildNumber: components["schemas"]["BuildNumber"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
@@ -4224,6 +7154,363 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listTests: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+                /** @description Period over which the test flakiness metrics are computed. */
+                metricsPeriod?: "LAST_24_HOURS" | "LAST_3_DAYS" | "LAST_7_DAYS" | "LAST_30_DAYS" | "LAST_90_DAYS";
+                /** @description Restrict to the tests of a single build name. */
+                buildName?: string;
+                /** @description Match tests on their name. */
+                search?: string;
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of the project's tests, flakiest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["TestSummary"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listProjectDeployments: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+                /** @description Restrict to one environment. */
+                environment?: "preview" | "production";
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of deployments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: {
+                            id: string;
+                            /** @enum {string} */
+                            status: "pending" | "ready" | "error";
+                            /** @enum {string} */
+                            environment: "preview" | "production";
+                            branch: components["schemas"]["GitBranch"];
+                            commitSha: components["schemas"]["Sha256Hash"];
+                            /** Format: uri */
+                            url: string;
+                            createdAt: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getProjectDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The production deployment domain */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectDomain"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    updateProjectDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description The full domain to serve production deployments on, under the Argos deployments domain — e.g. `acme-web.argos-ci.live`.
+                     * @example acme-web.argos-ci.live
+                     */
+                    domain: string;
+                };
+            };
+        };
+        responses: {
+            /** @description The updated production deployment domain */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectDomain"];
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listIgnoredChanges: {
+        parameters: {
+            query?: {
+                /** @description Number of items per page (max 100) */
+                perPage?: string;
+                /** @description Page number */
+                page?: string;
+            };
+            header?: never;
+            path: {
+                owner: string;
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of the project's ignored changes */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pageInfo: components["schemas"]["PageInfo"];
+                        results: components["schemas"]["IgnoredChange"][];
+                    };
+                };
+            };
+            /** @description Invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4477,7 +7764,7 @@ export interface operations {
                     body: string | {
                         [key: string]: unknown;
                     };
-                    /** @description Root comment ID to reply to. */
+                    /** @description Public ID of the root comment to reply to (e.g. `comment-xf23d`). */
                     threadId?: string;
                 };
             };
@@ -4548,7 +7835,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -4620,7 +7907,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -4692,7 +7979,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -4773,7 +8060,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -4855,7 +8142,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description The ID of the comment */
+                /** @description The public ID of the comment (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["CommentId"];
             };
             cookie?: never;
@@ -4927,7 +8214,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
@@ -4999,7 +8286,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
@@ -5071,7 +8358,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;
@@ -5143,7 +8430,7 @@ export interface operations {
                 project: string;
                 /** @description The test identifier, as returned in a diff's `test.id` */
                 testId: components["schemas"]["TestId"];
-                /** @description ID of any comment in the thread */
+                /** @description Public ID of any comment in the thread (e.g. `comment-xf23d`) */
                 commentId: components["schemas"]["ThreadCommentId"];
             };
             cookie?: never;

--- a/packages/cli/src/commands/account/_run.ts
+++ b/packages/cli/src/commands/account/_run.ts
@@ -1,0 +1,31 @@
+import { handleCliError, output } from "../../lib/run";
+import {
+  resolveAccountTarget,
+  type AccountTarget,
+  type AccountTargetOptions,
+} from "../../lib/target";
+
+export type AccountCommandOptions = AccountTargetOptions & {
+  json?: boolean | undefined;
+};
+
+/**
+ * Run an account-scoped command end to end: resolve the account target, run the
+ * handler, print the result, and turn any failure into a clean CLI error.
+ *
+ * Every account endpoint acts as a user, so failures get the personal access
+ * token hint.
+ */
+export async function runAccountAction<T>(opts: {
+  options: AccountCommandOptions;
+  handler: (target: AccountTarget) => Promise<T>;
+  format: (data: T) => string;
+}): Promise<void> {
+  try {
+    const target = await resolveAccountTarget(opts.options);
+    const data = await opts.handler(target);
+    output(data, opts.options, opts.format);
+  } catch (error) {
+    handleCliError(error, "user");
+  }
+}

--- a/packages/cli/src/commands/account/domain/index.ts
+++ b/packages/cli/src/commands/account/domain/index.ts
@@ -1,0 +1,80 @@
+import type { Command } from "commander";
+import { unwrap, unwrapEmpty } from "../../../lib/api";
+import { formatDomain, formatDomains } from "../../../lib/format";
+import { accountSlugOption, jsonOption, tokenOption } from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+export function registerAccountDomain(account: Command) {
+  const domain = account
+    .command("domain")
+    .description(
+      "Manage the email domains a team is open to: anyone signing up with a verified address on one joins automatically",
+    );
+
+  domain
+    .command("list")
+    .description("List the email domains a team is open to")
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: AccountCommandOptions) =>
+      runAccountAction({
+        options,
+        handler: async ({ client, accountSlug }) =>
+          unwrap(
+            await client.GET("/accounts/{accountSlug}/domains", {
+              params: { path: { accountSlug } },
+            }),
+          ),
+        format: formatDomains,
+      }),
+    );
+
+  domain
+    .command("add")
+    .description(
+      "Open a team to an email domain. You must hold a verified address on it; public email providers are refused",
+    )
+    .argument("<domain>", "Email domain, e.g. acme.com")
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((value: string, options: AccountCommandOptions) =>
+      runAccountAction({
+        options,
+        handler: async ({ client, accountSlug }) =>
+          unwrap(
+            await client.POST("/accounts/{accountSlug}/domains", {
+              params: { path: { accountSlug } },
+              body: { domain: value },
+            }),
+          ),
+        format: formatDomain,
+      }),
+    );
+
+  domain
+    .command("remove")
+    .description(
+      "Close a team to an email domain. Members who already joined through it stay",
+    )
+    .argument("<domain>", "Email domain to remove")
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((value: string, options: AccountCommandOptions) =>
+      runAccountAction({
+        options,
+        handler: async ({ client, accountSlug }) => {
+          unwrapEmpty(
+            await client.DELETE("/accounts/{accountSlug}/domains/{domain}", {
+              params: { path: { accountSlug, domain: value } },
+            }),
+          );
+          return { removed: true, domain: value };
+        },
+        format: ({ domain: removed }) =>
+          `Closed the team to ${removed}. Existing members keep their access.`,
+      }),
+    );
+}

--- a/packages/cli/src/commands/account/get.ts
+++ b/packages/cli/src/commands/account/get.ts
@@ -1,0 +1,26 @@
+import type { Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatAccount } from "../../lib/format";
+import { accountSlugOption, jsonOption, tokenOption } from "../../options";
+import { runAccountAction, type AccountCommandOptions } from "./_run";
+
+export function registerAccountGet(account: Command) {
+  account
+    .command("get")
+    .description("Fetch an account with its plan and current-period usage")
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: AccountCommandOptions) =>
+      runAccountAction({
+        options,
+        handler: async ({ client, accountSlug }) =>
+          unwrap(
+            await client.GET("/accounts/{accountSlug}", {
+              params: { path: { accountSlug } },
+            }),
+          ),
+        format: formatAccount,
+      }),
+    );
+}

--- a/packages/cli/src/commands/account/index.ts
+++ b/packages/cli/src/commands/account/index.ts
@@ -1,0 +1,19 @@
+import type { Command } from "commander";
+import { registerAccountDomain } from "./domain";
+import { registerAccountGet } from "./get";
+import { registerAccountInvite } from "./invite";
+import { registerAccountMember } from "./member";
+import { registerAccountUpdate } from "./update";
+
+export function accountCommand(program: Command) {
+  const account = program
+    .command("account")
+    .description(
+      "Inspect an account's plan and usage, and manage a team's members, invites, and email domains",
+    );
+  registerAccountGet(account);
+  registerAccountUpdate(account);
+  registerAccountMember(account);
+  registerAccountInvite(account);
+  registerAccountDomain(account);
+}

--- a/packages/cli/src/commands/account/invite/cancel.ts
+++ b/packages/cli/src/commands/account/invite/cancel.ts
@@ -1,0 +1,28 @@
+import type { Command } from "commander";
+import { unwrapEmpty } from "../../../lib/api";
+import { accountSlugOption, jsonOption, tokenOption } from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+export function registerInviteCancel(invite: Command) {
+  invite
+    .command("cancel")
+    .description("Cancel a pending invite, invalidating its link")
+    .argument("<inviteId>", "Invite ID, taken from `argos account invite list`")
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((inviteId: string, options: AccountCommandOptions) =>
+      runAccountAction({
+        options,
+        handler: async ({ client, accountSlug }) => {
+          unwrapEmpty(
+            await client.DELETE("/accounts/{accountSlug}/invites/{inviteId}", {
+              params: { path: { accountSlug, inviteId } },
+            }),
+          );
+          return { cancelled: true, inviteId };
+        },
+        format: ({ inviteId }) => `Cancelled invite ${inviteId}.`,
+      }),
+    );
+}

--- a/packages/cli/src/commands/account/invite/create.ts
+++ b/packages/cli/src/commands/account/invite/create.ts
@@ -1,0 +1,53 @@
+import { Option, type Command } from "commander";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { unwrap } from "../../../lib/api";
+import { formatInvites } from "../../../lib/format";
+import { accountSlugOption, jsonOption, tokenOption } from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+type TeamUserLevel = ArgosAPISchema.components["schemas"]["TeamUserLevel"];
+
+const TEAM_USER_LEVELS = [
+  "owner",
+  "member",
+  "contributor",
+] as const satisfies TeamUserLevel[];
+
+export function registerInviteCreate(invite: Command) {
+  invite
+    .command("create")
+    .description(
+      "Invite people to a team by email. Re-inviting a pending address refreshes its invite",
+    )
+    .argument("<emails...>", "Email addresses to invite")
+    .addOption(
+      new Option("--level <level>", "Role to give the invited people")
+        .choices(TEAM_USER_LEVELS)
+        .default("member" satisfies TeamUserLevel),
+    )
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(
+      (
+        emails: string[],
+        options: AccountCommandOptions & { level: TeamUserLevel },
+      ) =>
+        runAccountAction({
+          options,
+          handler: async ({ client, accountSlug }) =>
+            unwrap(
+              await client.POST("/accounts/{accountSlug}/invites", {
+                params: { path: { accountSlug } },
+                body: {
+                  members: emails.map((email) => ({
+                    email,
+                    level: options.level,
+                  })),
+                },
+              }),
+            ),
+          format: formatInvites,
+        }),
+    );
+}

--- a/packages/cli/src/commands/account/invite/index.ts
+++ b/packages/cli/src/commands/account/invite/index.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+import { registerInviteCancel } from "./cancel";
+import { registerInviteCreate } from "./create";
+import { registerInviteList } from "./list";
+import { registerInviteResetLink } from "./reset-link";
+
+export function registerAccountInvite(account: Command) {
+  const invite = account
+    .command("invite")
+    .description("Invite people to a team and manage pending invitations");
+  registerInviteList(invite);
+  registerInviteCreate(invite);
+  registerInviteCancel(invite);
+  registerInviteResetLink(invite);
+}

--- a/packages/cli/src/commands/account/invite/list.ts
+++ b/packages/cli/src/commands/account/invite/list.ts
@@ -1,0 +1,47 @@
+import type { Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { formatInvites } from "../../../lib/format";
+import { fetchPages } from "../../../lib/pagination";
+import {
+  accountSlugOption,
+  jsonOption,
+  limitOption,
+  toLimit,
+  tokenOption,
+  type LimitOption,
+} from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+type ListOptions = AccountCommandOptions &
+  LimitOption & { search?: string | undefined };
+
+export function registerInviteList(invite: Command) {
+  invite
+    .command("list")
+    .description("List a team's pending invites, most recent first")
+    .option("--search <query>", "Match invites on their email address")
+    .addOption(limitOption)
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: ListOptions) =>
+      runAccountAction({
+        options,
+        handler: ({ client, accountSlug }) =>
+          fetchPages(toLimit(options.limit), async (pagination) =>
+            unwrap(
+              await client.GET("/accounts/{accountSlug}/invites", {
+                params: {
+                  path: { accountSlug },
+                  query: {
+                    ...pagination,
+                    ...(options.search ? { search: options.search } : {}),
+                  },
+                },
+              }),
+            ),
+          ),
+        format: formatInvites,
+      }),
+    );
+}

--- a/packages/cli/src/commands/account/invite/reset-link.ts
+++ b/packages/cli/src/commands/account/invite/reset-link.ts
@@ -1,0 +1,28 @@
+import type { Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { formatInviteLink } from "../../../lib/format";
+import { accountSlugOption, jsonOption, tokenOption } from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+export function registerInviteResetLink(invite: Command) {
+  invite
+    .command("reset-link")
+    .description(
+      "Rotate the team's shared invite link, invalidating the previous one",
+    )
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: AccountCommandOptions) =>
+      runAccountAction({
+        options,
+        handler: async ({ client, accountSlug }) =>
+          unwrap(
+            await client.POST("/accounts/{accountSlug}/invite-link/reset", {
+              params: { path: { accountSlug } },
+            }),
+          ),
+        format: formatInviteLink,
+      }),
+    );
+}

--- a/packages/cli/src/commands/account/member/index.ts
+++ b/packages/cli/src/commands/account/member/index.ts
@@ -1,0 +1,13 @@
+import type { Command } from "commander";
+import { registerMemberList } from "./list";
+import { registerMemberRemove } from "./remove";
+import { registerMemberSetLevel } from "./set-level";
+
+export function registerAccountMember(account: Command) {
+  const member = account
+    .command("member")
+    .description("List a team's members, change their role, or remove them");
+  registerMemberList(member);
+  registerMemberSetLevel(member);
+  registerMemberRemove(member);
+}

--- a/packages/cli/src/commands/account/member/list.ts
+++ b/packages/cli/src/commands/account/member/list.ts
@@ -1,0 +1,64 @@
+import { Option, type Command } from "commander";
+import { unwrap } from "../../../lib/api";
+import { formatMembers } from "../../../lib/format";
+import { fetchPages } from "../../../lib/pagination";
+import {
+  accountSlugOption,
+  jsonOption,
+  limitOption,
+  toLimit,
+  tokenOption,
+  type LimitOption,
+} from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+const ORDER_BY_CHOICES = ["date", "name-asc", "name-desc"] as const;
+
+type ListOptions = AccountCommandOptions &
+  LimitOption & {
+    search?: string | undefined;
+    levels?: string | undefined;
+    orderBy?: (typeof ORDER_BY_CHOICES)[number] | undefined;
+  };
+
+export function registerMemberList(member: Command) {
+  member
+    .command("list")
+    .description("List a team's members and their roles")
+    .option("--search <query>", "Match members on their name, slug, or email")
+    .option(
+      "--levels <levels>",
+      "Restrict to the given roles, comma-separated (e.g. owner,member)",
+    )
+    .addOption(
+      new Option("--order-by <order>", "Ordering of the results").choices(
+        ORDER_BY_CHOICES,
+      ),
+    )
+    .addOption(limitOption)
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: ListOptions) =>
+      runAccountAction({
+        options,
+        handler: ({ client, accountSlug }) =>
+          fetchPages(toLimit(options.limit), async (pagination) =>
+            unwrap(
+              await client.GET("/accounts/{accountSlug}/members", {
+                params: {
+                  path: { accountSlug },
+                  query: {
+                    ...pagination,
+                    ...(options.search ? { search: options.search } : {}),
+                    ...(options.levels ? { levels: options.levels } : {}),
+                    ...(options.orderBy ? { orderBy: options.orderBy } : {}),
+                  },
+                },
+              }),
+            ),
+          ),
+        format: formatMembers,
+      }),
+    );
+}

--- a/packages/cli/src/commands/account/member/remove.ts
+++ b/packages/cli/src/commands/account/member/remove.ts
@@ -1,0 +1,30 @@
+import type { Command } from "commander";
+import { unwrapEmpty } from "../../../lib/api";
+import { accountSlugOption, jsonOption, tokenOption } from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+export function registerMemberRemove(member: Command) {
+  member
+    .command("remove")
+    .description(
+      "Remove a member from a team. The last member cannot be removed; removing the second-to-last one promotes the survivor to owner",
+    )
+    .argument("<userId>", "User ID, taken from `argos account member list`")
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((userId: string, options: AccountCommandOptions) =>
+      runAccountAction({
+        options,
+        handler: async ({ client, accountSlug }) => {
+          unwrapEmpty(
+            await client.DELETE("/accounts/{accountSlug}/members/{userId}", {
+              params: { path: { accountSlug, userId } },
+            }),
+          );
+          return { removed: true, userId };
+        },
+        format: ({ userId }) => `Removed user ${userId} from the team.`,
+      }),
+    );
+}

--- a/packages/cli/src/commands/account/member/set-level.ts
+++ b/packages/cli/src/commands/account/member/set-level.ts
@@ -1,0 +1,46 @@
+import { Option, type Command } from "commander";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { unwrap } from "../../../lib/api";
+import { formatMember } from "../../../lib/format";
+import { accountSlugOption, jsonOption, tokenOption } from "../../../options";
+import { runAccountAction, type AccountCommandOptions } from "../_run";
+
+type TeamUserLevel = ArgosAPISchema.components["schemas"]["TeamUserLevel"];
+
+const TEAM_USER_LEVELS = [
+  "owner",
+  "member",
+  "contributor",
+] as const satisfies TeamUserLevel[];
+
+export function registerMemberSetLevel(member: Command) {
+  member
+    .command("set-level")
+    .description("Change a team member's role")
+    .argument("<userId>", "User ID, taken from `argos account member list`")
+    .addOption(
+      new Option("--level <level>", "Role to give the member")
+        .choices(TEAM_USER_LEVELS)
+        .makeOptionMandatory(),
+    )
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(
+      (
+        userId: string,
+        options: AccountCommandOptions & { level: TeamUserLevel },
+      ) =>
+        runAccountAction({
+          options,
+          handler: async ({ client, accountSlug }) =>
+            unwrap(
+              await client.PATCH("/accounts/{accountSlug}/members/{userId}", {
+                params: { path: { accountSlug, userId } },
+                body: { level: options.level },
+              }),
+            ),
+          format: formatMember,
+        }),
+    );
+}

--- a/packages/cli/src/commands/account/update.ts
+++ b/packages/cli/src/commands/account/update.ts
@@ -1,0 +1,51 @@
+import { Option, type Command } from "commander";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { unwrap } from "../../lib/api";
+import { formatAccount } from "../../lib/format";
+import { accountSlugOption, jsonOption, tokenOption } from "../../options";
+import { runAccountAction, type AccountCommandOptions } from "./_run";
+
+type TeamDefaultUserLevel =
+  ArgosAPISchema.components["schemas"]["TeamDefaultUserLevel"];
+
+const DEFAULT_USER_LEVELS = [
+  "member",
+  "contributor",
+] as const satisfies TeamDefaultUserLevel[];
+
+export function registerAccountUpdate(account: Command) {
+  account
+    .command("update")
+    .description(
+      "Change the role given to users joining a team through its invite link or a verified email domain",
+    )
+    .addOption(
+      new Option(
+        "--default-user-level <level>",
+        "Role given to users that join the team automatically",
+      )
+        .choices(DEFAULT_USER_LEVELS)
+        .makeOptionMandatory(),
+    )
+    .addOption(accountSlugOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(
+      (
+        options: AccountCommandOptions & {
+          defaultUserLevel: TeamDefaultUserLevel;
+        },
+      ) =>
+        runAccountAction({
+          options,
+          handler: async ({ client, accountSlug }) =>
+            unwrap(
+              await client.PATCH("/accounts/{accountSlug}", {
+                params: { path: { accountSlug } },
+                body: { defaultUserLevel: options.defaultUserLevel },
+              }),
+            ),
+          format: formatAccount,
+        }),
+    );
+}

--- a/packages/cli/src/commands/automation/_definition.ts
+++ b/packages/cli/src/commands/automation/_definition.ts
@@ -1,0 +1,58 @@
+import { readFile } from "node:fs/promises";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { fail } from "../../lib/cli-error";
+
+export type AutomationRuleDefinition = NonNullable<
+  ArgosAPISchema.operations["createAutomationRule"]["requestBody"]
+>["content"]["application/json"];
+
+export type DefinitionOptions = {
+  definition?: string | undefined;
+  definitionFile?: string | undefined;
+};
+
+/**
+ * Resolve an automation rule definition from the mutually-exclusive
+ * `--definition` (inline JSON) and `--definition-file` (path) options.
+ *
+ * The definition is passed through as-is: events, conditions and actions are
+ * validated by the API, which owns their schemas.
+ */
+export async function resolveDefinition(
+  options: DefinitionOptions,
+): Promise<AutomationRuleDefinition> {
+  const { definition, definitionFile } = options;
+
+  if (definition !== undefined && definitionFile !== undefined) {
+    fail("Use either --definition or --definition-file, not both.");
+  }
+
+  let raw: string;
+  if (definition !== undefined) {
+    raw = definition;
+  } else if (definitionFile !== undefined) {
+    try {
+      raw = await readFile(definitionFile, "utf8");
+    } catch (error) {
+      fail(
+        `Failed to read --definition-file "${definitionFile}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  } else {
+    fail(
+      "A rule definition is required. Use --definition <json> or --definition-file <path>.",
+    );
+  }
+
+  try {
+    return JSON.parse(raw) as AutomationRuleDefinition;
+  } catch (error) {
+    fail(
+      `Invalid rule definition JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/packages/cli/src/commands/automation/index.ts
+++ b/packages/cli/src/commands/automation/index.ts
@@ -1,0 +1,186 @@
+import { Option, type Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatAutomationRule, formatAutomationRules } from "../../lib/format";
+import { fetchPages } from "../../lib/pagination";
+import {
+  jsonOption,
+  limitOption,
+  managedProjectPathOption,
+  toLimit,
+  tokenOption,
+  type LimitOption,
+} from "../../options";
+import { runProjectAction, type ProjectCommandOptions } from "../project/_run";
+import { resolveDefinition, type DefinitionOptions } from "./_definition";
+
+const ACTIVE_CHOICES = ["true", "false"] as const;
+
+const definitionOption = new Option(
+  "--definition <json>",
+  "Rule definition as JSON: name, events, conditions, actions",
+);
+
+const definitionFileOption = new Option(
+  "--definition-file <path>",
+  "Read the rule definition from a JSON file",
+);
+
+const EXAMPLE_DEFINITION = `Example definition:
+  {
+    "name": "Notify on regressions",
+    "events": ["build.completed"],
+    "conditions": [{ "type": "build-conclusion", "value": "changes-detected" }],
+    "actions": [{ "type": "sendSlackMessage", "payload": { "name": "argos-alerts" } }]
+  }`;
+
+export function automationCommand(program: Command) {
+  const automation = program
+    .command("automation")
+    .description(
+      "List and manage a project's automation rules — the actions Argos runs when a build event matches",
+    );
+
+  automation
+    .command("list")
+    .description("List a project's automation rules, most recent first")
+    .addOption(
+      new Option(
+        "--active <value>",
+        "Restrict to rules that still fire, or to deactivated ones",
+      ).choices(ACTIVE_CHOICES),
+    )
+    .addOption(limitOption)
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(
+      (
+        options: ProjectCommandOptions &
+          LimitOption & { active?: (typeof ACTIVE_CHOICES)[number] },
+      ) =>
+        runProjectAction({
+          options,
+          auth: "user",
+          handler: ({ client, owner, project }) =>
+            fetchPages(toLimit(options.limit), async (pagination) =>
+              unwrap(
+                await client.GET(
+                  "/projects/{owner}/{project}/automation-rules",
+                  {
+                    params: {
+                      path: { owner, project },
+                      query: {
+                        ...pagination,
+                        ...(options.active ? { active: options.active } : {}),
+                      },
+                    },
+                  },
+                ),
+              ),
+            ),
+          format: formatAutomationRules,
+        }),
+    );
+
+  automation
+    .command("get")
+    .description("Fetch a single automation rule")
+    .argument("<ruleId>", "Rule ID, taken from `argos automation list`")
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((ruleId: string, options: ProjectCommandOptions) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project }) =>
+          unwrap(
+            await client.GET(
+              "/projects/{owner}/{project}/automation-rules/{ruleId}",
+              { params: { path: { owner, project, ruleId } } },
+            ),
+          ),
+        format: formatAutomationRule,
+      }),
+    );
+
+  automation
+    .command("create")
+    .description("Create an automation rule on a project")
+    .addHelpText("after", `\n${EXAMPLE_DEFINITION}\n`)
+    .addOption(definitionOption)
+    .addOption(definitionFileOption)
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: ProjectCommandOptions & DefinitionOptions) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project }) => {
+          const body = await resolveDefinition(options);
+          return unwrap(
+            await client.POST("/projects/{owner}/{project}/automation-rules", {
+              params: { path: { owner, project } },
+              body,
+            }),
+          );
+        },
+        format: formatAutomationRule,
+      }),
+    );
+
+  automation
+    .command("update")
+    .description(
+      "Replace an automation rule's definition. Send the events, conditions and actions you want the rule to end up with",
+    )
+    .argument("<ruleId>", "Rule ID, taken from `argos automation list`")
+    .addHelpText("after", `\n${EXAMPLE_DEFINITION}\n`)
+    .addOption(definitionOption)
+    .addOption(definitionFileOption)
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(
+      (ruleId: string, options: ProjectCommandOptions & DefinitionOptions) =>
+        runProjectAction({
+          options,
+          auth: "user",
+          handler: async ({ client, owner, project }) => {
+            const body = await resolveDefinition(options);
+            return unwrap(
+              await client.PUT(
+                "/projects/{owner}/{project}/automation-rules/{ruleId}",
+                { params: { path: { owner, project, ruleId } }, body },
+              ),
+            );
+          },
+          format: formatAutomationRule,
+        }),
+    );
+
+  automation
+    .command("deactivate")
+    .description(
+      "Stop a rule from firing. Rules are never deleted — a deactivated one keeps its run history",
+    )
+    .argument("<ruleId>", "Rule ID, taken from `argos automation list`")
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((ruleId: string, options: ProjectCommandOptions) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project }) =>
+          unwrap(
+            await client.POST(
+              "/projects/{owner}/{project}/automation-rules/{ruleId}/deactivate",
+              { params: { path: { owner, project, ruleId } } },
+            ),
+          ),
+        format: formatAutomationRule,
+      }),
+    );
+}

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1,9 +1,15 @@
 import type { Command } from "commander";
 import { registerBuildGet } from "./get";
 import { registerBuildSnapshots } from "./snapshots";
+import {
+  registerBuildSubscribe,
+  registerBuildUnsubscribe,
+} from "./subscription";
 
 export function buildCommand(program: Command) {
   const build = program.command("build").description("Inspect Argos builds");
   registerBuildGet(build);
   registerBuildSnapshots(build);
+  registerBuildSubscribe(build);
+  registerBuildUnsubscribe(build);
 }

--- a/packages/cli/src/commands/build/subscription.ts
+++ b/packages/cli/src/commands/build/subscription.ts
@@ -1,0 +1,62 @@
+import type { Command } from "commander";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { unwrap } from "../../lib/api";
+import { formatSubscription } from "../../lib/format";
+import { runBuildAction, type BaseCommandOptions } from "../../lib/run";
+import type { BuildTarget } from "../../lib/target";
+import { jsonOption, projectPathOption, tokenOption } from "../../options";
+
+type NotificationSubscription =
+  ArgosAPISchema.components["schemas"]["NotificationSubscription"];
+
+/** Register `build subscribe` / `build unsubscribe`; both act as a user. */
+function defineBuildSubscription(opts: {
+  name: string;
+  description: string;
+  perform: (target: BuildTarget) => Promise<NotificationSubscription>;
+}) {
+  return (build: Command) => {
+    build
+      .command(opts.name)
+      .description(opts.description)
+      .argument("<buildReference>", "Build number or Argos build URL")
+      .addOption(tokenOption)
+      .addOption(projectPathOption)
+      .addOption(jsonOption)
+      .action((reference: string, options: BaseCommandOptions) =>
+        runBuildAction({
+          reference,
+          options,
+          auth: "user",
+          handler: opts.perform,
+          format: formatSubscription,
+        }),
+      );
+  };
+}
+
+export const registerBuildSubscribe = defineBuildSubscription({
+  name: "subscribe",
+  description:
+    "Subscribe to a build's notifications — new comments, reviews, and status changes",
+  perform: async ({ client, owner, project, buildNumber }) =>
+    unwrap(
+      await client.POST(
+        "/projects/{owner}/{project}/builds/{buildNumber}/subscription",
+        { params: { path: { owner, project, buildNumber } } },
+      ),
+    ),
+});
+
+export const registerBuildUnsubscribe = defineBuildSubscription({
+  name: "unsubscribe",
+  description:
+    "Stop receiving notifications about a build. Argos will not auto-subscribe you to it again",
+  perform: async ({ client, owner, project, buildNumber }) =>
+    unwrap(
+      await client.DELETE(
+        "/projects/{owner}/{project}/builds/{buildNumber}/subscription",
+        { params: { path: { owner, project, buildNumber } } },
+      ),
+    ),
+});

--- a/packages/cli/src/commands/change/index.ts
+++ b/packages/cli/src/commands/change/index.ts
@@ -1,11 +1,13 @@
 import type { Command } from "commander";
 import { registerChangeIgnore } from "./ignore";
+import { registerChangeList } from "./list";
 import { registerChangeUnignore } from "./unignore";
 
 export function changeCommand(program: Command) {
   const change = program
     .command("change")
     .description("Ignore or unignore flaky test changes");
+  registerChangeList(change);
   registerChangeIgnore(change);
   registerChangeUnignore(change);
 }

--- a/packages/cli/src/commands/change/list.ts
+++ b/packages/cli/src/commands/change/list.ts
@@ -1,0 +1,45 @@
+import type { Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatIgnoredChanges } from "../../lib/format";
+import { fetchPages } from "../../lib/pagination";
+import { handleCliError, output, type BaseCommandOptions } from "../../lib/run";
+import { resolveProjectTarget } from "../../lib/target";
+import {
+  changeProjectPathOption,
+  jsonOption,
+  limitOption,
+  toLimit,
+  tokenOption,
+  type LimitOption,
+} from "../../options";
+
+export function registerChangeList(change: Command) {
+  change
+    .command("list")
+    .description(
+      "List the changes currently ignored in a project, most recently ignored first",
+    )
+    .addOption(limitOption)
+    .addOption(tokenOption)
+    .addOption(changeProjectPathOption)
+    .addOption(jsonOption)
+    .action(async (options: BaseCommandOptions & LimitOption) => {
+      try {
+        const { client, owner, project } = await resolveProjectTarget(options, {
+          auth: "project",
+        });
+        const changes = await fetchPages(
+          toLimit(options.limit),
+          async (pagination) =>
+            unwrap(
+              await client.GET("/projects/{owner}/{project}/ignored-changes", {
+                params: { path: { owner, project }, query: pagination },
+              }),
+            ),
+        );
+        output(changes, options, formatIgnoredChanges);
+      } catch (error) {
+        handleCliError(error, "project");
+      }
+    });
+}

--- a/packages/cli/src/commands/create-project.ts
+++ b/packages/cli/src/commands/create-project.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { createApiClient, unwrap } from "../lib/api";
 import { fail } from "../lib/cli-error";
-import { formatProject } from "../lib/format";
+import { formatCreatedProject } from "../lib/format";
 import { handleCliError, output } from "../lib/run";
 import { resolveToken } from "../lib/target";
 import { accountOption, jsonOption, tokenOption } from "../options";
@@ -34,7 +34,7 @@ export function createProjectCommand(program: Command) {
             body: { name, accountSlug },
           }),
         );
-        output(project, options, formatProject);
+        output(project, options, formatCreatedProject);
       } catch (error) {
         handleCliError(error, "user");
       }

--- a/packages/cli/src/commands/project/_run.ts
+++ b/packages/cli/src/commands/project/_run.ts
@@ -1,0 +1,35 @@
+import { handleCliError, output } from "../../lib/run";
+import {
+  resolveProjectTarget,
+  type AuthMode,
+  type ProjectTarget,
+  type TargetOptions,
+} from "../../lib/target";
+
+export type ProjectCommandOptions = TargetOptions & {
+  json?: boolean | undefined;
+};
+
+/**
+ * Run a project-scoped command end to end: resolve the project target, run the
+ * handler, print the result, and turn any failure into a clean CLI error.
+ *
+ * `auth` follows {@link resolveProjectTarget}: `project` lets a project token
+ * fall back to its own project, `user` requires an explicit project path.
+ */
+export async function runProjectAction<T>(opts: {
+  options: ProjectCommandOptions;
+  auth: AuthMode;
+  handler: (target: ProjectTarget) => Promise<T>;
+  format: (data: T) => string;
+}): Promise<void> {
+  try {
+    const target = await resolveProjectTarget(opts.options, {
+      auth: opts.auth,
+    });
+    const data = await opts.handler(target);
+    output(data, opts.options, opts.format);
+  } catch (error) {
+    handleCliError(error, opts.auth);
+  }
+}

--- a/packages/cli/src/commands/project/contributor.ts
+++ b/packages/cli/src/commands/project/contributor.ts
@@ -1,0 +1,122 @@
+import { Option, type Command } from "commander";
+import type { ArgosAPISchema } from "@argos-ci/api-client";
+import { unwrap, unwrapEmpty } from "../../lib/api";
+import { formatContributor, formatContributors } from "../../lib/format";
+import { fetchPages } from "../../lib/pagination";
+import {
+  jsonOption,
+  limitOption,
+  managedProjectPathOption,
+  toLimit,
+  tokenOption,
+  type LimitOption,
+} from "../../options";
+import { runProjectAction, type ProjectCommandOptions } from "./_run";
+
+type ProjectUserLevel =
+  ArgosAPISchema.components["schemas"]["ProjectUserLevel"];
+
+const PROJECT_USER_LEVELS = [
+  "admin",
+  "reviewer",
+  "viewer",
+] as const satisfies ProjectUserLevel[];
+
+export function registerProjectContributor(project: Command) {
+  const contributor = project
+    .command("contributor")
+    .description(
+      "Manage the users explicitly granted access to a project. Team owners and members already reach every project",
+    );
+
+  contributor
+    .command("list")
+    .description("List a project's contributors and their access level")
+    .addOption(limitOption)
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: ProjectCommandOptions & LimitOption) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: ({ client, owner, project: name }) =>
+          fetchPages(toLimit(options.limit), async (pagination) =>
+            unwrap(
+              await client.GET("/projects/{owner}/{project}/contributors", {
+                params: {
+                  path: { owner, project: name },
+                  query: pagination,
+                },
+              }),
+            ),
+          ),
+        format: formatContributors,
+      }),
+    );
+
+  contributor
+    .command("set")
+    .description(
+      "Grant a user access to a project, or change the level they already hold",
+    )
+    .argument(
+      "<userId>",
+      "User ID, taken from `argos account member list` or `argos project contributor list`",
+    )
+    .addOption(
+      new Option("--level <level>", "Access level to grant")
+        .choices(PROJECT_USER_LEVELS)
+        .makeOptionMandatory(),
+    )
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(
+      (
+        userId: string,
+        options: ProjectCommandOptions & { level: ProjectUserLevel },
+      ) =>
+        runProjectAction({
+          options,
+          auth: "user",
+          handler: async ({ client, owner, project: name }) =>
+            unwrap(
+              await client.PUT(
+                "/projects/{owner}/{project}/contributors/{userId}",
+                {
+                  params: { path: { owner, project: name, userId } },
+                  body: { level: options.level },
+                },
+              ),
+            ),
+          format: formatContributor,
+        }),
+    );
+
+  contributor
+    .command("remove")
+    .description(
+      "Revoke a user's access to a project. Removing yourself never needs administrator access",
+    )
+    .argument("<userId>", "User ID of the contributor to remove")
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((userId: string, options: ProjectCommandOptions) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project: name }) => {
+          unwrapEmpty(
+            await client.DELETE(
+              "/projects/{owner}/{project}/contributors/{userId}",
+              { params: { path: { owner, project: name, userId } } },
+            ),
+          );
+          return { removed: true, userId };
+        },
+        format: ({ userId: removed }) => `Revoked access for user ${removed}.`,
+      }),
+    );
+}

--- a/packages/cli/src/commands/project/deployments.ts
+++ b/packages/cli/src/commands/project/deployments.ts
@@ -1,0 +1,59 @@
+import { Option, type Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatDeployments } from "../../lib/format";
+import { fetchPages } from "../../lib/pagination";
+import {
+  jsonOption,
+  limitOption,
+  managedProjectPathOption,
+  toLimit,
+  tokenOption,
+  type LimitOption,
+} from "../../options";
+import { runProjectAction, type ProjectCommandOptions } from "./_run";
+
+const ENVIRONMENTS = ["preview", "production"] as const;
+type Environment = (typeof ENVIRONMENTS)[number];
+
+export function registerProjectDeployments(project: Command) {
+  project
+    .command("deployments")
+    .description("List a project's deployments, most recent first")
+    .addOption(
+      new Option(
+        "--environment <environment>",
+        "Restrict to one environment. Use production to see what is live right now",
+      ).choices(ENVIRONMENTS),
+    )
+    .addOption(limitOption)
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action(
+      (
+        options: ProjectCommandOptions &
+          LimitOption & { environment?: Environment },
+      ) =>
+        runProjectAction({
+          options,
+          auth: "project",
+          handler: ({ client, owner, project: name }) =>
+            fetchPages(toLimit(options.limit), async (pagination) =>
+              unwrap(
+                await client.GET("/projects/{owner}/{project}/deployments", {
+                  params: {
+                    path: { owner, project: name },
+                    query: {
+                      ...pagination,
+                      ...(options.environment
+                        ? { environment: options.environment }
+                        : {}),
+                    },
+                  },
+                }),
+              ),
+            ),
+          format: formatDeployments,
+        }),
+    );
+}

--- a/packages/cli/src/commands/project/domain.ts
+++ b/packages/cli/src/commands/project/domain.ts
@@ -1,0 +1,61 @@
+import type { Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatProjectDomain } from "../../lib/format";
+import {
+  jsonOption,
+  managedProjectPathOption,
+  tokenOption,
+} from "../../options";
+import { runProjectAction, type ProjectCommandOptions } from "./_run";
+
+export function registerProjectDomain(project: Command) {
+  const domain = project
+    .command("domain")
+    .description(
+      "Read or set the domain a project's production deployments are served on",
+    );
+
+  domain
+    .command("get")
+    .description("Get a project's production deployment domain")
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: ProjectCommandOptions) =>
+      runProjectAction({
+        options,
+        auth: "project",
+        handler: async ({ client, owner, project: name }) =>
+          unwrap(
+            await client.GET("/projects/{owner}/{project}/domain", {
+              params: { path: { owner, project: name } },
+            }),
+          ),
+        format: formatProjectDomain,
+      }),
+    );
+
+  domain
+    .command("set")
+    .description(
+      "Set a project's production deployment domain. Only domains under the Argos deployments domain are accepted",
+    )
+    .argument("<domain>", "Full domain, e.g. acme-web.argos-ci.live")
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((value: string, options: ProjectCommandOptions) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project: name }) =>
+          unwrap(
+            await client.PUT("/projects/{owner}/{project}/domain", {
+              params: { path: { owner, project: name } },
+              body: { domain: value },
+            }),
+          ),
+        format: formatProjectDomain,
+      }),
+    );
+}

--- a/packages/cli/src/commands/project/get.ts
+++ b/packages/cli/src/commands/project/get.ts
@@ -1,0 +1,31 @@
+import type { Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatProject } from "../../lib/format";
+import {
+  jsonOption,
+  managedProjectPathOption,
+  tokenOption,
+} from "../../options";
+import { runProjectAction, type ProjectCommandOptions } from "./_run";
+
+export function registerProjectGet(project: Command) {
+  project
+    .command("get")
+    .description("Fetch a project and its settings")
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: ProjectCommandOptions) =>
+      runProjectAction({
+        options,
+        auth: "project",
+        handler: async ({ client, owner, project: name }) =>
+          unwrap(
+            await client.GET("/projects/{owner}/{project}", {
+              params: { path: { owner, project: name } },
+            }),
+          ),
+        format: formatProject,
+      }),
+    );
+}

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -1,0 +1,21 @@
+import type { Command } from "commander";
+import { registerProjectContributor } from "./contributor";
+import { registerProjectDeployments } from "./deployments";
+import { registerProjectDomain } from "./domain";
+import { registerProjectGet } from "./get";
+import { registerProjectTransfer } from "./transfer";
+import { registerProjectUpdate } from "./update";
+
+export function projectCommand(program: Command) {
+  const project = program
+    .command("project")
+    .description(
+      "Inspect and configure a project: settings, contributors, deployments, and its deployment domain",
+    );
+  registerProjectGet(project);
+  registerProjectUpdate(project);
+  registerProjectTransfer(project);
+  registerProjectContributor(project);
+  registerProjectDeployments(project);
+  registerProjectDomain(project);
+}

--- a/packages/cli/src/commands/project/transfer.ts
+++ b/packages/cli/src/commands/project/transfer.ts
@@ -1,0 +1,47 @@
+import { Option, type Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatProject } from "../../lib/format";
+import {
+  jsonOption,
+  managedProjectPathOption,
+  tokenOption,
+} from "../../options";
+import { runProjectAction, type ProjectCommandOptions } from "./_run";
+
+export function registerProjectTransfer(project: Command) {
+  project
+    .command("transfer")
+    .description(
+      "Move a project to another account. You must administer the project and the account receiving it",
+    )
+    .addOption(
+      new Option(
+        "--to <slug>",
+        "Slug of the account that will own the project",
+      ).makeOptionMandatory(),
+    )
+    .option(
+      "--name <name>",
+      "Name to give the project on the target account. Defaults to its current name, which must be free there",
+    )
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: ProjectCommandOptions & { to: string; name?: string }) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project: name }) =>
+          unwrap(
+            await client.POST("/projects/{owner}/{project}/transfer", {
+              params: { path: { owner, project: name } },
+              body: {
+                targetAccountSlug: options.to,
+                ...(options.name ? { name: options.name } : {}),
+              },
+            }),
+          ),
+        format: formatProject,
+      }),
+    );
+}

--- a/packages/cli/src/commands/project/update.ts
+++ b/packages/cli/src/commands/project/update.ts
@@ -1,0 +1,259 @@
+import { Option, type Command } from "commander";
+import type { ArgosAPISchema, ArgosAPIClient } from "@argos-ci/api-client";
+import { unwrap } from "../../lib/api";
+import { fail } from "../../lib/cli-error";
+import { formatProject } from "../../lib/format";
+import {
+  jsonOption,
+  managedProjectPathOption,
+  tokenOption,
+} from "../../options";
+import { runProjectAction, type ProjectCommandOptions } from "./_run";
+
+type UpdateProjectBody = NonNullable<
+  ArgosAPISchema.operations["updateProject"]["requestBody"]
+>["content"]["application/json"];
+type SummaryCheck = ArgosAPISchema.components["schemas"]["SummaryCheck"];
+type DeploymentAuth = ArgosAPISchema.components["schemas"]["DeploymentAuth"];
+type ProjectUserLevel =
+  ArgosAPISchema.components["schemas"]["ProjectUserLevel"];
+
+const BOOLEAN_CHOICES = ["true", "false"] as const;
+type BooleanChoice = (typeof BOOLEAN_CHOICES)[number];
+
+const SUMMARY_CHECKS = [
+  "always",
+  "never",
+  "auto",
+] as const satisfies SummaryCheck[];
+
+const DEPLOYMENT_AUTHS = [
+  "public",
+  "domain-private",
+  "private",
+] as const satisfies DeploymentAuth[];
+
+const PROJECT_USER_LEVELS = [
+  "admin",
+  "reviewer",
+  "viewer",
+] as const satisfies ProjectUserLevel[];
+
+type UpdateOptions = ProjectCommandOptions & {
+  name?: string | undefined;
+  defaultBaseBranch?: string | undefined;
+  autoApprovedBranchGlob?: string | undefined;
+  deploymentProductionBranchGlob?: string | undefined;
+  private?: BooleanChoice | "inherit" | undefined;
+  summaryCheck?: SummaryCheck | undefined;
+  defaultUserLevel?: ProjectUserLevel | "none" | undefined;
+  ignoreChanges?: BooleanChoice | undefined;
+  autoIgnoreAfter?: string | undefined;
+  deployments?: BooleanChoice | undefined;
+  deploymentAuth?: DeploymentAuth | undefined;
+  githubActionsOidc?: BooleanChoice | undefined;
+  tokenlessAuth?: BooleanChoice | undefined;
+};
+
+function toBoolean(value: BooleanChoice): boolean {
+  return value === "true";
+}
+
+/** An empty string resets a nullable setting to its inherited default. */
+function toNullable(value: string): string | null {
+  return value === "" ? null : value;
+}
+
+/**
+ * Build the `ignoreConfig` object. The API takes it whole, so a command that
+ * touches only one of its two settings has to read the other back from the
+ * project first.
+ */
+async function resolveIgnoreConfig(
+  options: UpdateOptions,
+  load: () => Promise<UpdateProjectBody["ignoreConfig"]>,
+): Promise<UpdateProjectBody["ignoreConfig"]> {
+  if (!options.ignoreChanges && !options.autoIgnoreAfter) {
+    return undefined;
+  }
+  const current = await load();
+  const enabled = options.ignoreChanges
+    ? toBoolean(options.ignoreChanges)
+    : (current?.enabled ?? true);
+  if (!options.autoIgnoreAfter) {
+    return { enabled, autoIgnore: current?.autoIgnore ?? null };
+  }
+  if (options.autoIgnoreAfter === "off") {
+    return { enabled, autoIgnore: null };
+  }
+  const changes = Number(options.autoIgnoreAfter);
+  if (!Number.isInteger(changes) || changes < 1) {
+    fail(
+      `--auto-ignore-after must be a positive integer or "off", received "${options.autoIgnoreAfter}".`,
+    );
+  }
+  return { enabled, autoIgnore: { changes } };
+}
+
+/** Map the flags onto the request body, leaving untouched settings out. */
+async function buildBody(
+  options: UpdateOptions,
+  load: () => Promise<UpdateProjectBody["ignoreConfig"]>,
+): Promise<UpdateProjectBody> {
+  const body: UpdateProjectBody = {};
+  if (options.name !== undefined) {
+    body.name = options.name;
+  }
+  if (options.defaultBaseBranch !== undefined) {
+    body.defaultBaseBranch = toNullable(options.defaultBaseBranch);
+  }
+  if (options.autoApprovedBranchGlob !== undefined) {
+    body.autoApprovedBranchGlob = toNullable(options.autoApprovedBranchGlob);
+  }
+  if (options.deploymentProductionBranchGlob !== undefined) {
+    body.deploymentProductionBranchGlob = toNullable(
+      options.deploymentProductionBranchGlob,
+    );
+  }
+  if (options.private !== undefined) {
+    body.private =
+      options.private === "inherit" ? null : toBoolean(options.private);
+  }
+  if (options.summaryCheck !== undefined) {
+    body.summaryCheck = options.summaryCheck;
+  }
+  if (options.defaultUserLevel !== undefined) {
+    body.defaultUserLevel =
+      options.defaultUserLevel === "none" ? null : options.defaultUserLevel;
+  }
+  if (options.deployments !== undefined) {
+    body.deploymentEnabled = toBoolean(options.deployments);
+  }
+  if (options.deploymentAuth !== undefined) {
+    body.deploymentAuth = options.deploymentAuth;
+  }
+  if (options.githubActionsOidc !== undefined) {
+    body.githubActionsOidcEnabled = toBoolean(options.githubActionsOidc);
+  }
+  if (options.tokenlessAuth !== undefined) {
+    body.tokenlessAuthEnabled = toBoolean(options.tokenlessAuth);
+  }
+  const ignoreConfig = await resolveIgnoreConfig(options, load);
+  if (ignoreConfig !== undefined) {
+    body.ignoreConfig = ignoreConfig;
+  }
+  return body;
+}
+
+/** Read the project's current ignore settings, to patch them partially. */
+async function loadIgnoreConfig(
+  client: ArgosAPIClient,
+  owner: string,
+  project: string,
+): Promise<UpdateProjectBody["ignoreConfig"]> {
+  const current = unwrap(
+    await client.GET("/projects/{owner}/{project}", {
+      params: { path: { owner, project } },
+    }),
+  );
+  return current.ignoreConfig;
+}
+
+export function registerProjectUpdate(project: Command) {
+  project
+    .command("update")
+    .description(
+      "Update a project's settings. Only the settings you pass are changed",
+    )
+    .option("--name <name>", "Rename the project")
+    .option(
+      "--default-base-branch <branch>",
+      "Branch used as the baseline when no better one applies. Pass an empty string to fall back to the repository default",
+    )
+    .option(
+      "--auto-approved-branch-glob <glob>",
+      "Glob matching the branches whose builds are approved automatically. Pass an empty string to fall back to the default base branch",
+    )
+    .option(
+      "--deployment-production-branch-glob <glob>",
+      "Glob matching the branches whose deployments count as production. Pass an empty string to fall back to the repository default",
+    )
+    .addOption(
+      new Option(
+        "--private <value>",
+        "Force the project's privacy, or inherit it from the linked repository",
+      ).choices([...BOOLEAN_CHOICES, "inherit"]),
+    )
+    .addOption(
+      new Option(
+        "--summary-check <mode>",
+        "When to post the summary check on a pull request",
+      ).choices(SUMMARY_CHECKS),
+    )
+    .addOption(
+      new Option(
+        "--default-user-level <level>",
+        "Access given to team members that are not contributors on this project",
+      ).choices([...PROJECT_USER_LEVELS, "none"]),
+    )
+    .addOption(
+      new Option(
+        "--ignore-changes <value>",
+        "Whether changes can be ignored on this project",
+      ).choices(BOOLEAN_CHOICES),
+    )
+    .option(
+      "--auto-ignore-after <changes>",
+      'Ignore a change automatically once it has reappeared this many times, or "off"',
+    )
+    .addOption(
+      new Option(
+        "--deployments <value>",
+        "Whether deployments are served for this project",
+      ).choices(BOOLEAN_CHOICES),
+    )
+    .addOption(
+      new Option(
+        "--deployment-auth <mode>",
+        "Who can reach the project's deployments",
+      ).choices(DEPLOYMENT_AUTHS),
+    )
+    .addOption(
+      new Option(
+        "--github-actions-oidc <value>",
+        "Whether builds can authenticate with a GitHub Actions OIDC token",
+      ).choices(BOOLEAN_CHOICES),
+    )
+    .addOption(
+      new Option(
+        "--tokenless-auth <value>",
+        "Whether builds from forked pull requests can be uploaded without a token",
+      ).choices(BOOLEAN_CHOICES),
+    )
+    .addOption(managedProjectPathOption)
+    .addOption(tokenOption)
+    .addOption(jsonOption)
+    .action((options: UpdateOptions) =>
+      runProjectAction({
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project: name }) => {
+          const body = await buildBody(options, () =>
+            loadIgnoreConfig(client, owner, name),
+          );
+          if (Object.keys(body).length === 0) {
+            fail(
+              "Nothing to update. Pass at least one setting — run `argos project update --help` for the list.",
+            );
+          }
+          return unwrap(
+            await client.PATCH("/projects/{owner}/{project}", {
+              params: { path: { owner, project: name } },
+              body,
+            }),
+          );
+        },
+        format: formatProject,
+      }),
+    );
+}

--- a/packages/cli/src/commands/review/index.ts
+++ b/packages/cli/src/commands/review/index.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { registerReviewCreate } from "./create";
 import { registerReviewDismiss } from "./dismiss";
 import { registerReviewList } from "./list";
+import { registerReviewReviewer } from "./reviewer";
 
 export function reviewCommand(program: Command) {
   const review = program
@@ -10,4 +11,5 @@ export function reviewCommand(program: Command) {
   registerReviewList(review);
   registerReviewCreate(review);
   registerReviewDismiss(review);
+  registerReviewReviewer(review);
 }

--- a/packages/cli/src/commands/review/reviewer.ts
+++ b/packages/cli/src/commands/review/reviewer.ts
@@ -1,0 +1,95 @@
+import type { Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatReviewers } from "../../lib/format";
+import { runBuildAction, type BaseCommandOptions } from "../../lib/run";
+import { jsonOption, projectPathOption, tokenOption } from "../../options";
+
+export function registerReviewReviewer(review: Command) {
+  const reviewer = review
+    .command("reviewer")
+    .description("List, request, and cancel review requests on a build");
+
+  reviewer
+    .command("list")
+    .description("List the users currently requested to review a build")
+    .argument("<buildReference>", "Build number or Argos build URL")
+    .addOption(tokenOption)
+    .addOption(projectPathOption)
+    .addOption(jsonOption)
+    .action((reference: string, options: BaseCommandOptions) =>
+      runBuildAction({
+        reference,
+        options,
+        auth: "user",
+        handler: async ({ client, owner, project, buildNumber }) =>
+          unwrap(
+            await client.GET(
+              "/projects/{owner}/{project}/builds/{buildNumber}/reviewers",
+              { params: { path: { owner, project, buildNumber } } },
+            ),
+          ),
+        format: formatReviewers,
+      }),
+    );
+
+  reviewer
+    .command("add")
+    .description(
+      "Request users to review a build. Users already requested are left untouched and not notified again",
+    )
+    .argument("<buildReference>", "Build number or Argos build URL")
+    .argument(
+      "<userIds...>",
+      "User IDs to request, taken from `argos account member list` or `argos whoami`",
+    )
+    .addOption(tokenOption)
+    .addOption(projectPathOption)
+    .addOption(jsonOption)
+    .action(
+      (reference: string, userIds: string[], options: BaseCommandOptions) =>
+        runBuildAction({
+          reference,
+          options,
+          auth: "user",
+          handler: async ({ client, owner, project, buildNumber }) =>
+            unwrap(
+              await client.POST(
+                "/projects/{owner}/{project}/builds/{buildNumber}/reviewers",
+                {
+                  params: { path: { owner, project, buildNumber } },
+                  body: { userIds },
+                },
+              ),
+            ),
+          format: formatReviewers,
+        }),
+    );
+
+  reviewer
+    .command("remove")
+    .description("Cancel the review requests standing on a build")
+    .argument("<buildReference>", "Build number or Argos build URL")
+    .argument("<userIds...>", "User IDs whose review request to cancel")
+    .addOption(tokenOption)
+    .addOption(projectPathOption)
+    .addOption(jsonOption)
+    .action(
+      (reference: string, userIds: string[], options: BaseCommandOptions) =>
+        runBuildAction({
+          reference,
+          options,
+          auth: "user",
+          handler: async ({ client, owner, project, buildNumber }) =>
+            unwrap(
+              await client.DELETE(
+                "/projects/{owner}/{project}/builds/{buildNumber}/reviewers",
+                {
+                  params: { path: { owner, project, buildNumber } },
+                  body: { userIds },
+                },
+              ),
+            ),
+          format: formatReviewers,
+        }),
+    );
+}

--- a/packages/cli/src/commands/test/index.ts
+++ b/packages/cli/src/commands/test/index.ts
@@ -2,6 +2,8 @@ import type { Command } from "commander";
 import { registerTestChanges } from "./changes";
 import { registerTestComment } from "./comment";
 import { registerTestGet } from "./get";
+import { registerTestList } from "./list";
+import { registerTestSubscribe, registerTestUnsubscribe } from "./subscription";
 
 export function testCommand(program: Command) {
   const test = program
@@ -9,7 +11,10 @@ export function testCommand(program: Command) {
     .description(
       "Inspect a test's flakiness and the changes that keep coming back",
     );
+  registerTestList(test);
   registerTestGet(test);
   registerTestChanges(test);
   registerTestComment(test);
+  registerTestSubscribe(test);
+  registerTestUnsubscribe(test);
 }

--- a/packages/cli/src/commands/test/list.ts
+++ b/packages/cli/src/commands/test/list.ts
@@ -1,0 +1,72 @@
+import type { Command } from "commander";
+import { unwrap } from "../../lib/api";
+import { formatTests } from "../../lib/format";
+import { fetchPages } from "../../lib/pagination";
+import { handleCliError, output } from "../../lib/run";
+import { resolveProjectTarget } from "../../lib/target";
+import {
+  jsonOption,
+  limitOption,
+  metricsPeriodOption,
+  testProjectPathOption,
+  toLimit,
+  toMetricsPeriod,
+  tokenOption,
+  type LimitOption,
+  type MetricsPeriodOption,
+} from "../../options";
+import type { BaseCommandOptions } from "../../lib/run";
+
+type ListOptions = BaseCommandOptions &
+  MetricsPeriodOption &
+  LimitOption & {
+    buildName?: string | undefined;
+    search?: string | undefined;
+  };
+
+export function registerTestList(test: Command) {
+  test
+    .command("list")
+    .description(
+      "List the tests currently running in a project, flakiest first — the project's flakiness backlog",
+    )
+    .option(
+      "--build-name <name>",
+      "Restrict to the tests of a single build name",
+    )
+    .option("--search <query>", "Match tests on their name")
+    .addOption(limitOption)
+    .addOption(tokenOption)
+    .addOption(testProjectPathOption)
+    .addOption(metricsPeriodOption)
+    .addOption(jsonOption)
+    .action(async (options: ListOptions) => {
+      try {
+        const { client, owner, project } = await resolveProjectTarget(options, {
+          auth: "project",
+        });
+        const tests = await fetchPages(
+          toLimit(options.limit),
+          async (pagination) =>
+            unwrap(
+              await client.GET("/projects/{owner}/{project}/tests", {
+                params: {
+                  path: { owner, project },
+                  query: {
+                    ...pagination,
+                    metricsPeriod: toMetricsPeriod(options.metricsPeriod),
+                    ...(options.buildName
+                      ? { buildName: options.buildName }
+                      : {}),
+                    ...(options.search ? { search: options.search } : {}),
+                  },
+                },
+              }),
+            ),
+        );
+        output(tests, options, formatTests);
+      } catch (error) {
+        handleCliError(error, "project");
+      }
+    });
+}

--- a/packages/cli/src/commands/test/subscription.ts
+++ b/packages/cli/src/commands/test/subscription.ts
@@ -1,0 +1,82 @@
+import type { Command } from "commander";
+import type { ArgosAPIClient, ArgosAPISchema } from "@argos-ci/api-client";
+import { unwrap } from "../../lib/api";
+import { formatSubscription } from "../../lib/format";
+import { handleCliError, output, type BaseCommandOptions } from "../../lib/run";
+import { resolveProjectTarget } from "../../lib/target";
+import { jsonOption, testProjectPathOption, tokenOption } from "../../options";
+
+type NotificationSubscription =
+  ArgosAPISchema.components["schemas"]["NotificationSubscription"];
+
+/**
+ * Register `test subscribe` / `test unsubscribe`. Both act as a user, so they
+ * need a personal access token, and the project comes from `--project` or
+ * `ARGOS_PROJECT` since a test id does not carry the account slug.
+ */
+function defineTestSubscription(opts: {
+  name: string;
+  description: string;
+  perform: (ctx: {
+    client: ArgosAPIClient;
+    owner: string;
+    project: string;
+    testId: string;
+  }) => Promise<NotificationSubscription>;
+}) {
+  return (test: Command) => {
+    test
+      .command(opts.name)
+      .description(opts.description)
+      .argument(
+        "<testId>",
+        "Test ID, taken from a diff's `test.id` (see `argos build snapshots`)",
+      )
+      .addOption(tokenOption)
+      .addOption(testProjectPathOption)
+      .addOption(jsonOption)
+      .action(async (testId: string, options: BaseCommandOptions) => {
+        try {
+          const { client, owner, project } = await resolveProjectTarget(
+            options,
+            { auth: "user" },
+          );
+          const result = await opts.perform({
+            client,
+            owner,
+            project,
+            testId,
+          });
+          output(result, options, formatSubscription);
+        } catch (error) {
+          handleCliError(error, "user");
+        }
+      });
+  };
+}
+
+export const registerTestSubscribe = defineTestSubscription({
+  name: "subscribe",
+  description:
+    "Subscribe to a test's notifications — its new comments and the changes it produces",
+  perform: async ({ client, owner, project, testId }) =>
+    unwrap(
+      await client.POST(
+        "/projects/{owner}/{project}/tests/{testId}/subscription",
+        { params: { path: { owner, project, testId } } },
+      ),
+    ),
+});
+
+export const registerTestUnsubscribe = defineTestSubscription({
+  name: "unsubscribe",
+  description:
+    "Stop receiving notifications about a test. Argos will not auto-subscribe you to it again",
+  perform: async ({ client, owner, project, testId }) =>
+    unwrap(
+      await client.DELETE(
+        "/projects/{owner}/{project}/tests/{testId}/subscription",
+        { params: { path: { owner, project, testId } } },
+      ),
+    ),
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,9 @@ import { createProjectCommand } from "./commands/create-project";
 import { analyticsCommand } from "./commands/analytics";
 import { changeCommand } from "./commands/change";
 import { testCommand } from "./commands/test";
+import { accountCommand } from "./commands/account";
+import { projectCommand } from "./commands/project";
+import { automationCommand } from "./commands/automation";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -43,6 +46,9 @@ createProjectCommand(program);
 analyticsCommand(program);
 changeCommand(program);
 testCommand(program);
+accountCommand(program);
+projectCommand(program);
+automationCommand(program);
 
 if (!process.argv.slice(2).length) {
   program.outputHelp();

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -38,3 +38,16 @@ export function unwrap<T>(result: {
   }
   return result.data;
 }
+
+/**
+ * Like {@link unwrap} for endpoints that answer `204 No Content`: it only
+ * checks the request succeeded, since there is no body to return.
+ */
+export function unwrapEmpty(result: {
+  error?: unknown;
+  response: Response;
+}): void {
+  if (!result.response.ok) {
+    throwAPIError(result.error, result.response);
+  }
+}

--- a/packages/cli/src/lib/format.test.ts
+++ b/packages/cli/src/lib/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatChange,
   formatComment,
   formatComments,
+  formatCreatedProject,
   formatProject,
   formatReview,
   formatReviews,
@@ -51,7 +52,7 @@ describe("formatValue", () => {
   });
 });
 
-describe("formatProject", () => {
+describe("formatCreatedProject", () => {
   it("summarizes the created project", () => {
     const project = {
       id: "project-1",
@@ -60,11 +61,68 @@ describe("formatProject", () => {
       defaultBaseBranch: "main",
       hasRemoteContentAccess: true,
     } as ArgosAPISchema.components["schemas"]["Project"];
-    const output = formatProject(project);
+    const output = formatCreatedProject(project);
     expect(output).toContain("Created project acme/my-app.");
     expect(output).toContain("ID: project-1");
     expect(output).toContain("Account: acme");
     expect(output).toContain("Default base branch: main");
+  });
+});
+
+describe("formatProject", () => {
+  it("summarizes the project settings", () => {
+    const project = {
+      id: "project-1",
+      name: "my-app",
+      account: { id: "account-1", slug: "acme" },
+      defaultBaseBranch: "main",
+      hasRemoteContentAccess: true,
+      autoApprovedBranchGlob: "main",
+      deploymentProductionBranchGlob: "main",
+      private: true,
+      summaryCheck: "auto",
+      prCommentEnabled: true,
+      githubActionsOidcEnabled: false,
+      tokenlessAuthEnabled: false,
+      deploymentEnabled: true,
+      deploymentAuth: "public",
+      defaultUserLevel: "reviewer",
+      ignoreConfig: { enabled: true, autoIgnore: { changes: 3 } },
+    } as ArgosAPISchema.components["schemas"]["Project"];
+    const output = formatProject(project);
+    expect(output).toContain("Project acme/my-app");
+    expect(output).toContain("Visibility: private");
+    expect(output).toContain("Summary check: auto");
+    expect(output).toContain(
+      "Ignore changes: enabled, auto-ignore after 3 occurrences",
+    );
+    expect(output).toContain(
+      "Deployments: yes (public, production branches main)",
+    );
+  });
+
+  it("reports a disabled ignore config", () => {
+    const project = {
+      id: "project-1",
+      name: "my-app",
+      account: { id: "account-1", slug: "acme" },
+      defaultBaseBranch: "main",
+      autoApprovedBranchGlob: "main",
+      deploymentProductionBranchGlob: "main",
+      private: false,
+      summaryCheck: "never",
+      prCommentEnabled: false,
+      githubActionsOidcEnabled: false,
+      tokenlessAuthEnabled: false,
+      deploymentEnabled: false,
+      deploymentAuth: "private",
+      defaultUserLevel: null,
+      ignoreConfig: { enabled: false, autoIgnore: null },
+    } as unknown as ArgosAPISchema.components["schemas"]["Project"];
+    const output = formatProject(project);
+    expect(output).toContain("Visibility: public");
+    expect(output).toContain("Ignore changes: disabled");
+    expect(output).toContain("Default user level: -");
   });
 });
 

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -15,6 +15,23 @@ type User = ArgosAPISchema.components["schemas"]["User"];
 type Project = ArgosAPISchema.components["schemas"]["Project"];
 type AccountAnalytics =
   ArgosAPISchema.components["schemas"]["AccountAnalytics"];
+type AccountDetails = ArgosAPISchema.components["schemas"]["AccountDetails"];
+type TeamMember = ArgosAPISchema.components["schemas"]["TeamMember"];
+type TeamInvite = ArgosAPISchema.components["schemas"]["TeamInvite"];
+type TeamDomain = ArgosAPISchema.components["schemas"]["TeamDomain"];
+type InviteLink = ArgosAPISchema.components["schemas"]["InviteLink"];
+type ProjectContributor =
+  ArgosAPISchema.components["schemas"]["ProjectContributor"];
+type ProjectDomain = ArgosAPISchema.components["schemas"]["ProjectDomain"];
+type IgnoredChange = ArgosAPISchema.components["schemas"]["IgnoredChange"];
+type TestSummary = ArgosAPISchema.components["schemas"]["TestSummary"];
+type BuildReviewers = ArgosAPISchema.components["schemas"]["BuildReviewers"];
+type NotificationSubscription =
+  ArgosAPISchema.components["schemas"]["NotificationSubscription"];
+type AutomationRule = ArgosAPISchema.components["schemas"]["AutomationRule"];
+/** A deployment as returned by `listProjectDeployments`; it has no named schema. */
+export type ProjectDeployment =
+  ArgosAPISchema.operations["listProjectDeployments"]["responses"][200]["content"]["application/json"]["results"][number];
 
 /** Render a scalar, using `-` for empty values. */
 export function formatValue(value: string | number | null | undefined): string {
@@ -22,6 +39,11 @@ export function formatValue(value: string | number | null | undefined): string {
     return "-";
   }
   return String(value);
+}
+
+/** Render a flag as `yes` / `no`. */
+function formatBoolean(value: boolean): string {
+  return value ? "yes" : "no";
 }
 
 function formatUser(user: User | null | undefined): string {
@@ -39,7 +61,7 @@ export function formatMe(user: User): string {
   ].join("\n");
 }
 
-export function formatProject(project: Project): string {
+export function formatCreatedProject(project: Project): string {
   return [
     `Created project ${project.account.slug}/${project.name}.`,
     `ID: ${project.id}`,
@@ -47,6 +69,33 @@ export function formatProject(project: Project): string {
     `Account: ${project.account.slug}`,
     `Default base branch: ${formatValue(project.defaultBaseBranch)}`,
   ].join("\n");
+}
+
+export function formatProject(project: Project): string {
+  return [
+    `Project ${project.account.slug}/${project.name}`,
+    `ID: ${project.id}`,
+    `Visibility: ${project.private ? "private" : "public"}`,
+    `Default base branch: ${formatValue(project.defaultBaseBranch)}`,
+    `Auto-approved branches: ${formatValue(project.autoApprovedBranchGlob)}`,
+    `Summary check: ${project.summaryCheck}`,
+    `PR comment: ${formatBoolean(project.prCommentEnabled)}`,
+    `Default user level: ${formatValue(project.defaultUserLevel)}`,
+    `Ignore changes: ${formatIgnoreConfig(project.ignoreConfig)}`,
+    `Deployments: ${formatBoolean(project.deploymentEnabled)} (${project.deploymentAuth}, production branches ${formatValue(project.deploymentProductionBranchGlob)})`,
+    `GitHub Actions OIDC: ${formatBoolean(project.githubActionsOidcEnabled)}`,
+    `Tokenless auth: ${formatBoolean(project.tokenlessAuthEnabled)}`,
+  ].join("\n");
+}
+
+function formatIgnoreConfig(config: Project["ignoreConfig"]): string {
+  if (!config.enabled) {
+    return "disabled";
+  }
+  const autoIgnore = config.autoIgnore;
+  return autoIgnore
+    ? `enabled, auto-ignore after ${autoIgnore.changes} occurrences`
+    : "enabled, auto-ignore off";
 }
 
 export function formatStats(stats: Build["stats"]): string {
@@ -358,6 +407,237 @@ export function formatComments(comments: Comment[]): string {
         "",
       ];
     }),
+  ]
+    .slice(0, -1)
+    .join("\n");
+}
+
+export function formatAccount(account: AccountDetails): string {
+  const lines = [
+    `Account ${account.slug} (${account.type})`,
+    `ID: ${account.id}`,
+    `Name: ${formatValue(account.name)}`,
+    `Plan: ${formatValue(account.plan?.name)}`,
+    `Period: ${formatValue(account.periodStartDate)} → ${formatValue(account.periodEndDate)}`,
+    `Screenshots: ${account.currentPeriodScreenshots} / ${account.includedScreenshots} (${Math.round(account.consumptionRatio * 100)}%)`,
+  ];
+  if (account.additionalScreenshotsCost > 0) {
+    lines.push(
+      `Additional screenshots cost: ${account.additionalScreenshotsCost}`,
+    );
+  }
+  if (account.defaultUserLevel) {
+    lines.push(`Default user level: ${account.defaultUserLevel}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatMembers(members: TeamMember[]): string {
+  if (members.length === 0) {
+    return "No members found.";
+  }
+  return [
+    `Members (${members.length})`,
+    "",
+    ...members.map(
+      (member) =>
+        `${formatUser(member.user)} [${member.level}] · user ${member.user.id}`,
+    ),
+  ].join("\n");
+}
+
+export function formatMember(member: TeamMember): string {
+  return [
+    `Member ${formatUser(member.user)}`,
+    `Level: ${member.level}`,
+    `User ID: ${member.user.id}`,
+  ].join("\n");
+}
+
+export function formatInvites(invites: TeamInvite[]): string {
+  if (invites.length === 0) {
+    return "No pending invites found.";
+  }
+  return [
+    `Invites (${invites.length})`,
+    "",
+    ...invites.map(
+      (invite) =>
+        `${invite.email} [${invite.level}${invite.expired ? ", expired" : ""}] · ${invite.id} · expires ${invite.expiresAt}`,
+    ),
+  ].join("\n");
+}
+
+export function formatInviteLink(link: InviteLink): string {
+  return `Invite link: ${link.inviteLink}`;
+}
+
+export function formatDomains(domains: TeamDomain[]): string {
+  if (domains.length === 0) {
+    return "No email domains found.";
+  }
+  return [
+    `Email domains (${domains.length})`,
+    "",
+    ...domains.map((domain) => `${domain.domain} · added ${domain.createdAt}`),
+  ].join("\n");
+}
+
+export function formatDomain(domain: TeamDomain): string {
+  return [`Domain ${domain.domain}`, `Added: ${domain.createdAt}`].join("\n");
+}
+
+export function formatContributors(contributors: ProjectContributor[]): string {
+  if (contributors.length === 0) {
+    return "No contributors found.";
+  }
+  return [
+    `Contributors (${contributors.length})`,
+    "",
+    ...contributors.map(
+      (contributor) =>
+        `${formatUser(contributor.user)} [${contributor.level}] · user ${contributor.user.id}`,
+    ),
+  ].join("\n");
+}
+
+export function formatContributor(contributor: ProjectContributor): string {
+  return [
+    `Contributor ${formatUser(contributor.user)}`,
+    `Level: ${contributor.level}`,
+    `User ID: ${contributor.user.id}`,
+  ].join("\n");
+}
+
+export function formatDeployments(deployments: ProjectDeployment[]): string {
+  if (deployments.length === 0) {
+    return "No deployments found.";
+  }
+  return [
+    `Deployments (${deployments.length})`,
+    "",
+    ...deployments.flatMap((deployment) => [
+      `${deployment.id} [${deployment.status}, ${deployment.environment}]`,
+      `  Branch: ${formatValue(deployment.branch)}`,
+      `  Commit: ${formatValue(deployment.commitSha)}`,
+      `  Date: ${deployment.createdAt}`,
+      `  URL: ${deployment.url}`,
+      "",
+    ]),
+  ]
+    .slice(0, -1)
+    .join("\n");
+}
+
+export function formatProjectDomain(domain: ProjectDomain): string {
+  return `Deployment domain: ${formatValue(domain.domain)}`;
+}
+
+export function formatIgnoredChanges(changes: IgnoredChange[]): string {
+  if (changes.length === 0) {
+    return "No ignored changes found.";
+  }
+  return [
+    `Ignored changes (${changes.length})`,
+    "",
+    ...changes.flatMap((change) => [
+      change.id,
+      `  Test: ${change.test.name} (${change.test.buildName})`,
+      `  Test ID: ${change.test.id}`,
+      "",
+    ]),
+  ]
+    .slice(0, -1)
+    .join("\n");
+}
+
+export function formatTests(tests: TestSummary[]): string {
+  if (tests.length === 0) {
+    return "No tests found.";
+  }
+  return [
+    `Tests (${tests.length})`,
+    "",
+    ...tests.flatMap((test) => [
+      `${test.name} (${test.buildName})`,
+      `  ID: ${test.id}`,
+      `  Flakiness: ${formatFlakiness(test.metrics)}`,
+      `  Changes: ${test.metrics.changes} over ${test.metrics.total} builds`,
+      "",
+    ]),
+  ]
+    .slice(0, -1)
+    .join("\n");
+}
+
+export function formatReviewers(data: BuildReviewers): string {
+  if (data.reviewers.length === 0) {
+    return "No reviewers requested.";
+  }
+  return [
+    `Requested reviewers (${data.reviewers.length})`,
+    "",
+    ...data.reviewers.map((user) => `${formatUser(user)} · user ${user.id}`),
+  ].join("\n");
+}
+
+export function formatSubscription(
+  subscription: NotificationSubscription,
+): string {
+  return subscription.subscribed
+    ? "Subscribed: you will receive notifications."
+    : "Unsubscribed: you will no longer receive notifications.";
+}
+
+/** One line per condition, rendering the `not` and `glob` wrappers inline. */
+function formatConditions(conditions: AutomationRule["conditions"]): string[] {
+  return conditions.map((condition) => {
+    if ("not" in condition) {
+      const inner = condition.not;
+      return "glob" in inner
+        ? `not ${inner.glob.type} matches ${inner.glob.value}`
+        : `not ${inner.type} is ${formatValue(inner.value)}`;
+    }
+    if ("glob" in condition) {
+      return `${condition.glob.type} matches ${condition.glob.value}`;
+    }
+    return `${condition.type} is ${formatValue(condition.value)}`;
+  });
+}
+
+export function formatAutomationRule(rule: AutomationRule): string {
+  const lines = [
+    `Rule ${rule.name} [${rule.active ? "active" : "inactive"}]`,
+    `ID: ${rule.id}`,
+    `Events: ${rule.events.join(", ")}`,
+  ];
+  const conditions = formatConditions(rule.conditions);
+  lines.push(
+    conditions.length > 0
+      ? `Conditions: ${conditions.join(" AND ")}`
+      : "Conditions: none",
+  );
+  lines.push(
+    `Actions: ${rule.actions.map((action) => action.action).join(", ")}`,
+  );
+  lines.push(`Updated: ${rule.updatedAt}`);
+  return lines.join("\n");
+}
+
+export function formatAutomationRules(rules: AutomationRule[]): string {
+  if (rules.length === 0) {
+    return "No automation rules found.";
+  }
+  return [
+    `Automation rules (${rules.length})`,
+    "",
+    ...rules.flatMap((rule) => [
+      `${rule.name} [${rule.active ? "active" : "inactive"}]`,
+      `  ID: ${rule.id}`,
+      `  Events: ${rule.events.join(", ")}`,
+      `  Actions: ${rule.actions.map((action) => action.action).join(", ")}`,
+      "",
+    ]),
   ]
     .slice(0, -1)
     .join("\n");

--- a/packages/cli/src/lib/pagination.test.ts
+++ b/packages/cli/src/lib/pagination.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchPages } from "./pagination";
+
+/** A fake endpoint serving `total` sequential items, page by page. */
+function serve(total: number) {
+  return vi.fn(async ({ page, perPage }: { page: string; perPage: string }) => {
+    const size = Number(perPage);
+    const start = (Number(page) - 1) * size;
+    return {
+      pageInfo: { total },
+      results: Array.from(
+        { length: Math.max(0, Math.min(size, total - start)) },
+        (_, index) => start + index,
+      ),
+    };
+  });
+}
+
+describe("fetchPages", () => {
+  it("follows pagination until the limit is reached", async () => {
+    const fetchPage = serve(500);
+    const results = await fetchPages(250, fetchPage);
+    expect(results).toHaveLength(250);
+    expect(results.at(-1)).toBe(249);
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    // The page size never changes, so the offsets the API derives stay aligned.
+    expect(fetchPage).toHaveBeenLastCalledWith({ page: "3", perPage: "100" });
+  });
+
+  it("asks for no more than the limit on a single page", async () => {
+    const fetchPage = serve(500);
+    const results = await fetchPages(10, fetchPage);
+    expect(results).toHaveLength(10);
+    expect(fetchPage).toHaveBeenCalledExactlyOnceWith({
+      page: "1",
+      perPage: "10",
+    });
+  });
+
+  it("stops at the server's total", async () => {
+    const fetchPage = serve(3);
+    const results = await fetchPages(100, fetchPage);
+    expect(results).toEqual([0, 1, 2]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps the page size at 100", async () => {
+    const fetchPage = serve(1000);
+    await fetchPages(1000, fetchPage);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, { page: "1", perPage: "100" });
+  });
+
+  it("returns nothing when there is nothing to list", async () => {
+    const fetchPage = serve(0);
+    await expect(fetchPages(100, fetchPage)).resolves.toEqual([]);
+  });
+});

--- a/packages/cli/src/lib/pagination.ts
+++ b/packages/cli/src/lib/pagination.ts
@@ -1,0 +1,37 @@
+/** Largest page the API serves. */
+const MAX_PER_PAGE = 100;
+
+type Page<T> = {
+  results: T[];
+  pageInfo: { total: number };
+};
+
+/**
+ * Walk a paginated endpoint until `limit` items have been collected, the server
+ * runs out of results, or its reported total is reached.
+ *
+ * `fetchPage` receives the page number and the size to request, both already
+ * stringified — every paginated Argos endpoint takes them as query strings.
+ */
+export async function fetchPages<T>(
+  limit: number,
+  fetchPage: (params: { page: string; perPage: string }) => Promise<Page<T>>,
+): Promise<T[]> {
+  // The page size stays constant: the API turns `page` into an offset by
+  // multiplying it by `perPage`, so shrinking it on the last page would skip
+  // items. Overshooting the limit is trimmed below instead.
+  const perPage = String(Math.min(MAX_PER_PAGE, limit));
+  const results: T[] = [];
+  for (let page = 1; ; page++) {
+    const data = await fetchPage({ page: String(page), perPage });
+    results.push(...data.results);
+    if (
+      results.length >= limit ||
+      results.length >= data.pageInfo.total ||
+      data.results.length === 0
+    ) {
+      break;
+    }
+  }
+  return results.slice(0, limit);
+}

--- a/packages/cli/src/lib/target.ts
+++ b/packages/cli/src/lib/target.ts
@@ -26,6 +26,11 @@ export type TargetOptions = {
   project?: string | undefined;
 };
 
+export type AccountTargetOptions = {
+  token?: string | undefined;
+  account?: string | undefined;
+};
+
 /** A resolved build, ready to drive API calls. */
 export type BuildTarget = ProjectPath & {
   client: ArgosAPIClient;
@@ -38,11 +43,19 @@ export type ProjectTarget = ProjectPath & {
   client: ArgosAPIClient;
 };
 
+/** A resolved account, ready to drive account-scoped API calls. */
+export type AccountTarget = {
+  client: ArgosAPIClient;
+  accountSlug: string;
+};
+
 /**
  * Resolve the API token, preferring an explicit token (`--token` /
  * `ARGOS_TOKEN`) over the one stored by `argos login`.
  */
-export async function resolveToken(options: TargetOptions): Promise<string> {
+export async function resolveToken(options: {
+  token?: string | undefined;
+}): Promise<string> {
   const token =
     options.token || process.env["ARGOS_TOKEN"] || (await getAccessToken());
   if (!token) {
@@ -132,4 +145,21 @@ export async function resolveProjectTarget(
   }
   const project = unwrap(await client.GET("/project"));
   return { client, owner: project.account.slug, project: project.name };
+}
+
+/**
+ * Resolve an account-scoped command target: an authenticated client and the
+ * account slug, taken from `--account <slug>` or the `ARGOS_ACCOUNT`
+ * environment variable. Account endpoints all act as a user, so the token must
+ * be a personal access token scoped to that account.
+ */
+export async function resolveAccountTarget(
+  options: AccountTargetOptions,
+): Promise<AccountTarget> {
+  const accountSlug = options.account || process.env["ARGOS_ACCOUNT"];
+  if (!accountSlug) {
+    fail("An account is required. Use --account <slug> or set ARGOS_ACCOUNT.");
+  }
+  const client = createApiClient(await resolveToken(options));
+  return { client, accountSlug };
 }

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -1,4 +1,5 @@
 import { Option } from "commander";
+import { fail } from "./lib/cli-error";
 
 export type ParallelNonceOption = { parallelNonce?: string | undefined };
 export const parallelNonceOption = new Option(
@@ -27,6 +28,11 @@ export const accountOption = new Option(
   "Slug of the account (personal or team) that will own the project",
 );
 
+export const accountSlugOption = new Option(
+  "--account <slug>",
+  "Slug of the account (personal or team) to act on. Also ARGOS_ACCOUNT",
+);
+
 export type JsonOption = { json?: boolean | undefined };
 export const jsonOption = new Option(
   "--json",
@@ -48,6 +54,29 @@ export const testProjectPathOption = new Option(
   "--project <owner/project>",
   "Project the test belongs to, in owner/project format. Also ARGOS_PROJECT. Optional with a project token, which already identifies its project",
 );
+
+export const managedProjectPathOption = new Option(
+  "--project <owner/project>",
+  "Project to act on, in owner/project format. Also ARGOS_PROJECT",
+);
+
+/** Default number of items a paginated command fetches. */
+export const DEFAULT_LIMIT = 100;
+
+export type LimitOption = { limit: string };
+export const limitOption = new Option(
+  "--limit <number>",
+  "Maximum number of items to fetch, following pagination as needed",
+).default(String(DEFAULT_LIMIT));
+
+/** Parse a `--limit` value into a positive integer, or abort. */
+export function toLimit(value: string): number {
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1) {
+    fail(`--limit must be a positive integer, received "${value}".`);
+  }
+  return limit;
+}
 
 /** API values accepted by the `metricsPeriod` query parameter. */
 export type MetricsPeriod =

--- a/skills/argos-cli/SKILL.md
+++ b/skills/argos-cli/SKILL.md
@@ -2,11 +2,13 @@
 name: argos-cli
 description: >
   Operate Argos visual testing from the terminal with the `argos` CLI — inspect
-  builds and snapshot diffs, submit reviews, post comments, inspect a test's
-  flakiness and its recurring changes, ignore flaky test changes, fetch
-  analytics, upload screenshots, and manage CI builds. Use
-  whenever running `argos` commands or working with Argos builds, snapshots,
-  flakiness, or visual-regression reviews from a shell, script, or CI pipeline.
+  builds and snapshot diffs, submit reviews, request reviewers, post comments,
+  inspect a test's flakiness and its recurring changes, ignore flaky test
+  changes, configure a project and its contributors, manage a team's members,
+  invites and email domains, manage automation rules, fetch analytics, upload
+  screenshots, and manage CI builds. Use whenever running `argos` commands or
+  working with Argos builds, snapshots, flakiness, projects, teams, or
+  visual-regression reviews from a shell, script, or CI pipeline.
   Load before running `argos` — it covers the token model and JSON output
   contract that prevent silent failures.
 license: MIT
@@ -14,7 +16,7 @@ metadata:
   author: argos-ci
   homepage: https://argos-ci.com
   source: https://github.com/argos-ci/argos-javascript
-argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project owner/project` for build-number refs on review/comment commands, for every `change` command, and for `test` commands unless the token is a project token.
+argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project owner/project` for build-number refs on review/comment commands, for every `change`, `project` and `automation` command, and for `test` commands unless the token is a project token; `--account <slug>` (or ARGOS_ACCOUNT) for every `account` command.
 ---
 
 # Argos CLI
@@ -39,31 +41,41 @@ account, so every `change` command needs `--project owner/project` (or
 `ARGOS_PROJECT`). A `<testId>` comes from a diff's `test.id` and carries the
 project name but not the account, so `test` commands need the same
 `--project`/`ARGOS_PROJECT` — except with a project token, which already
-identifies its own project.
+identifies its own project. `project` and `automation` commands take the same
+`--project owner/project`; `account` commands take `--account <slug>` (or
+`ARGOS_ACCOUNT`).
 
 Two token types — pick by command:
 
-| Commands                                                                             | Token                       | Resolution order                            |
-| ------------------------------------------------------------------------------------ | --------------------------- | ------------------------------------------- |
-| `build get`, `build snapshots`, `test get`, `test changes`                           | Project token               | `--token` › `ARGOS_TOKEN`                   |
-| `review *`, `comment *`, `test comment *`, `change *`, `analytics`, `create-project` | Personal access token (PAT) | `--token` › `ARGOS_TOKEN` › `argos login`   |
-| `upload`, `finalize`, `skip`, `deploy`                                               | CI / project token          | `--token` › `ARGOS_TOKEN` (or tokenless CI) |
+| Commands                                                                                                                                                                                                                                                                                      | Token                       | Resolution order                            |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------- |
+| `build get`, `build snapshots`, `test list`, `test get`, `test changes`, `change list`, `project get`, `project deployments`, `project domain get`                                                                                                                                            | Project token               | `--token` › `ARGOS_TOKEN`                   |
+| `review *`, `comment *`, `test comment *`, `test subscribe` / `unsubscribe`, `build subscribe` / `unsubscribe`, `change ignore` / `unignore`, `account *`, `project update`, `project transfer`, `project contributor *`, `project domain set`, `automation *`, `analytics`, `create-project` | Personal access token (PAT) | `--token` › `ARGOS_TOKEN` › `argos login`   |
+| `upload`, `finalize`, `skip`, `deploy`                                                                                                                                                                                                                                                        | CI / project token          | `--token` › `ARGOS_TOKEN` (or tokenless CI) |
 
-Project tokens read build data but **cannot** review, comment, or ignore
-changes — those need a PAT. If no suitable token is available, ask the user. For
-these actions, if no PAT exists, report the conclusion and evidence instead of
-acting. `argos login` is for interactive humans, not CI.
+Project tokens read build data but **cannot** review, comment, ignore changes, or
+administer a project or team — those need a PAT. If no suitable token is
+available, ask the user. For these actions, if no PAT exists, report the
+conclusion and evidence instead of acting. `argos login` is for interactive
+humans, not CI.
 
 ## Commands
 
-- **Inspect** — `build get <ref>` · `build snapshots <ref> [--needs-review] [--metrics-period 24h|3d|7d|30d|90d]`
-- **Review** — `review list <ref>` · `review create <ref> --event <approve|reject|comment> [--body <md>]` · `review dismiss <ref> <reviewId>`
+- **Inspect** — `build get <ref>` · `build snapshots <ref> [--needs-review] [--metrics-period 24h|3d|7d|30d|90d]` · `build subscribe|unsubscribe <ref>`
+- **Review** — `review list <ref>` · `review create <ref> --event <approve|reject|comment> [--body <md>]` · `review dismiss <ref> <reviewId>` · `review reviewer list <ref>` · `review reviewer add|remove <ref> <userId...>`
 - **Comment** — `comment list <ref>` · `comment create <ref> --body <md> [--reply-to <id>] [--diff <id>] [--draft]` · `comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <ref> <id>` · `comment react|unreact <ref> <id> <emoji>`
-- **Flakiness** — `test get <testId>` · `test changes <testId> [--ignored true|false] [--metrics-period …]` · `change ignore <changeId> --project owner/project` · `change unignore <changeId> --project owner/project`
+- **Flakiness** — `test list [--build-name <name>] [--search <q>]` · `test get <testId>` · `test changes <testId> [--ignored true|false] [--metrics-period …]` · `test subscribe|unsubscribe <testId>` · `change list` · `change ignore|unignore <changeId> --project owner/project`
 - **Test comments** — `test comment list|create <testId>` · `test comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <testId> <id>` · `test comment react|unreact <testId> <id> <emoji>`
+- **Project** — `project get` · `project update [--name …] [--summary-check …] [--default-user-level …] [--ignore-changes true|false] [--deployments true|false] …` · `project transfer --to <slug>` · `project contributor list|set|remove` · `project deployments [--environment preview|production]` · `project domain get|set <domain>`
+- **Automation** — `automation list [--active true|false]` · `automation get <ruleId>` · `automation create|update [<ruleId>] --definition-file <path>` · `automation deactivate <ruleId>`
+- **Team** — `account get` · `account update --default-user-level <member|contributor>` · `account member list|set-level|remove` · `account invite list|create|cancel|reset-link` · `account domain list|add|remove`
 - **Account** — `analytics --account <slug>` · `create-project <name> --account <slug>` · `whoami`
 - **CI** — `upload <dir>` · `finalize` · `skip` · `deploy <dir>`
 - **Auth** — `login` · `logout`
+
+List commands (`test list`, `change list`, `account member list`, `project
+contributor list`, `project deployments`, `automation list`, `account invite
+list`) follow pagination up to `--limit` (default 100).
 
 `build snapshots --json` enriches each diff with `test.metrics` (flakiness:
 `stability`, `consistency`, `flakiness`, all 0–1) and, on a change, `change`
@@ -89,6 +101,15 @@ argos change ignore <changeId> --token <pat> --project owner/project
 # revert: argos change unignore <changeId> --token <pat> --project owner/project
 ```
 
+Work through a project's flakiness backlog. `test list` returns the tests still
+running in the project, flakiest first, so the first page is what to stabilise;
+`change list` audits what has already been silenced:
+
+```bash
+ARGOS_TOKEN=<project-token> argos test list --project owner/project --json --limit 20
+ARGOS_TOKEN=<project-token> argos change list --project owner/project --json   # already ignored
+```
+
 Diagnose a flaky test before deciding whether to fix it or ignore it. `test get`
 reports how flaky it is; `test changes` lists the distinct changes most-frequent
 first, each with the diff, baseline and head image URLs to look at:
@@ -111,4 +132,29 @@ Parallel builds:
 ```bash
 argos upload ./screenshots --parallel-nonce $ID --parallel-index $i --parallel-total $n
 argos finalize --parallel-nonce $ID
+```
+
+Onboard someone onto a team and a project. Team roles come from `account`,
+per-project access from `project contributor` — owners and members already reach
+every project, so contributors are the only ones that need a grant:
+
+```bash
+argos account invite create dev@acme.com --account acme --level contributor --json
+argos account member list --account acme --search dev --json          # read back user.id once they accept
+argos project contributor set <userId> --level reviewer --project acme/web --json
+```
+
+Configure a project. `project update` only changes the settings you pass, and
+prints the project back so you can check what it ended up with:
+
+```bash
+argos project get --project acme/web --json
+argos project update --project acme/web --summary-check auto --ignore-changes true --auto-ignore-after 3 --json
+```
+
+Ask for a review on a build, then check who is still on the hook:
+
+```bash
+argos review reviewer add <ref> <userId> --token <pat> --project acme/web
+argos review reviewer list <ref> --token <pat> --project acme/web --json
 ```


### PR DESCRIPTION
Follows [argos-ci/argos#2440](https://github.com/argos-ci/argos/pull/2440), which adds 34 REST endpoints. This brings them to the CLI.

`packages/api-client/src/schema.ts` is regenerated from that PR's OpenAPI document — the same output `pnpm run build-schema-types` will produce once it is deployed. I checked the generator against production first: regenerating from the live `openapi.yaml` reproduces main's committed `schema.ts` operation-for-operation, and the PR branch adds exactly the 34 new operations and removes none. The diff is large because the committed file also predates a few description changes already live in production.

## New command groups

| Command | What it does |
| --- | --- |
| `account get` / `update` | Plan, current-period usage, and the role given to users who join through the invite link or a verified domain |
| `account member list \| set-level \| remove` | A team's members and their roles |
| `account invite list \| create \| cancel \| reset-link` | Pending invitations and the shared invite link |
| `account domain list \| add \| remove` | The email domains a team is open to |
| `project get` / `update` / `transfer` | Read a project's settings, change them one flag at a time, move it to another account |
| `project contributor list \| set \| remove` | Per-project access for users who are not team members |
| `project deployments` | Deployments, most recent first, filterable by environment |
| `project domain get \| set` | The domain production deployments are served on |
| `automation list \| get \| create \| update \| deactivate` | A project's automation rules |

## Added to existing groups

- `test list` — the project's tests, flakiest first. The first page is the flakiness backlog.
- `change list` — the changes currently ignored in a project, to audit what has been silenced.
- `test subscribe` / `unsubscribe`, `build subscribe` / `unsubscribe`.
- `review reviewer list \| add \| remove` — the review requests standing on a build.

## Notes

- **Pagination is shared.** `lib/pagination.ts` walks a paginated endpoint up to `--limit` (default 100). It keeps `perPage` **constant** across pages: the API turns `page` into an offset by multiplying it by `perPage`, so shrinking the last page to "just what is missing" would skip items. The overshoot is trimmed client-side instead. Covered by unit tests.
- **Auth mode follows the endpoint's own security.** Read-only endpoints that accept a project token (`test list`, `change list`, `project get`, `project deployments`, `project domain get`) fall back to the token's own project the way `build get` does. Everything else is declared `user`, so it asks for `--project` / `--account` explicitly and gets the personal-access-token hint on a 401/403 — this matters for `project contributor list` and `listBuildReviewers`, which read but are *not* open to project tokens.
- **`project update` only sends what you pass.** Every setting takes an explicit value (`--summary-check auto`, `--deployments true`, `--private inherit`) rather than a `--no-x` pair, so a script never has to guess whether an omitted flag means "false" or "leave alone". Nullable strings reset with an empty value. `ignoreConfig` is the one exception the API takes whole, so touching either half reads the project back first and merges.
- **Automation rules take JSON.** Conditions and actions are a tagged union with a `not`/`glob` wrapper — not something to flatten into flags. `--definition` / `--definition-file` mirror the existing `--body` / `--body-file` pattern, and `--help` prints a worked example.
- **`204` responses** go through a new `unwrapEmpty`, since `unwrap` treats an empty body as an error. The commands return a small `{ removed: true, … }` object so `--json` still has something to read.
- `formatProject` now renders a project's settings. The old "Created project …" wording moved to `formatCreatedProject`, which is what `create-project` actually wanted.
- The `argos-cli` skill is updated: new commands, the token table, and three flows (onboarding someone onto a team and a project, configuring a project, requesting reviewers).

## Testing

- `check-types`, `lint`, `check-format` clean on `@argos-ci/cli` and `@argos-ci/api-client`.
- 57/57 unit tests pass, including new coverage for `fetchPages` and `formatProject`.
- Built the CLI and walked the whole command tree by hand: every group and subcommand resolves, `--help` renders at all three levels, and the argument/flag validation paths (missing account, nothing to update, missing rule definition, `--limit 0`) produce the right errors.
- The e2e suite hits a live API with credentials, so it was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
