### PR TITLE
chore: ignore *.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 # Dist
 dist/
+# TypeScript incremental build info
+*.tsbuildinfo
 # Generated docs
 /docs
 # Storybook


### PR DESCRIPTION
Running `npx tsc --noEmit` at the repo root writes `tsconfig.tsbuildinfo`, which was not covered by `.gitignore` and therefore showed up as an untracked file that could be committed by accident.

Adds `*.tsbuildinfo` next to the `dist/` entry. The pattern is unanchored, so it also covers per-package build info files (e.g. `packages/*/tsconfig.tsbuildinfo`).

`git ls-files | grep tsbuildinfo` returns nothing — no such file is currently tracked, so no index cleanup was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)