### PR TITLE
feat: record the capture order of screenshots

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -10,6 +10,8 @@ import { getGlobalScript } from "@argos-ci/browser";
 import {
   getMetadataPath,
   getScreenshotName,
+  getTestRunKey,
+  nextCaptureIndex,
   normalizeBaseNames,
   type ScreenshotMetadata,
   validateThreshold,
@@ -216,6 +218,15 @@ Cypress.Commands.add(
 
     injectArgos();
 
+    // One index per command, not per file: the viewport variants below are the
+    // same step of the journey seen at several widths, so they share it.
+    const captureIndex = nextCaptureIndex(
+      getTestRunKey({
+        titlePath: Cypress.currentTest.titlePath,
+        retry: Cypress.currentRetry,
+      }),
+    );
+
     const afterAll = beforeAll(options);
 
     function stabilizeAndScreenshot(name: string, baseNames: string[] | null) {
@@ -270,6 +281,7 @@ Cypress.Commands.add(
             name: "@argos-ci/cypress",
             version,
           },
+          capture: { index: captureIndex },
         };
 
         metadata.transient = {};

--- a/packages/playwright/src/metadata.ts
+++ b/packages/playwright/src/metadata.ts
@@ -29,6 +29,12 @@ export type MetadataConfig = {
   test?: ScreenshotMetadata["test"];
   story?: ScreenshotMetadata["story"];
   viewport?: ScreenshotMetadata["viewport"];
+  /**
+   * Position of the screenshot within its test. Injected by SDKs that drive
+   * Playwright without a Playwright test (Vitest), where the counter has to be
+   * kept on the side that owns the test context.
+   */
+  captureIndex?: number | null;
 };
 
 /**

--- a/packages/playwright/src/screenshot.ts
+++ b/packages/playwright/src/screenshot.ts
@@ -37,6 +37,7 @@ import {
   prepare,
   screenshotToSnapshotPath,
   setViewportSize,
+  takeCaptureIndex,
   waitForReadiness,
 } from "./util";
 import { writeFile } from "node:fs/promises";
@@ -199,6 +200,10 @@ export async function argosScreenshot(
 
   const testInfo = await getTestInfo();
 
+  // One index per call, not per file: the viewport variants below are the same
+  // step of the journey seen at several widths, so they share it.
+  const captureIndex = takeCaptureIndex(testInfo);
+
   const useArgosReporter = checkIsUsingArgosReporter(testInfo);
 
   await prepare({ handler, useArgosReporter, root });
@@ -227,6 +232,7 @@ export async function argosScreenshot(
       names,
       testInfo,
       useArgosReporter,
+      captureIndex,
     });
 
     if (options.tag) {

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -12,7 +12,11 @@ import {
   type StabilizationContext,
   type ViewportSize,
 } from "@argos-ci/browser";
-import type { ScreenshotMetadata } from "@argos-ci/util";
+import {
+  getTestRunKey,
+  nextCaptureIndex,
+  type ScreenshotMetadata,
+} from "@argos-ci/util";
 import { dirname, resolve } from "node:path";
 import { mkdir } from "node:fs/promises";
 import type { ArgosAttachment } from "./attachment";
@@ -95,6 +99,29 @@ export async function getTestInfo() {
   } catch {
     return null;
   }
+}
+
+/**
+ * Take the next capture index for the running test, or `null` when the
+ * screenshot isn't taken from a test — there is no sequence to record then.
+ */
+export function takeCaptureIndex(testInfo: TestInfo | null): number | null {
+  // Another SDK drives Playwright and owns the test context (Vitest): it
+  // counts on its side and hands us the result.
+  const injected = getMetadataOverrides()?.captureIndex;
+  if (injected != null) {
+    return injected;
+  }
+  if (!testInfo) {
+    return null;
+  }
+  return nextCaptureIndex(
+    getTestRunKey({
+      id: testInfo.testId,
+      retry: testInfo.retry,
+      repeat: testInfo.repeatEachIndex,
+    }),
+  );
 }
 
 /**
@@ -249,11 +276,21 @@ export async function getPathAndMetadata(args: {
   extension: string;
   root: string;
   useArgosReporter: boolean;
+  /** Position of the screenshot in its test, see {@link takeCaptureIndex}. */
+  captureIndex?: number | null;
 }): Promise<{
   metadata: ScreenshotMetadataWithTransient;
   path: string;
 }> {
-  const { handler, testInfo, names, extension, root, useArgosReporter } = args;
+  const {
+    handler,
+    testInfo,
+    names,
+    extension,
+    root,
+    useArgosReporter,
+    captureIndex,
+  } = args;
   const overrides = getMetadataOverrides();
 
   const path =
@@ -304,6 +341,10 @@ export async function getPathAndMetadata(args: {
 
   if (viewport) {
     metadata.viewport = viewport;
+  }
+
+  if (captureIndex != null) {
+    metadata.capture = { index: captureIndex };
   }
 
   metadata.transient = {};

--- a/packages/util/src/browser.ts
+++ b/packages/util/src/browser.ts
@@ -1,5 +1,6 @@
 export { getMetadataPath } from "./metadata";
 export type { ScreenshotMetadata } from "./metadata";
 export * from "./base-name";
+export * from "./capture-index";
 export * from "./name";
 export * from "./threshold";

--- a/packages/util/src/capture-index.test.ts
+++ b/packages/util/src/capture-index.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearCaptureIndex,
+  getTestRunKey,
+  nextCaptureIndex,
+  resetCaptureIndexes,
+} from "./capture-index";
+
+beforeEach(() => {
+  resetCaptureIndexes();
+});
+
+describe("nextCaptureIndex", () => {
+  it("numbers the captures of a test from 0", () => {
+    expect(nextCaptureIndex("test")).toBe(0);
+    expect(nextCaptureIndex("test")).toBe(1);
+    expect(nextCaptureIndex("test")).toBe(2);
+  });
+
+  it("counts each test independently", () => {
+    expect(nextCaptureIndex("a")).toBe(0);
+    expect(nextCaptureIndex("b")).toBe(0);
+    expect(nextCaptureIndex("a")).toBe(1);
+  });
+
+  it("starts over once a test run is cleared", () => {
+    nextCaptureIndex("test");
+    clearCaptureIndex("test");
+    expect(nextCaptureIndex("test")).toBe(0);
+  });
+});
+
+describe("getTestRunKey", () => {
+  it("gives a retry its own counter", () => {
+    const first = getTestRunKey({ id: "t1", retry: 0 });
+    const retry = getTestRunKey({ id: "t1", retry: 1 });
+    expect(first).not.toBe(retry);
+    expect(nextCaptureIndex(first)).toBe(0);
+    expect(nextCaptureIndex(retry)).toBe(0);
+  });
+
+  it("gives a repeat its own counter", () => {
+    expect(getTestRunKey({ id: "t1", repeat: 0 })).not.toBe(
+      getTestRunKey({ id: "t1", repeat: 1 }),
+    );
+  });
+
+  it("falls back to the title path when there is no id", () => {
+    expect(getTestRunKey({ titlePath: ["a.spec.ts", "checkout"] })).toBe(
+      "a.spec.ts › checkout#0@0",
+    );
+  });
+
+  it("treats missing retry and repeat as the first run", () => {
+    expect(getTestRunKey({ id: "t1" })).toBe(
+      getTestRunKey({ id: "t1", retry: 0, repeat: 0 }),
+    );
+  });
+});

--- a/packages/util/src/capture-index.ts
+++ b/packages/util/src/capture-index.ts
@@ -1,0 +1,48 @@
+/**
+ * Capture order.
+ *
+ * A test walks a journey and screenshots it step by step, but nothing of that
+ * sequence survives the upload: the CLI discovers snapshot files by globbing a
+ * directory, which yields them alphabetically. Numbering each screenshot as it
+ * is taken is what lets Argos replay the journey in the order it happened.
+ *
+ * Counters are scoped to a test run rather than to a test, so a retry starts
+ * over at 0 instead of continuing the previous attempt's numbering.
+ */
+const counters = new Map<string, number>();
+
+/**
+ * Return the next 0-based capture index for `testRunKey` and advance it.
+ */
+export function nextCaptureIndex(testRunKey: string): number {
+  const index = counters.get(testRunKey) ?? 0;
+  counters.set(testRunKey, index + 1);
+  return index;
+}
+
+/**
+ * Forget the counter of a test run. Called when a test ends, so a long worker
+ * process doesn't keep one entry per test it has run.
+ */
+export function clearCaptureIndex(testRunKey: string): void {
+  counters.delete(testRunKey);
+}
+
+/** Drop every counter. Exposed for tests. */
+export function resetCaptureIndexes(): void {
+  counters.clear();
+}
+
+/**
+ * Build the key identifying a single run of a test. The retry and repeat
+ * counters are part of it so each attempt numbers its screenshots from 0.
+ */
+export function getTestRunKey(test: {
+  id?: string | null;
+  titlePath?: string[];
+  retry?: number | null;
+  repeat?: number | null;
+}): string {
+  const identity = test.id ?? test.titlePath?.join(" › ") ?? "";
+  return `${identity}#${test.retry ?? 0}@${test.repeat ?? 0}`;
+}

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./base-name";
+export * from "./capture-index";
 export * from "./fs";
 export * from "./git";
 export * from "./introspection";

--- a/packages/util/src/metadata.ts
+++ b/packages/util/src/metadata.ts
@@ -88,6 +88,14 @@ export type ScreenshotMetadata = {
     /** @description The version of the Argos SDK */
     version: string;
   };
+  /** @description How the screenshot was captured within its test */
+  capture?: {
+    /**
+     * @description The 0-based position of the screenshot within its test,
+     * following capture order
+     */
+    index: number;
+  } | null;
   // Metadata used to pass informations later removed from metadata.
   transient?: {
     /** Threshold configured for this screenshot. */

--- a/packages/vitest/src/command.ts
+++ b/packages/vitest/src/command.ts
@@ -22,6 +22,7 @@ export type ArgosScreenshotCommandArgs = [
   name: string,
   options?: VitestScreenshotOptions,
   test?: TestMetadata,
+  captureIndex?: number | null,
 ];
 
 /**
@@ -35,7 +36,7 @@ export type ArgosScreenshotCommandArgs = [
 export const createArgosScreenshotCommand = (
   pluginOptions: ArgosVitestPluginOptions = {},
 ): BrowserCommand<ArgosScreenshotCommandArgs> => {
-  return async (ctx, name, options, test) => {
+  return async (ctx, name, options, test, captureIndex) => {
     if (!name) {
       throw new Error("The `name` argument is required.");
     }
@@ -60,6 +61,8 @@ export const createArgosScreenshotCommand = (
           // (Playwright's own `testInfo` is absent here). It resolves
           // `location.file` relative to the git repository.
           test,
+          // Counted on the test side, for the same reason.
+          captureIndex,
         });
       };
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,6 +1,10 @@
 import type { ArgosAttachment } from "@argos-ci/playwright";
 import { resolveAutoName } from "./auto-name";
-import { getTestMetadata, type TestMetadata } from "./metadata";
+import {
+  getTestMetadata,
+  takeCaptureIndex,
+  type TestMetadata,
+} from "./metadata";
 import type {
   SerializableSnapshotOptions,
   VitestScreenshotOptions,
@@ -88,11 +92,12 @@ export async function argosScreenshot(
     return [];
   }
 
-  const [resolvedName, test] = await Promise.all([
+  const [resolvedName, test, captureIndex] = await Promise.all([
     resolveAutoName(name, { reservedLength: SCREENSHOT_NAME_RESERVED }),
     // Gather the test metadata here (browser side), where the Vitest test
     // context is available; it crosses the RPC boundary to the Node command.
     getTestMetadata(),
+    takeCaptureIndex(),
   ]);
 
   // Load vitest/browser using dynamic import to avoid loading it in non-Vitest
@@ -100,7 +105,12 @@ export async function argosScreenshot(
   const { server } = await import("vitest/browser");
   // Pass a defined `options` so the trailing `test` argument is never preceded
   // by an `undefined` hole (which the browser/node RPC would drop).
-  return server.commands.argosScreenshot(resolvedName, options ?? {}, test);
+  return server.commands.argosScreenshot(
+    resolvedName,
+    options ?? {},
+    test,
+    captureIndex,
+  );
 }
 
 /**
@@ -151,7 +161,7 @@ export async function argosSnapshot(
   const extension = rawExtension.startsWith(".")
     ? rawExtension
     : `.${rawExtension}`;
-  const [resolvedName, test] = await Promise.all([
+  const [resolvedName, test, captureIndex] = await Promise.all([
     resolveAutoName(options.name, {
       reservedLength:
         ".snapshot".length + extension.length + METADATA_SUFFIX.length,
@@ -159,6 +169,7 @@ export async function argosSnapshot(
     // Gather the test metadata here (browser or Node), where the Vitest test
     // context is available.
     getTestMetadata(),
+    takeCaptureIndex(),
   ]);
 
   // Serialize on the test side (browser or Node), so values that only exist
@@ -183,12 +194,19 @@ export async function argosSnapshot(
       serialized,
       serializableOptions,
       test,
+      captureIndex,
     );
   }
 
   // Node: write directly to disk.
   const { writeSnapshotFile } = await import("./snapshot-file");
-  return writeSnapshotFile(resolvedName, serialized, serializableOptions, test);
+  return writeSnapshotFile(
+    resolvedName,
+    serialized,
+    serializableOptions,
+    test,
+    captureIndex,
+  );
 }
 
 /**

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -32,12 +32,14 @@ declare module "vitest/browser" {
       name: string,
       options?: VitestScreenshotOptions,
       test?: TestMetadata,
+      captureIndex?: number | null,
     ) => Promise<ArgosAttachment[]>;
     argosSnapshot: (
       name: string,
       content: string,
       options?: SerializableSnapshotOptions,
       test?: TestMetadata,
+      captureIndex?: number | null,
     ) => Promise<ArgosAttachment[]>;
   }
 }

--- a/packages/vitest/src/metadata.ts
+++ b/packages/vitest/src/metadata.ts
@@ -1,4 +1,8 @@
-import type { ScreenshotMetadata } from "@argos-ci/util";
+import {
+  getTestRunKey,
+  nextCaptureIndex,
+  type ScreenshotMetadata,
+} from "@argos-ci/util";
 import {
   getCurrentTest,
   type CurrentSuite,
@@ -85,4 +89,26 @@ export async function getTestMetadata(): Promise<TestMetadata> {
     return null;
   }
   return buildTestMetadata(task);
+}
+
+/**
+ * Take the next capture index for the current Vitest test, or `null` outside a
+ * test. Screenshots and snapshots share the counter, so a test that mixes both
+ * still numbers them in the order it produced them.
+ *
+ * Runs on the test side, where the test context is available; the number then
+ * crosses the RPC boundary to the Node command.
+ */
+export async function takeCaptureIndex(): Promise<number | null> {
+  const task = await getCurrentTest();
+  if (!task) {
+    return null;
+  }
+  return nextCaptureIndex(
+    getTestRunKey({
+      id: task.id,
+      retry: task.result?.retryCount ?? undefined,
+      repeat: task.result?.repeatCount ?? undefined,
+    }),
+  );
 }

--- a/packages/vitest/src/snapshot-command.test.ts
+++ b/packages/vitest/src/snapshot-command.test.ts
@@ -29,6 +29,7 @@ describe("createArgosSnapshotCommand", () => {
       "serialized",
       { root: "/abs/screenshots" },
       undefined,
+      undefined,
     );
   });
 
@@ -43,6 +44,7 @@ describe("createArgosSnapshotCommand", () => {
       "user",
       "serialized",
       { root: "/other", extension: ".json", tag: "a" },
+      undefined,
       undefined,
     );
   });
@@ -61,6 +63,19 @@ describe("createArgosSnapshotCommand", () => {
       "serialized",
       { root: "/abs/screenshots" },
       test,
+      undefined,
+    );
+  });
+
+  it("forwards the capture index to the writer", async () => {
+    const command = createArgosSnapshotCommand({ root: "/abs/screenshots" });
+    await command(ctx, "user", "serialized", undefined, undefined, 2);
+    expect(writeSnapshotFile).toHaveBeenCalledWith(
+      "user",
+      "serialized",
+      { root: "/abs/screenshots" },
+      undefined,
+      2,
     );
   });
 });

--- a/packages/vitest/src/snapshot-command.ts
+++ b/packages/vitest/src/snapshot-command.ts
@@ -17,6 +17,7 @@ export type ArgosSnapshotCommandArgs = [
   content: string,
   options?: SerializableSnapshotOptions,
   test?: TestMetadata,
+  captureIndex?: number | null,
 ];
 
 /**
@@ -33,6 +34,7 @@ export const createArgosSnapshotCommand = (
     content,
     options,
     test,
+    captureIndex,
   ): Promise<ArgosAttachment[]> => {
     if (!name) {
       throw new Error("The `name` argument is required.");
@@ -41,6 +43,6 @@ export const createArgosSnapshotCommand = (
       root: pluginOptions.root,
       ...options,
     };
-    return writeSnapshotFile(name, content, merged, test);
+    return writeSnapshotFile(name, content, merged, test, captureIndex);
   };
 };

--- a/packages/vitest/src/snapshot-file.ts
+++ b/packages/vitest/src/snapshot-file.ts
@@ -71,6 +71,7 @@ export async function writeSnapshotFile(
   content: string,
   options: SerializableSnapshotOptions = {},
   test?: TestMetadata,
+  captureIndex?: number | null,
 ): Promise<ArgosAttachment[]> {
   if (!name) {
     throw new Error("The `name` argument is required.");
@@ -100,6 +101,7 @@ export async function writeSnapshotFile(
     sdk: { name: "@argos-ci/vitest", version: sdkVersion },
     ...(tags ? { tags } : {}),
     ...(resolvedTest ? { test: resolvedTest } : {}),
+    ...(captureIndex != null ? { capture: { index: captureIndex } } : {}),
   };
 
   await createDirectory(dirname(snapshotPath));


### PR DESCRIPTION
A test walks a journey and screenshots it step by step, but none of that sequence reaches Argos: the CLI discovers snapshot files by globbing a directory, which yields them alphabetically. Each screenshot now carries its 0-based position within its test in `capture.index`, which is what lets Argos replay a journey in the order it happened.

Covered in Playwright, Cypress and Vitest — the three SDKs that report a test title path. Counters are scoped to a test run so a retry starts over at 0, and one index is taken per call rather than per file so viewport variants of the same screen share it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)