### PR TITLE
feat(cli): detect the pull request with gh, print one Markdown embed for the batch

### DIFF
--- a/packages/cli/src/commands/media/upload.ts
+++ b/packages/cli/src/commands/media/upload.ts
@@ -3,13 +3,13 @@ import { Option } from "commander";
 import ora from "ora";
 import { uploadMedia, type Media, type MediaState } from "@argos-ci/core";
 import { getApiBaseUrl } from "../../lib/api";
-import { formatMediaList } from "../../lib/format";
+import { formatUploadedMediaList } from "../../lib/format";
+import { resolveUploadPrNumber } from "../../lib/media-pr";
 import { handleCliError, output } from "../../lib/run";
 import { resolveOptionalToken } from "../../lib/target";
 import {
   jsonOption,
   mediaProjectPathOption,
-  toPrNumber,
   tokenOption,
   type JsonOption,
 } from "../../options";
@@ -18,7 +18,11 @@ type UploadMediaOptions = JsonOption & {
   token?: string | undefined;
   project?: string | undefined;
   branch?: string | undefined;
-  pr?: string | undefined;
+  /**
+   * The pull request to publish to: a number as given, `false` for `--no-pr`,
+   * or absent when the caller said nothing and autodetection should run.
+   */
+  pr?: string | false | undefined;
   state?: MediaState | undefined;
   description?: string | undefined;
   visibility?: "team" | "public" | undefined;
@@ -43,7 +47,13 @@ export function registerMediaUpload(media: Command) {
     .addOption(
       new Option(
         "--pr <number>",
-        "Pull request to publish the media to. Argos keeps one comment on it listing every media uploaded, edited in place",
+        "Pull request to publish the media to. Argos keeps one comment on it listing every media uploaded, edited in place. Detected with the GitHub CLI when neither this nor --branch is given",
+      ),
+    )
+    .addOption(
+      new Option(
+        "--no-pr",
+        "Skip pull request detection and upload the media unattached",
       ),
     )
     .addOption(
@@ -91,8 +101,7 @@ export function registerMediaUpload(media: Command) {
           apiBaseUrl: getApiBaseUrl(),
           project: options.project,
           branch: options.branch,
-          prNumber:
-            options.pr === undefined ? undefined : toPrNumber(options.pr),
+          prNumber: await resolveUploadPrNumber(options),
           state: options.state,
           description: options.description,
           visibility: options.visibility,
@@ -100,7 +109,7 @@ export function registerMediaUpload(media: Command) {
         });
 
         spinner?.stop();
-        output(results, options, formatMediaList);
+        output(results, options, formatUploadedMediaList);
       } catch (error) {
         spinner?.stop();
         handleCliError(error, "project");

--- a/packages/cli/src/lib/format.test.ts
+++ b/packages/cli/src/lib/format.test.ts
@@ -15,6 +15,7 @@ import {
   formatSnapshotSummary,
   formatSnapshots,
   formatStats,
+  formatUploadedMediaList,
   formatValue,
 } from "./format";
 
@@ -453,6 +454,122 @@ describe("formatMedia / formatMediaList", () => {
     const output = formatMedia(afterAbandonedUpload);
     expect(output).toContain("Version: 3 (2 uploaded)");
     expect(output).not.toContain("of 2");
+  });
+});
+
+describe("formatUploadedMediaList", () => {
+  function uploaded(attributes: Partial<Media>): Media {
+    return {
+      id: "1",
+      name: "checkout.png",
+      state: null,
+      description: null,
+      stage: "published",
+      branch: null,
+      prNumber: 20,
+      url: "https://app.argos-ci.com/m/tok",
+      markdown: "[![checkout.png](https://files/abc.webp)](https://app/m/tok)",
+      version: 1,
+      versionCount: 1,
+      fileUrl: "https://files/abc.webp",
+      posterUrl: null,
+      contentType: "image/webp",
+      sizeBytes: 1024,
+      width: 800,
+      height: 600,
+      visibility: "team",
+      status: "ready",
+      expiresAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      ...attributes,
+    } as unknown as Media;
+  }
+
+  const before = uploaded({
+    id: "1",
+    state: "before",
+    url: "https://app/m/before",
+    markdown:
+      "[![checkout.png](https://files/before.webp)](https://app/m/before)",
+  });
+  const after = uploaded({
+    id: "2",
+    state: "after",
+    url: "https://app/m/after",
+    markdown:
+      "[![checkout.png](https://files/after.webp)](https://app/m/after)",
+  });
+
+  it("adds nothing for a single upload", () => {
+    // Its own `Markdown:` line already is the thing to paste; a one-row table
+    // says nothing more.
+    const output = formatUploadedMediaList([uploaded({})]);
+    expect(output).toBe(formatMediaList([uploaded({})]));
+    expect(output).not.toContain("| Name |");
+  });
+
+  it("puts a pair's two halves in one row, like the pull request comment", () => {
+    const output = formatUploadedMediaList([before, after]);
+
+    expect(output).toContain("Markdown for all of them:");
+    expect(output).toContain("| Name | Before | After |");
+    expect(output).toContain(
+      `| checkout.png | ${before.markdown} | ${after.markdown} |`,
+    );
+  });
+
+  it("keeps unpaired media to a single preview column", () => {
+    const output = formatUploadedMediaList([
+      uploaded({ id: "1", name: "a.png" }),
+      uploaded({ id: "2", name: "b.png" }),
+    ]);
+
+    expect(output).toContain("| Name | Preview |");
+    expect(output).not.toContain("| Before |");
+  });
+
+  it("does not let a solo media absorb a pair that shares its name", () => {
+    // Grouping is keyed on the name for a pair and on the id for a lone media,
+    // so a standalone `checkout.png` stays its own row.
+    const output = formatUploadedMediaList([
+      before,
+      after,
+      uploaded({ id: "3" }),
+    ]);
+
+    expect(
+      output.split("\n").filter((line) => line.startsWith("| checkout")).length,
+    ).toBe(2);
+  });
+
+  it("carries the pair's note into a Notes column", () => {
+    const output = formatUploadedMediaList([
+      before,
+      { ...after, description: "Spacing fix." } as Media,
+    ]);
+
+    expect(output).toContain("| Name | Before | After | Notes |");
+    expect(output).toContain("| Spacing fix. |");
+  });
+
+  it("escapes a pipe in a name so it cannot open a column", () => {
+    const output = formatUploadedMediaList([
+      uploaded({ id: "1", name: "a|b.png" }),
+      uploaded({ id: "2", name: "c.png" }),
+    ]);
+
+    expect(output).toContain("| a\\|b.png |");
+  });
+
+  it("turns a newline in a note into a break instead of a new row", () => {
+    // A raw newline ends the row outright and drops the rest of the note into
+    // the comment as top-level Markdown.
+    const output = formatUploadedMediaList([
+      before,
+      { ...after, description: "First.\nSecond." } as Media,
+    ]);
+
+    expect(output).toContain("| First.<br>Second. |");
   });
 });
 

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -748,6 +748,131 @@ export function formatMediaList(list: Media[]): string {
 }
 
 /**
+ * What `media upload` prints: the listing, then one Markdown block embedding
+ * everything that was just uploaded.
+ *
+ * The per-media `Markdown:` lines are what you copy to embed *one* of them, and
+ * reassembling a table out of several by hand — pairing the halves, escaping the
+ * names — is work the caller should not be doing. This is the thing to paste
+ * after uploading a batch.
+ *
+ * Only past one media: for a single upload the table says nothing its own
+ * `Markdown:` line does not, and printing one is noise.
+ */
+export function formatUploadedMediaList(list: Media[]): string {
+  const listing = formatMediaList(list);
+
+  if (list.length < 2) {
+    return listing;
+  }
+
+  return [listing, "", "Markdown for all of them:", "", mediaTable(list)].join(
+    "\n",
+  );
+}
+
+/** One row of the embed table: a before/after pair, or a lone media. */
+type MediaRow = {
+  name: string;
+  description: string | null;
+  before: Media | null;
+  after: Media | null;
+};
+
+/**
+ * Group an upload so a pair's two halves land in one row.
+ *
+ * Keyed on the name, which is what a pair shares — the same grouping the
+ * managed pull request comment does, so a table pasted by hand reads like the
+ * one Argos posts. A media with no state is its own row, keyed separately so a
+ * standalone `checkout.png` never absorbs a `checkout.png` that is half of a
+ * pair.
+ */
+function groupMediaByPair(list: Media[]): MediaRow[] {
+  const rows = new Map<string, MediaRow>();
+
+  for (const media of list) {
+    const key = media.state ? `pair:${media.name}` : `solo:${media.id}`;
+    const row = rows.get(key) ?? {
+      name: media.name,
+      description: null,
+      before: null,
+      after: null,
+    };
+    if (media.state === "before") {
+      row.before = media;
+    } else {
+      row.after = media;
+    }
+    // The description belongs to the pair, and the "after" is the half it
+    // describes.
+    row.description = row.after?.description ?? row.before?.description ?? null;
+    rows.set(key, row);
+  }
+
+  return [...rows.values()];
+}
+
+/**
+ * The Markdown table itself.
+ *
+ * Each cell is the embed the API already built for that media, so what a caller
+ * pastes points at the same bytes and the same share page the pull request
+ * comment does — and the alt text arrives already escaped for a table cell.
+ */
+function mediaTable(list: Media[]): string {
+  const rows = groupMediaByPair(list);
+  const hasPairs = rows.some((row) => row.before && row.after);
+  const hasNotes = rows.some((row) => row.description);
+
+  const headers = hasPairs ? ["Name", "Before", "After"] : ["Name", "Preview"];
+  if (hasNotes) {
+    headers.push("Notes");
+  }
+
+  const body = rows.flatMap((row) => {
+    const solo = row.after ?? row.before;
+    if (!solo) {
+      return [];
+    }
+    const cells = hasPairs
+      ? [
+          escapeTableCell(row.name),
+          row.before?.markdown ?? "",
+          row.after?.markdown ?? "",
+        ]
+      : [escapeTableCell(row.name), solo.markdown];
+    if (hasNotes) {
+      cells.push(row.description ? escapeTableCell(row.description) : "");
+    }
+    return [`| ${cells.join(" | ")} |`];
+  });
+
+  return [
+    `| ${headers.join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...body,
+  ].join("\n");
+}
+
+/**
+ * Escape a value so it stays inside its table cell.
+ *
+ * Backslashes first: escaping turns `|` into `\|`, so a value already ending in
+ * a backslash would have that backslash escaped by ours and let the pipe
+ * through — the very break this prevents. A line ending has no escape at all
+ * since it ends the row outright, so it becomes the `<br>` a cell renders a
+ * break with. All three forms of it, because a lone carriage return ends a row
+ * too.
+ */
+function escapeTableCell(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r\n|[\r\n]/g, "<br>");
+}
+
+/**
  * Format a media's versions.
  *
  * The id leads each entry because that is what this listing is for: a comment

--- a/packages/cli/src/lib/gh.ts
+++ b/packages/cli/src/lib/gh.ts
@@ -1,0 +1,42 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * How long `gh` gets to answer before we stop waiting.
+ *
+ * `gh pr view` makes a network call, and an upload must not hang on it: this is
+ * a convenience that saves typing a number, not a step the upload depends on.
+ * A slow or unreachable GitHub costs the caller two seconds and then the upload
+ * proceeds unattached, which is exactly what passing nothing would have done.
+ */
+const GH_TIMEOUT_MS = 2000;
+
+/**
+ * The number of the pull request for the current branch, discovered with the
+ * GitHub CLI, or `null` when there is nothing to discover.
+ *
+ * Every ordinary reason to come back empty — `gh` not installed, not signed in,
+ * not inside a repository, no pull request open for this branch yet — is one of
+ * them. None is an error: they all mean "no pull request to attach to", which is
+ * a perfectly good state for an upload to be in. The media is uploaded and its
+ * share URL printed either way.
+ *
+ * `execFile`, not `exec`: no shell is involved, so nothing here can be widened
+ * by a repository or branch name containing shell metacharacters.
+ */
+export async function detectPullRequestNumber(): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["pr", "view", "--json", "number", "--jq", ".number"],
+      { timeout: GH_TIMEOUT_MS, windowsHide: true },
+    );
+
+    const parsed = Number.parseInt(stdout.trim(), 10);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/lib/media-pr.test.ts
+++ b/packages/cli/src/lib/media-pr.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { detectPullRequestNumber } = vi.hoisted(() => ({
+  detectPullRequestNumber: vi.fn(),
+}));
+
+vi.mock("./gh", () => ({ detectPullRequestNumber }));
+
+import { resolveUploadPrNumber } from "./media-pr";
+
+describe("resolveUploadPrNumber", () => {
+  beforeEach(() => {
+    detectPullRequestNumber.mockReset();
+    detectPullRequestNumber.mockResolvedValue(42);
+  });
+
+  it("detects the pull request when nothing was passed", async () => {
+    // The everyday case: on a branch with a pull request open, uploading a
+    // screenshot of what was just changed.
+    await expect(resolveUploadPrNumber({})).resolves.toBe(42);
+  });
+
+  it("takes an explicit --pr as given, without asking gh", async () => {
+    await expect(resolveUploadPrNumber({ pr: "20" })).resolves.toBe(20);
+    expect(detectPullRequestNumber).not.toHaveBeenCalled();
+  });
+
+  it("attaches to nothing on --no-pr", async () => {
+    await expect(resolveUploadPrNumber({ pr: false })).resolves.toBeUndefined();
+    expect(detectPullRequestNumber).not.toHaveBeenCalled();
+  });
+
+  it("leaves --branch alone", async () => {
+    // `--branch` stages the media for whatever pull request opens on it, which
+    // is the flow for one that does not exist yet. Detecting over it would
+    // publish immediately and discard the staging that was asked for.
+    await expect(
+      resolveUploadPrNumber({ branch: "feat/checkout" }),
+    ).resolves.toBeUndefined();
+    expect(detectPullRequestNumber).not.toHaveBeenCalled();
+  });
+
+  it("uploads unattached when there is no pull request to find", async () => {
+    // No `gh`, not signed in, or none open yet — all the same state, and none of
+    // them is a reason to fail an upload.
+    detectPullRequestNumber.mockResolvedValue(null);
+
+    await expect(resolveUploadPrNumber({})).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/media-pr.ts
+++ b/packages/cli/src/lib/media-pr.ts
@@ -1,0 +1,50 @@
+import { detectPullRequestNumber } from "./gh";
+import { toPrNumber } from "../options";
+
+/** What `media upload` was told about where the media belongs. */
+export type MediaTargetOptions = {
+  /** `--pr <number>`, `false` for `--no-pr`, absent when neither was passed. */
+  pr?: string | false | undefined;
+  branch?: string | undefined;
+};
+
+/**
+ * Which pull request an upload publishes to.
+ *
+ * The everyday case is somebody on a branch with a pull request open, uploading
+ * a screenshot of what they just changed — and looking the number up to type it
+ * back is friction for something the environment already knows. So when the
+ * caller says nothing, `gh` is asked.
+ *
+ * Only when the caller says *nothing*:
+ *
+ * - `--pr <n>` is taken as given.
+ * - `--no-pr` opts out, for uploading a screenshot that has nothing to do with
+ *   the branch that happens to be checked out.
+ * - `--branch` is already an answer to this question. It stages the media for
+ *   whatever pull request opens on that branch, which is the flow for one that
+ *   does not exist yet — detecting a pull request over it would publish
+ *   immediately and silently discard the staging that was asked for.
+ *
+ * Detection never fails an upload: every way it can come back empty — no `gh`,
+ * not signed in, no pull request open yet — means "no pull request to attach
+ * to", which is the same state as passing nothing. The media uploads and its
+ * share URL prints either way.
+ */
+export async function resolveUploadPrNumber(
+  options: MediaTargetOptions,
+): Promise<number | undefined> {
+  if (options.pr === false) {
+    return undefined;
+  }
+
+  if (options.pr !== undefined) {
+    return toPrNumber(options.pr);
+  }
+
+  if (options.branch !== undefined) {
+    return undefined;
+  }
+
+  return (await detectPullRequestNumber()) ?? undefined;
+}

--- a/skills/argos-cli/SKILL.md
+++ b/skills/argos-cli/SKILL.md
@@ -70,7 +70,7 @@ humans, not CI.
 - **Automation** — `automation list [--active true|false]` · `automation get <ruleId>` · `automation create|update [<ruleId>] --definition-file <path>` · `automation deactivate <ruleId>`
 - **Team** — `account get` · `account update --default-user-level <member|contributor>` · `account member list|set-level|remove` · `account invite list|create|cancel|reset-link` · `account domain list|add|remove`
 - **Account** — `analytics --account <slug>` · `create-project <name> --account <slug>` · `whoami`
-- **Media** — `media upload <files...> [--branch <b> | --pr <n>] [--state before|after] [--description <text>] [--visibility team|public] [--no-compress]` · `media list [--branch <b>] [--pr <n>] [--stage staged|published] [--search <q>] [--type image|video]` · `media get|delete|versions <mediaId>` · `media update <mediaId> [--name <n>] [--description <text>] [--branch <b>]`
+- **Media** — `media upload <files...> [--branch <b> | --pr <n> | --no-pr] [--state before|after] [--description <text>] [--visibility team|public] [--no-compress]` (with none of `--branch`/`--pr`/`--no-pr`, the pull request is detected with `gh`) · `media list [--branch <b>] [--pr <n>] [--stage staged|published] [--search <q>] [--type image|video]` · `media get|delete|versions <mediaId>` · `media update <mediaId> [--name <n>] [--description <text>] [--branch <b>]`
 - **Media comments** — `media comment list <mediaId> [--all]` (open threads by default) · `media comment create <mediaId>` · `media comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <mediaId> <id>` · `media comment react|unreact <mediaId> <id> <emoji>`
 - **CI** — `upload <dir>` · `finalize` · `skip` · `deploy <dir>`
 - **Auth** — `login` · `logout`

--- a/skills/argos-upload/SKILL.md
+++ b/skills/argos-upload/SKILL.md
@@ -58,6 +58,8 @@ appended to.
 ```bash
 argos media upload after.png --pr 1234              # the pull request exists
 argos media upload after.png --branch feat/checkout # it does not, yet
+argos media upload after.png                        # ask gh which one you are on
+argos media upload after.png --no-pr                # attach it to nothing
 ```
 
 `--branch` is the one to reach for while working. The media is **staged**: it has
@@ -65,12 +67,21 @@ its share URL immediately, and the moment a pull request opens for that branch
 Argos attaches it and posts the comment on its own. You do not have to come back
 and connect the two. `--pr` publishes straight away.
 
-Passing neither uploads a loose media: a share URL and nothing else. That is the
-right call for a chat message or an issue, where you paste the Markdown yourself.
-Neither flag is inferred from the environment, CI included — an upload does not
-post to a pull request unless you asked it to. Two consequences worth knowing
-before you leave them off: nothing will ever attach that media to a pull request,
-and since a loose media's identity is only its name, uploading `shot.png` from two
+**Passing neither runs detection**: Argos asks the GitHub CLI for the pull request
+of the branch you are on, and publishes there. That is usually what you want —
+you are working in a pull request and screenshotting what you changed. It happens
+only when you pass neither flag; `--pr` is taken as given, and `--branch` is
+already an answer, so detection never overrides the staging you asked for.
+
+Detection never fails an upload. No `gh`, not signed in, no pull request open
+yet, not a git repository — all mean "nothing to attach to", and you get the
+share URL anyway. **Check the output**: `published to PR #1234` versus
+`staged` / neither tells you which happened, and it is the only way to know.
+
+Pass `--no-pr` when the screenshot has nothing to do with the branch that happens
+to be checked out — a chat message, an issue, a scratch capture. Two consequences
+of a media attached to nothing: nothing will ever attach it to a pull request
+later, and since its identity is only its name, uploading `shot.png` from two
 different branches makes them versions of one media rather than two.
 
 Commenting needs the project connected to GitHub, and pull request comments
@@ -92,20 +103,33 @@ checkout.png (after)
   image/webp · 184 KB · 1440x900 · public · ready
   URL: https://app.argos-ci.com/m/kQ8vN2pXr4tYw7...
   File: https://media.argos-ci.com/media/12/a1b2c3.webp
-  Markdown: ![checkout.png](https://app.argos-ci.com/m/kQ8vN2pXr4tYw7...)
+  Markdown: [![checkout.png](https://media.argos-ci.com/media/12/a1b2c3.webp)](https://app.argos-ci.com/m/kQ8vN2pXr4tYw7...)
 ```
 
-**Paste the `Markdown` line verbatim.** Do not hand-write the embed:
+**Paste the `Markdown` line verbatim.** It is a picture linked to the share page:
+the media shows inline, and clicking it opens the page where a human can compare
+versions and comment.
 
-- For an **image**, the Markdown is a plain `![alt](url)`.
-- For a **video**, it is the **poster frame wrapped in a link** to the share
-  page. GitHub renders an inline player only for media it hosts itself, so a
-  `<video>` tag or a bare `.mp4` link pointing at Argos renders as a dead link.
-  The poster-in-a-link is the form that actually shows something.
+**Never build the embed yourself from `URL`.** That is an HTML page, so
+`![alt](URL)` renders as a broken image everywhere you paste it. The image part
+has to be the file, which is what the `Markdown` line already gives you.
+
+The picture is the file for an image and the **poster frame** for a video —
+GitHub renders an inline player only for media it hosts itself, so a `<video>`
+tag or a bare `.mp4` link pointing at Argos renders as a dead link.
+
+Uploading several files prints one more block at the end: the whole batch as a
+Markdown table, pairs side by side in one row. Paste that when you want all of
+them at once instead of assembling the individual lines.
 
 `URL` is the share page, for a human. `File` is the image or video itself, for
 you: fetch it when you want to look at what you just uploaded. Use `--json` when
 you parse the output.
+
+A **public** media's share link also unfurls on its own — Argos serves OpenGraph
+and oEmbed with the page — so pasting the bare `URL` into Slack or an issue shows
+the screenshot. A **team** link does not, deliberately: it would leak the file
+name to anyone holding it. Pass `--visibility public` when a link has to travel.
 
 ## Before/after pairs
 


### PR DESCRIPTION
Based on `feat/media-upload`, not `main` — that branch is not merged yet, so this targets it to keep the diff to the two commits below.

## `gh` detects the pull request

Uploading a screenshot of what you just changed meant looking up the number of the pull request you are *already working in* and typing it back. With neither `--pr` nor `--branch` given, `media upload` now asks the GitHub CLI for the pull request of the current branch and publishes there.

Only when neither is given:

- `--pr <n>` is taken as given.
- `--branch` is already an answer to the question — detecting over it would publish immediately and silently discard the staging that was asked for.
- `--no-pr` opts out, for a screenshot that has nothing to do with whatever branch happens to be checked out.

Detection cannot fail an upload. No `gh`, not signed in, no pull request open yet, not a repository at all — every one of them means "nothing to attach to", which is exactly the state passing nothing already produced. `execFile` with a 2s timeout, so no shell is involved and a slow GitHub costs two seconds rather than hanging the upload.

Worth calling out in the docs and skill: **CI is where detection usually finds nothing** (`gh` is often absent, and checkouts are frequently detached HEAD), so a workflow should keep passing `--pr` or `--branch` explicitly.

## One Markdown block for the whole upload

The per-media `Markdown:` lines embed one media each, so pasting a batch meant reassembling a table by hand — pairing the halves, escaping the names. Past a single file, the command now prints the whole batch as one Markdown table, before/after pairs side by side in one row, using the same grouping the managed pull request comment does so a table pasted by hand reads like the one Argos posts.

Nothing extra for a single upload: its own `Markdown:` line already is the thing to paste.

## Skill and reference

Both follow the server-side embed fix (argos-ci/argos#2453): the `Markdown` line is a **picture linked to its share page**, and building one from the share URL by hand renders as a broken image. The `argos-upload` skill now also says to check the output for `published to PR #N` — with detection in play, that line is the only way to know what happened.

## Verification

`pnpm run check-types` and `lint` clean (2 warnings pre-existing in `git.test.ts`); 89 CLI tests pass, including 5 new ones covering the flag precedence. `detectPullRequestNumber` verified live: `20` inside the test repository, `null` outside it with no throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)