### PR TITLE
fix: make a canary release republishable

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing
+
+Both releases go through the **Release** workflow
+(`.github/workflows/release.yml`), dispatched by hand with a release type. It
+runs the matching script below with `--yes`.
+
+## Normal release
+
+```bash
+npm run release
+```
+
+Lerna reads the conventional commits since each package's last tag, bumps the
+packages that changed, tags them, and creates the GitHub release.
+
+## Canary release
+
+```bash
+npm run release-canary
+```
+
+Publishes every package — `--force-publish`, so the set stays consistent — under
+the `canary` dist-tag, without committing or tagging anything.
+
+### Why the preid carries a timestamp
+
+Lerna builds a canary version as:
+
+```
+${nextVersion}-${preid}.${refCount - 1}.sha-${sha}
+```
+
+where `nextVersion` comes from the package's last release tag, `refCount` is the
+number of commits since that tag, and `sha` is the current commit. Every one of
+those is a property of **the commit being released**, so with a fixed preid the
+version is a pure function of the commit — and a second canary from the same
+commit regenerates a version that is already on npm, which npm refuses to
+overwrite:
+
+```
+403 You cannot publish over the previously published versions: 6.7.1-alpha.1.sha-4c8577c
+```
+
+That made a canary a one-shot per commit. It bites in two ordinary ways: cutting
+a second canary to re-test something, and resuming a publish that half landed —
+if one package fails partway through (a network blip, an expired OTP), re-running
+now collides on the packages that already succeeded, so the run can never be
+finished. The only way out was an empty commit.
+
+So `--preid canary-$(date -u +%Y%m%d%H%M%S)` puts the release _time_ in the
+version, which is the one thing that differs between two runs of the same commit:
+
+```
+6.7.1-canary-20260810193000.1.sha-4c8577c
+6.7.1-canary-20260810200500.1.sha-4c8577c
+```
+
+The stamp is fixed-width and UTC, so the identifier compares as a string in
+chronological order — each canary sorts above the last, and the `canary` dist-tag
+always moves forward. Keep it if you touch that script.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "release": "npm run build && lerna publish --conventional-commits --create-release=github",
-    "release-canary": "npm run build && lerna publish --force-publish --dist-tag canary --canary"
+    "release-canary": "npm run build && lerna publish --canary --force-publish --dist-tag canary --preid canary-$(date -u +%Y%m%d%H%M%S)"
   },
   "engines": {
     "node": "22"


### PR DESCRIPTION
Dispatching **Release → canary** a second time against the same commit fails. The command is fixed; I did not run it.

## Why it fails

Lerna builds a canary version like this ([`make-canary-version.ts`](https://github.com/lerna/lerna/blob/main/libs/commands/publish/src/lib/make-canary-version.ts)):

```
${nextVersion}-${preid}.${refCount - 1}.sha-${sha}
```

- `nextVersion` — `semver.inc()` of the package's **last release tag**
- `refCount` — commits **since that tag**
- `sha` — the **current commit**

Every input is a property of the commit being released, so with a fixed preid the version is a *pure function of the commit*. A second canary from the same commit regenerates a version npm already has, and npm won't overwrite it:

```
403 You cannot publish over the previously published versions: 6.7.1-alpha.1.sha-4c8577c
```

Checked against what is actually on npm — the formula reproduces the published version exactly:

| input | value |
| --- | --- |
| last tag | `@argos-ci/cli@6.7.0` |
| commits since tag | `2` → `alpha.1` |
| sha | `4c8577c` (`main`) |
| **result** | `6.7.1-alpha.1.sha-4c8577c` — the version published under `canary` |

So a canary is **one-shot per commit**. Beyond cutting a second one to re-test something, this also makes a half-landed publish unresumable: `--force-publish` pushes 12 packages, and if one fails partway through (network blip, expired OTP), re-running collides on the ones that already succeeded. The run can never be finished without an empty commit.

## The fix

Put the release **time** in the preid — the one thing that differs between two runs of the same commit.

```diff
-lerna publish --force-publish --dist-tag canary --canary
+lerna publish --canary --force-publish --dist-tag canary --preid canary-$(date -u +%Y%m%d%H%M%S)
```

The stamp is fixed-width and UTC, so the identifier compares as a **string** in chronological order — no leading-zero or numeric-identifier pitfalls, each canary sorts above the last, and the `canary` dist-tag keeps moving forward.

`--canary` also moves to the front of the flag list, where it reads as the mode rather than a trailing afterthought. No behaviour change from that.

## Verified without publishing

Reproduced lerna's `makeCanaryVersion` against this repo's real tags and SHA:

```
last tag        : @argos-ci/cli@6.7.0 | refCount: 2 | sha: 4c8577c
BEFORE (run 1&2): 6.7.1-alpha.1.sha-4c8577c          <- identical, second run 403s
AFTER  (run 1)  : 6.7.1-canary-20260810193000.1.sha-4c8577c
AFTER  (run 2)  : 6.7.1-canary-20260810200500.1.sha-4c8577c
run2 > run1     : true
after > before  : true     <- sorts above the existing alpha canaries
valid semver    : true
```

Also confirmed the shell substitution expands under `sh` (how npm runs scripts), and that the workflow's `npm run release-canary -- --yes` still appends `--yes` to `lerna publish` rather than to `npm run build`.

## Things I checked and ruled out

- **`allowBranch: "main"`** does not block this. `--canary` takes the `detectCanaryVersions()` path and never runs the version command's branch validation, so a canary from a feature branch is fine.
- **`workspace:*` deps** resolve correctly — the last canary published `"@argos-ci/core": "6.7.4-alpha.1.sha-4c8577c"`, not the raw protocol.

`RELEASING.md` is new: `package.json` cannot carry a comment, and `--preid canary-$(date …)` is exactly the kind of thing someone tidies away later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)