### PR TITLE
fix(cli): request media scopes at login

### DIFF
--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -13,7 +13,11 @@ export const OAUTH_CLIENT_ID = "argos-cli";
 
 /**
  * Scopes requested by `argos login`, covering the CLI's user actions (identity,
- * projects, reviews, comments). Build upload keeps using a project token.
+ * projects, reviews, comments, media). Build upload keeps using a project token.
+ *
+ * Every scope a CLI command needs has to be listed here: the consent screen
+ * only offers what the client asks for, so a missing entry is not something the
+ * user can grant — it leaves the command permanently answering 403.
  */
 export const OAUTH_SCOPES = [
   "profile",
@@ -22,6 +26,8 @@ export const OAUTH_SCOPES = [
   "reviews:write",
   "comments:read",
   "comments:write",
+  "media:read",
+  "media:write",
 ] as const;
 
 /** Refresh a bit early so a token never expires mid-request. */

--- a/packages/cli/src/lib/run.test.ts
+++ b/packages/cli/src/lib/run.test.ts
@@ -1,0 +1,54 @@
+import { APIError } from "@argos-ci/api-client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handleCliError } from "./run";
+
+/**
+ * `handleCliError` ends the process, so both effects have to be intercepted:
+ * `process.exit` throws instead of exiting, and the printed message is the
+ * assertion target.
+ */
+function runAndCapture(error: unknown, auth?: "user" | "project"): string {
+  const printed: string[] = [];
+  vi.spyOn(console, "error").mockImplementation((message: string) => {
+    printed.push(message);
+  });
+  vi.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit");
+  });
+  expect(() => handleCliError(error, auth)).toThrow("process.exit");
+  return printed.join("\n");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleCliError", () => {
+  it("tells the user to log in again when a scope is missing", () => {
+    const message = runAndCapture(
+      new APIError("Insufficient scope. This endpoint requires: media:write.", {
+        status: 403,
+      }),
+      "project",
+    );
+    expect(message).toContain("Insufficient scope");
+    expect(message).toContain("Run `argos login` again");
+    // Switching token type does not add a scope, so that hint would misdirect.
+    expect(message).not.toContain("personal access token");
+  });
+
+  it("keeps the token-type hint for other permission failures", () => {
+    const message = runAndCapture(
+      new APIError("Forbidden.", { status: 403 }),
+      "user",
+    );
+    expect(message).toContain("personal access token");
+    expect(message).not.toContain("Run `argos login` again");
+  });
+
+  it("shows a plain message when nothing applies", () => {
+    const message = runAndCapture(new Error("Boom."));
+    expect(message).toBe("Error: Boom.");
+  });
+});

--- a/packages/cli/src/lib/run.ts
+++ b/packages/cli/src/lib/run.ts
@@ -1,4 +1,5 @@
 import { APIError } from "@argos-ci/api-client";
+
 import { CliError } from "./cli-error";
 import {
   resolveBuildTarget,
@@ -13,16 +14,34 @@ const USER_AUTH_HINT =
   "Ensure your token is a personal access token with access to this project. " +
   "Project tokens (ARGOS_TOKEN in CI) can read build data but cannot perform review or comment actions.";
 
+const SCOPE_HINT =
+  "Your `argos login` session was granted before the CLI asked for this permission. " +
+  "Run `argos login` again to grant it.";
+
+/**
+ * A scope rejection, as opposed to any other 403: the token is valid and the
+ * user is allowed, it was simply issued without the permission this endpoint
+ * needs. Matched on the message because that is all the API returns — see
+ * `assertOAuthScopes` in the Argos backend.
+ */
+function isInsufficientScope(error: APIError): boolean {
+  return error.status === 403 && /insufficient scope/i.test(error.message);
+}
+
 /**
  * Print an error and exit. {@link CliError} and {@link APIError} messages are
- * shown as-is; permission failures on user-authenticated commands get an extra
- * hint about token types.
+ * shown as-is; permission failures get an extra hint — how to grant a missing
+ * scope, or which token type the command needs.
  */
 export function handleCliError(error: unknown, auth?: AuthMode): never {
   let message: string;
   if (error instanceof CliError || error instanceof APIError) {
     message = error.message;
-    if (
+    if (error instanceof APIError && isInsufficientScope(error)) {
+      // A missing scope is never fixed by switching token type, so this hint
+      // replaces the one about tokens rather than piling on next to it.
+      message += `\n${SCOPE_HINT}`;
+    } else if (
       auth === "user" &&
       error instanceof APIError &&
       (error.status === 401 || error.status === 403)


### PR DESCRIPTION
`argos media` shipped in 6.7.0, but `OAUTH_SCOPES` — the scope list `argos login` sends to the authorize endpoint — never grew `media:read` / `media:write`. The scopes exist and are enforced server-side (`OAUTH_SCOPES` in `apps/backend/src/oauth/scopes.ts`, `anyTokenOrOAuthAuth(["media:write"])` on every media handler), so every media command answered:

```
Error: Insufficient scope. This endpoint requires: media:write.
```

Because the consent screen renders only what the client asked for, there was no Media section to approve — re-running `argos login` produced the same token, and a project token was the only way to upload media at all.

## Changes

- `lib/oauth.ts` — add `media:read` and `media:write` to `OAUTH_SCOPES`, with a note that a scope missing here is not something the user can grant.
- `lib/run.ts` — an insufficient-scope 403 now ends with `Run \`argos login\` again to grant it.` Anyone already logged in keeps failing after this upgrade until they re-authorize, and the API's message doesn't say so. The token-type hint is skipped in that case: switching from a project token to a PAT never adds a scope, so it would misdirect.
- `lib/run.test.ts` — covers the new hint, the token-type hint it must not displace, and the plain-error path.

`check-types`, `lint`, `check-format` and the CLI unit tests (70) pass. The two `vitest/no-disabled-tests` lint warnings are pre-existing in `src/ci-environment/git.test.ts`.

## Note for existing users

Merging this is not enough on its own — tokens already in `~/.config/argos-ci/config.json` were issued without the media scopes and stay that way until `argos login` runs again. That is exactly what the new hint tells them to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)