### PR TITLE
ci: stop npm provenance 409 from failing the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ env:
 
 jobs:
   release:
+    # Publish gives each HTTP call five minutes and retries twice, so a hung
+    # Sigstore or registry could otherwise stall the job for hours.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:
@@ -52,3 +55,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+          # Budget for a single HTTP call during publish, Sigstore's included.
+          # Lerna passes no timeout, so Sigstore falls back to 5s and abandons
+          # slow Rekor writes; the retry then hits a 409 and fails the publish.
+          # 300000 is npm's own `fetch-timeout` default.
+          NPM_CONFIG_TIMEOUT: "300000"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,39 +22,7 @@ npm run release-canary
 Publishes every package — `--force-publish`, so the set stays consistent — under
 the `canary` dist-tag, without committing or tagging anything.
 
-### Why the preid carries a timestamp
-
-Lerna builds a canary version as:
-
-```
-${nextVersion}-${preid}.${refCount - 1}.sha-${sha}
-```
-
-where `nextVersion` comes from the package's last release tag, `refCount` is the
-number of commits since that tag, and `sha` is the current commit. Every one of
-those is a property of **the commit being released**, so with a fixed preid the
-version is a pure function of the commit — and a second canary from the same
-commit regenerates a version that is already on npm, which npm refuses to
-overwrite:
-
-```
-403 You cannot publish over the previously published versions: 6.7.1-alpha.1.sha-4c8577c
-```
-
-That made a canary a one-shot per commit. It bites in two ordinary ways: cutting
-a second canary to re-test something, and resuming a publish that half landed —
-if one package fails partway through (a network blip, an expired OTP), re-running
-now collides on the packages that already succeeded, so the run can never be
-finished. The only way out was an empty commit.
-
-So `--preid canary-$(date -u +%Y%m%d%H%M%S)` puts the release _time_ in the
-version, which is the one thing that differs between two runs of the same commit:
-
-```
-6.7.1-canary-20260810193000.1.sha-4c8577c
-6.7.1-canary-20260810200500.1.sha-4c8577c
-```
-
-The stamp is fixed-width and UTC, so the identifier compares as a string in
-chronological order — each canary sorts above the last, and the `canary` dist-tag
-always moves forward. Keep it if you touch that script.
+The preid carries a UTC timestamp (`--preid canary-$(date -u +%Y%m%d%H%M%S)`).
+Every other part of a canary version derives from the commit, so without it a
+second canary from the same commit regenerates a version already on npm and the
+publish fails. Keep it if you touch that script.

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,9 @@
   "command": {
     "version": {
       "allowBranch": "main"
+    },
+    "publish": {
+      "concurrency": 1
     }
   },
   "version": "independent",


### PR DESCRIPTION
## Description

[Release run 31469292296](https://github.com/argos-ci/argos-javascript/actions/runs/31469292296/job/93708867830) failed with:

```
lerna ERR! TLOG_CREATE_ENTRY_ERROR error creating tlog entry - (409) an equivalent
entry already exists in the transparency log with UUID 108e9186…
```

Only `@argos-ci/util` published; `@argos-ci/browser` and `@argos-ci/api-client` hit this and the run died, so 11 of 12 packages never went out.

**It's a retry-after-success.** Rekor commits the log entry, the client gives up before reading the response, `@sigstore/sign` resubmits the identical entry, and Rekor deduplicates it with a 409. A 409 isn't retryable and `fetchOnConflict` — the recovery path that would just fetch the entry Rekor already has — is hardcoded off in `sigstore`. Upstream: [sigstore-js#1708](https://github.com/sigstore/sigstore-js/issues/1708).

**What made the client give up is the timeout.** `sigstore` reads its per-request timeout from `options.timeout` and falls back to **5 seconds** when the caller passes nothing. The npm CLI passes `fetch-timeout` (5 minutes); lerna hands `libnpmpublish` its raw npm-config snapshot, which has no `timeout` key — so under lerna, Rekor gets 5 seconds. The failing run's timings match exactly: OIDC tokens at `07:32:40`, `util` done at `07:32:43`, the two failures at `07:32:47` and `07:32:49` — one 5s timeout plus retry backoff each.

Changes:

| Where | Change |
|---|---|
| `release.yml` | `NPM_CONFIG_TIMEOUT: "300000"` — restores npm's own fetch budget |
| `lerna.json` | `command.publish.concurrency: 1` |
| `release.yml` | `timeout-minutes: 30` on the job |
| `RELEASING.md` | trimmed back to how the release process works |

Concurrency mattered too: lerna defaults to one process per core, so the runner had 3 signings in flight at once and would have gone to 4 on the next wave. Serializing costs a few seconds across 12 packages and leaves less of a half-published release behind when something does fail.

`timeout-minutes` is a guard for the change itself — a hung call can now block for 5 minutes and retry twice.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [ ] I have added tests if needed — n/a, CI config only

Optional checks:

- [x] My changes requires a change to the documentation
- [x] I have updated the documentation accordingly

## Further comments

**Two things a reviewer should weigh:**

1. **`NPM_CONFIG_TIMEOUT` rides on a lerna implementation detail.** I traced it end to end in the installed code — `Conf.addEnv` maps `NPM_CONFIG_TIMEOUT` → `timeout`, `ProtoList.snapshot` walks the layer prototype chain, `publishPacked` uses that snapshot as `opts`, `npmPublish` spreads it into `libnpmpublish`, which forwards `opts` to `sigstore.attest`. But it's a raw config spread, not a documented option, and the value arrives as the string `"300000"` (only `setTimeout` consumes it, no arithmetic, so that's harmless). **The next release run is what actually confirms it.**

2. **`RELEASING.md` lost 36 lines of @gregberge's preid rationale** from dc814d63. I kept the fact and the "keep it if you touch that script" instruction, dropped the derivation. Revert me if the reasoning was the point.

**Also note:** the `canary` dist-tag is currently inconsistent — `@argos-ci/util@4.1.1-canary-20260811073218.13.sha-09576db` sits alone on it while the other 11 packages are on the previous `20260810183019` canary. Re-dispatching the canary release after this lands realigns them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)