### PR TITLE
ci: add a debug toggle to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         options:
           - normal
           - canary
+      debug:
+        description: "Verbose publish logs (needed to see Sigstore HTTP status codes)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -46,10 +51,17 @@ jobs:
 
       - name: Publish
         run: |
+          # Lerna reports a failed publish as just the Sigstore error code and
+          # logs the underlying HTTP response at `silly` only, so a Fulcio or
+          # Rekor failure is undiagnosable without this.
+          if [ "${{ inputs.debug }}" = "true" ]; then
+            set -- --loglevel silly
+          fi
+
           if [ "${{ github.event.inputs.release_type }}" = "canary" ]; then
-            npm run release-canary -- --yes
+            npm run release-canary -- --yes "$@"
           else
-            npm run release -- --yes
+            npm run release -- --yes "$@"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

[Release run 31471572213](https://github.com/argos-ci/argos-javascript/actions/runs/31471572213/job/93715840066) failed with:

```
lerna ERR! CA_CREATE_SIGNING_CERTIFICATE_ERROR error creating signing certificate
```

That's **Fulcio** — the Sigstore CA that issues the signing certificate — which runs *before* Rekor. All three leaf packages failed on it, so the run never reached the transparency log and the 409 fix from #364 was never exercised (untested, not disproven). `concurrency: 1` from that PR did take effect: the three attempts are now sequential (`08:05:31`, `08:05:34`, `08:05:37`) instead of parallel.

**We can't tell why Fulcio refused.** Lerna reports a failed publish as just the Sigstore error code and hands the underlying error to `logger.silly`, which is suppressed at the default loglevel. It also drops `@sigstore/sign`'s own proc-log `http` lines, which carry the status of each attempt. So a Fulcio or Rekor failure is undiagnosable from a normal run.

This adds a `debug` boolean to the dispatch form that appends `--loglevel silly`. Default is off, so normal releases are unchanged.

## Type of changes

`enhancement`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [ ] I have added tests if needed — n/a, CI config only

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

**This is a diagnostic, not a fix.** I can't fix a Fulcio 5xx from this repo. The evidence says it was transient:

- Fulcio is healthy now — `200` in 0.16s.
- No incident on status.sigstore.dev for Aug 10–11, and no other repos reporting `CA_CREATE_SIGNING_CERTIFICATE_ERROR` today.
- The earlier 07:32 run got *through* Fulcio 3/3 with the identical token flow, and only died later at Rekor.
- All three failures took 3.07–3.08s, identical to ~10ms — fixed retry backoff dominating, so Fulcio was returning a **retryable** status (5xx or 429) and failing fast. That's a server-side blip, not a malformed request.

**On whether #364 caused this** — I checked rather than assumed, and it doesn't hold up as a cause:

- `NPM_CONFIG_TIMEOUT` reaches exactly one consumer, `setTimeout(fn, timeout)` in minipass-fetch. No arithmetic on it anywhere, and `@npmcli/agent` reads `opts.timeouts` (plural), not `opts.timeout`. A longer timeout can turn a timeout into a response; it can't manufacture an HTTP error from Fulcio.
- `concurrency: 1` only serializes.

That said, without the status code it's an argument, not a proof — which is exactly why this toggle exists.

**Suggested next step:** re-dispatch the canary release as-is. If Fulcio was blipping it just works, and it finally exercises the 409 fix too. If it fails the same way, dispatch again with `debug` on and we'll have the real status in one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)