### PR TITLE
fix: remove NPM_CONFIG_TIMEOUT, it breaks every publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,7 @@ env:
 
 jobs:
   release:
-    # Publish gives each HTTP call five minutes and retries twice, so a hung
-    # Sigstore or registry could otherwise stall the job for hours.
+    # A release normally takes ~2 minutes; this just caps a hung publish.
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
@@ -67,8 +66,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
-          # Budget for a single HTTP call during publish, Sigstore's included.
-          # Lerna passes no timeout, so Sigstore falls back to 5s and abandons
-          # slow Rekor writes; the retry then hits a 409 and fails the publish.
-          # 300000 is npm's own `fetch-timeout` default.
-          NPM_CONFIG_TIMEOUT: "300000"
+          # Do not add NPM_CONFIG_TIMEOUT here. Lerna spreads its raw npm-config
+          # snapshot into the publish options and does not coerce `timeout` to a
+          # number, so the env var arrives as a string, reaches
+          # `http.ClientRequest`, and every publish dies on
+          # `ERR_INVALID_ARG_TYPE`. Sigstore's 5s default stands instead.


### PR DESCRIPTION
## Description

`NPM_CONFIG_TIMEOUT` was added in #364 to stop Sigstore abandoning slow Rekor writes at its 5s default. **It does not work, and it broke the release outright.** Runs [31471572213](https://github.com/argos-ci/argos-javascript/actions/runs/31471572213), [31479221263](https://github.com/argos-ci/argos-javascript/actions/runs/31479221263) and [31479397753](https://github.com/argos-ci/argos-javascript/actions/runs/31479397753) all failed with `CA_CREATE_SIGNING_CERTIFICATE_ERROR`.

Dispatching with the debug toggle from #365 showed the real cause:

```
code: 'CA_CREATE_SIGNING_CERTIFICATE_ERROR',
cause: TypeError [ERR_INVALID_ARG_TYPE]: The "timeout" argument must be of
       type number. Received type string ('300000')
    at getTimerDuration (node:internal/timers:422:3)
    at new ClientRequest (node:_http_client:269:20)
    at minipass-fetch/lib/index.js:98
```

An environment variable is a string, and lerna doesn't type `timeout` in its npm-config, so no coercion happens. Lerna spreads that raw snapshot into the publish options, `libnpmpublish` forwards it to `sigstore`, and it lands in `http.ClientRequest`, which validates strictly and throws. **Fulcio was never contacted** — the error name was misleading.

Verified locally against the same `make-fetch-happen`:

| `timeout` value | result |
|---|---|
| `"300000"` (string — what an env var produces) | `ERR_INVALID_ARG_TYPE` |
| `300000` (number) | HTTP 200 |
| unset | HTTP 200 |

There's no way to pass a number through the environment, so the setting is removed and a comment records why it can't come back.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [ ] I have added tests if needed — n/a, CI config only

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

**What this gives back.** Sigstore's 5s timeout returns, so the Rekor 409 that started all this can recur. That was a single flake; this was breaking every release deterministically. Reverting first is the right trade, and I'd rather not bundle a second clever fix into a hotfix.

**The proper fix for the 409** is `fetchOnConflict: true` in `sigstore`, which makes a duplicate-entry conflict recoverable instead of fatal — upstream's own recommendation in [sigstore-js#1708](https://github.com/sigstore/sigstore-js/issues/1708). It's hardcoded `false` and not reachable through `sigstore.attest()` options, so it needs a `pnpm patch` on `sigstore@4.1.1` rather than a config knob. Separate PR if wanted.

**Kept from the previous PRs:**
- `concurrency: 1` — the logs confirm publishes are now sequential.
- The debug toggle from #365 — it's what made this diagnosable at all. Worth keeping.

**Also in this diff:** the `timeout-minutes` comment described the five-minute timeout being removed here, so it's reworded. The 30-minute cap itself stays.

**Post-mortem, since #364 was mine.** I traced `timeout` to `setTimeout` (which coerces strings) and to `@npmcli/agent` (which reads `timeouts`, plural) and concluded it was inert — I never checked `http.ClientRequest`, where it actually lands. I also had disconfirming evidence and explained it away: three failures at 3.07s ±10ms were retry backoff around an instantly-thrown error, and a constant that reproducible should have pointed at our own code rather than a Sigstore blip. The 07:32 run without the change got through Fulcio fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)