### PR TITLE
feat(cli): identify the coding agent driving the CLI

### DIFF
--- a/packages/api-client/src/index.test.ts
+++ b/packages/api-client/src/index.test.ts
@@ -1,6 +1,53 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { APIError } from "./fetch";
-import { formatAPIError, throwAPIError } from "./index";
+import {
+  createClient,
+  formatAPIError,
+  throwAPIError,
+  type UserAgentOption,
+} from "./index";
+
+describe("createClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Stub the global fetch (what `apiFetch` ultimately calls) and return the
+   * `User-Agent` of the request it received.
+   */
+  async function getSentUserAgent(
+    userAgent: UserAgentOption,
+  ): Promise<string | null> {
+    const fetchMock = vi.fn<(request: Request) => Promise<Response>>(
+      async () => new Response("{}", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createClient({
+      baseUrl: "https://api.argos-ci.test/v2/",
+      userAgent,
+    });
+    await client.GET("/me");
+    const request = fetchMock.mock.calls[0]?.[0];
+    return request?.headers.get("user-agent") ?? null;
+  }
+
+  it("sends a static User-Agent", async () => {
+    await expect(getSentUserAgent("argos-cli/6.7.0")).resolves.toBe(
+      "argos-cli/6.7.0",
+    );
+  });
+
+  it("resolves a User-Agent supplied as an async function", async () => {
+    await expect(
+      getSentUserAgent(async () => "argos-cli/6.7.0 agent/claude"),
+    ).resolves.toBe("argos-cli/6.7.0 agent/claude");
+  });
+
+  it("leaves the header alone when the resolver has no value yet", async () => {
+    await expect(getSentUserAgent(() => undefined)).resolves.toBeNull();
+  });
+});
 
 describe("formatAPIError", () => {
   it("formats a structured API error", () => {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -9,19 +9,47 @@ export { APIError } from "./fetch";
 export type ArgosAPIClient = ReturnType<typeof createClient>;
 
 /**
+ * A `User-Agent` value, or a resolver for it. The resolver may be async and is
+ * called per request, so a caller that only learns its identity asynchronously
+ * (the CLI detecting the coding agent driving it) does not have to await that
+ * before it can build a client.
+ */
+export type UserAgentOption =
+  string | (() => string | undefined | Promise<string | undefined>);
+
+/**
+ * Wrap {@link apiFetch} so every request carries a `User-Agent`.
+ *
+ * The header is set on the request openapi-fetch just built for this call — no
+ * one else observes it — and `apiFetch` copies the headers before retrying, so
+ * every attempt keeps the value.
+ */
+function createUserAgentFetch(userAgent: UserAgentOption): typeof apiFetch {
+  return async (input, options) => {
+    const value =
+      typeof userAgent === "function" ? await userAgent() : userAgent;
+    if (value) {
+      input.headers.set("user-agent", value);
+    }
+    return apiFetch(input, options);
+  };
+}
+
+/**
  * Create Argos API client.
  */
 export function createClient(options?: {
   baseUrl?: string;
   authToken?: string;
+  userAgent?: UserAgentOption;
 }) {
-  const { baseUrl, authToken } = options || {};
+  const { baseUrl, authToken, userAgent } = options || {};
   return createFetchClient<paths>({
     baseUrl: baseUrl || "https://api.argos-ci.com/v2/",
     headers: {
       Authorization: authToken ? `Bearer ${authToken}` : undefined,
     },
-    fetch: apiFetch,
+    fetch: userAgent ? createUserAgentFetch(userAgent) : apiFetch,
   });
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@argos-ci/api-client": "workspace:*",
     "@argos-ci/core": "workspace:*",
+    "@vercel/detect-agent": "^1.2.5",
     "commander": "^15.0.0",
     "open": "^11.0.0",
     "ora": "^9.4.1"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,11 +20,16 @@ import { testCommand } from "./commands/test";
 import { accountCommand } from "./commands/account";
 import { projectCommand } from "./commands/project";
 import { automationCommand } from "./commands/automation";
+import { initUserAgent } from "./lib/user-agent";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const rawPkg = await readFile(resolve(__dirname, "..", "package.json"), "utf8");
 const pkg = JSON.parse(rawPkg);
+
+// Detect the coding agent driving the CLI, if any, before any command runs, so
+// every API request identifies it.
+await initUserAgent(pkg.version);
 
 program
   .name(pkg.name)

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -5,6 +5,8 @@ import {
   type ArgosAPIClient,
 } from "@argos-ci/api-client";
 
+import { getUserAgent } from "./user-agent";
+
 /** Optional override for the API base URL (used in tests and dev). */
 export function getApiBaseUrl(): string | undefined {
   return process.env["ARGOS_API_BASE_URL"];
@@ -12,7 +14,13 @@ export function getApiBaseUrl(): string | undefined {
 
 /** Create an Argos API client authenticated with the given token. */
 export function createApiClient(authToken?: string): ArgosAPIClient {
-  return createClient({ authToken, baseUrl: getApiBaseUrl() });
+  return createClient({
+    authToken,
+    baseUrl: getApiBaseUrl(),
+    // Read per request rather than captured here: agent detection is async and
+    // resolves at startup, while clients are built synchronously all over.
+    userAgent: getUserAgent,
+  });
 }
 
 /**

--- a/packages/cli/src/lib/user-agent.test.ts
+++ b/packages/cli/src/lib/user-agent.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatUserAgent } from "./user-agent";
+
+const NODE = `node/${process.versions.node}`;
+
+describe("formatUserAgent", () => {
+  it("identifies the CLI and the runtime", () => {
+    expect(formatUserAgent({ version: "6.7.0" })).toBe(
+      `argos-cli/6.7.0 ${NODE}`,
+    );
+  });
+
+  it("appends the agent when one drives the CLI", () => {
+    expect(formatUserAgent({ version: "6.7.0", agent: "claude" })).toBe(
+      `argos-cli/6.7.0 ${NODE} agent/claude`,
+    );
+  });
+
+  it.each([
+    ["Claude Code", "claude-code"],
+    ["  cursor-cli  ", "cursor-cli"],
+    ["custom-agent@2.0", "custom-agent@2.0"],
+    ["MyAgent/1.0", "myagent-1.0"],
+    ["évadé", "vad"],
+  ])("normalizes %j into a header token", (agent, expected) => {
+    expect(formatUserAgent({ version: "6.7.0", agent })).toBe(
+      `argos-cli/6.7.0 ${NODE} agent/${expected}`,
+    );
+  });
+
+  it("truncates an overlong agent name", () => {
+    const agent = "a".repeat(200);
+    expect(formatUserAgent({ version: "6.7.0", agent })).toBe(
+      `argos-cli/6.7.0 ${NODE} agent/${"a".repeat(64)}`,
+    );
+  });
+
+  it.each([
+    ["not set", undefined],
+    ["null", null],
+    ["empty", ""],
+    ["only separators", " -- "],
+    ["nothing usable", "🤖"],
+  ])("omits the agent token when it is %s", (_label, agent) => {
+    expect(formatUserAgent({ version: "6.7.0", agent })).toBe(
+      `argos-cli/6.7.0 ${NODE}`,
+    );
+  });
+
+  it("never emits a value that could inject a header", () => {
+    const agent = "evil\r\nX-Injected: 1";
+    expect(formatUserAgent({ version: "6.7.0", agent })).toBe(
+      `argos-cli/6.7.0 ${NODE} agent/evil-x-injected-1`,
+    );
+  });
+});

--- a/packages/cli/src/lib/user-agent.ts
+++ b/packages/cli/src/lib/user-agent.ts
@@ -1,0 +1,78 @@
+import { determineAgent } from "@vercel/detect-agent";
+
+/**
+ * The `User-Agent` the CLI sends on every API request.
+ *
+ * Beyond the usual product token, it carries an `agent/<name>` token when a
+ * coding agent is driving the CLI. That token is the only thing telling the API
+ * apart a command a person typed from one an agent ran on their behalf — the
+ * token signing the request is the same either way — and is what lets Argos
+ * mark the resulting comment as agent-made.
+ */
+
+/** Product token of the CLI itself, e.g. `argos-cli/6.7.0`. */
+const PRODUCT = "argos-cli";
+
+/**
+ * Longest agent name we forward. `AI_AGENT` is free-form, so a caller could put
+ * anything in it; the API only needs enough to recognize the agent.
+ */
+const MAX_AGENT_LENGTH = 64;
+
+/**
+ * Reduce an agent name to a `token` as the HTTP grammar defines it (RFC 9110
+ * §5.6.2), lowercased.
+ *
+ * `@vercel/detect-agent` returns the `AI_AGENT` environment variable verbatim
+ * when it is set, so the value is user input: anything outside the allowed set —
+ * spaces, and control characters that would otherwise let it inject a header —
+ * becomes a hyphen. Returns `null` when nothing usable is left.
+ */
+function sanitizeAgentName(name: string): string | null {
+  const sanitized = name
+    .trim()
+    .toLowerCase()
+    .slice(0, MAX_AGENT_LENGTH)
+    .replaceAll(/[^a-z0-9.@_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || null;
+}
+
+/**
+ * Format the `User-Agent` value, e.g.
+ * `argos-cli/6.7.0 node/22.11.0 agent/claude`.
+ */
+export function formatUserAgent(input: {
+  version: string;
+  agent?: string | null | undefined;
+}): string {
+  const tokens = [
+    `${PRODUCT}/${input.version}`,
+    `node/${process.versions.node}`,
+  ];
+  const agent = input.agent ? sanitizeAgentName(input.agent) : null;
+  if (agent) {
+    tokens.push(`agent/${agent}`);
+  }
+  return tokens.join(" ");
+}
+
+let userAgent: string | undefined;
+
+/**
+ * Detect the agent driving the CLI and build the `User-Agent` from it, once per
+ * process. Called at startup, before any command runs.
+ */
+export async function initUserAgent(version: string): Promise<void> {
+  const { agent } = await determineAgent();
+  userAgent = formatUserAgent({ version, agent: agent?.name });
+}
+
+/**
+ * The `User-Agent` for API requests, `undefined` until {@link initUserAgent} has
+ * run — the API client then falls back to the runtime's own default rather than
+ * claiming a version we do not know.
+ */
+export function getUserAgent(): string | undefined {
+  return userAgent;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@argos-ci/core':
         specifier: workspace:*
         version: link:../core
+      '@vercel/detect-agent':
+        specifier: ^1.2.5
+        version: 1.2.5
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -3040,6 +3043,10 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/detect-agent@1.2.5':
+    resolution: {integrity: sha512-0krENrjuitlW8s6TJu0MlqCevyCU7K7JK63jZAf7xZ6n17tx+vUEwzHT3sTxawtwZxaW21hu+oFUpoOrm49FsQ==}
+    engines: {node: '>=14'}
 
   '@vercel/repository-dispatch@0.1.0':
     resolution: {integrity: sha512-NP8DDQnO6bglStIL++lXmv5N+3SPNPjVIXOP3X/zykB4ZHgqegGc68/R8LqvmBDCBWCgpBSuJyf4brtXJET98w==}
@@ -10451,6 +10458,8 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vercel/detect-agent@1.2.5': {}
 
   '@vercel/repository-dispatch@0.1.0':
     dependencies:


### PR DESCRIPTION
## Description

Part 1 of [ARG-496](https://linear.app/argos/issue/ARG-496) — the producer side. The backend half is [argos-ci/argos#2471](https://github.com/argos-ci/argos/pull/2471).

Argos cannot tell a command a person typed from one an agent ran on their behalf: the token signing the request is the same either way. This makes the CLI say so.

**`packages/cli`** — [`src/lib/user-agent.ts`](https://github.com/argos-ci/argos-javascript/blob/greg/arg-496-let-the-agent-identify-itself-in-mcp-cli/packages/cli/src/lib/user-agent.ts) detects the agent with [`@vercel/detect-agent`](https://github.com/vercel/vercel/tree/main/packages/detect-agent) once at startup and sends it as a product token:

```
User-Agent: argos-cli/6.8.0 node/22.11.0 agent/claude-code_2-1-227_agent
```

The agent name is user input in the end — `@vercel/detect-agent` returns `AI_AGENT` verbatim — so it is reduced to an HTTP `token` (RFC 9110 §5.6.2) and truncated. A name that could inject a header cannot survive that.

**`packages/api-client`** — `createClient({ userAgent })` takes a string *or* a resolver, possibly async. Detection resolves at startup while clients are built synchronously in ~30 CLI call sites; a resolver keeps all of them unchanged instead of turning `createApiClient` async.

## Verified

`build`, `check-types`, `lint`, `check-format` and `test` pass for both packages. Beyond the unit tests, I ran the built CLI against a local server that echoes the header:

```
UA: argos-cli/6.8.0 node/26.4.0 agent/claude-code_2-1-227_agent   # under Claude Code
UA: argos-cli/6.8.0 node/26.4.0 agent/custom-agent-2.0            # AI_AGENT="Custom Agent/2.0"
```

That run is also what caught the version suffix Claude Code really appends — the backend PR strips it before matching the agent registry.

## Type of changes

`enhancement`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

Optional checks:

- [ ] My changes requires a change to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)