### PR TITLE
docs(media): a media's visibility now follows its project's

### DIFF
--- a/packages/cli/src/commands/media/upload.ts
+++ b/packages/cli/src/commands/media/upload.ts
@@ -61,7 +61,7 @@ export function registerMediaUpload(media: Command) {
     .addOption(
       new Option(
         "--visibility <visibility>",
-        "Who can open the share page. Defaults to the most private option your plan allows",
+        "Who can open the share page. Defaults to your project's visibility in Argos: public for a public project, team for a private one",
       ).choices(["team", "public"]),
     )
     .addOption(

--- a/packages/core/mocks/handlers/createMedia.ts
+++ b/packages/core/mocks/handlers/createMedia.ts
@@ -36,6 +36,9 @@ function buildMedia(body: CreateMediaRequestBody, status: string) {
     sizeBytes: body.size,
     width: null,
     height: null,
+    // The real server infers this from the project when the caller sends
+    // nothing; there is no project here, so the mock stands in with the private
+    // answer. Tests that care about the choice assert on `createMediaRequests`.
     visibility: body.visibility ?? "team",
     status,
     expiresAt: null,

--- a/packages/core/src/media.ts
+++ b/packages/core/src/media.ts
@@ -106,7 +106,11 @@ export interface UploadMediaParameters {
 
   /**
    * Who can open the share page. `team` requires an Argos session; `public` only
-   * requires the URL. Defaults to the most private option the plan allows.
+   * requires the URL.
+   *
+   * Leave it out — the usual case — and the media takes the visibility of its
+   * project in Argos: `public` for a public project, `team` for a private one.
+   * `team` requires a paid plan.
    */
   visibility?: MediaVisibility;
 

--- a/skills/argos-upload/SKILL.md
+++ b/skills/argos-upload/SKILL.md
@@ -198,8 +198,14 @@ EXIF — including GPS, if the camera recorded it — does not reach Argos. With
 ## Visibility, and what it does not cover
 
 `--visibility` controls the **share page** — `team` requires an Argos session,
-`public` does not. It defaults to the most private option the plan allows: `team`
-on Pro, and `public` on the free plan, which cannot do `team` at all.
+`public` does not. It defaults to the **project's** visibility in Argos: `public`
+for a public project, `team` for a private one. So the usual upload needs no flag
+at all. `team` is Pro-only; on the free plan every share page is public, and asking
+for `team` is rejected rather than silently downgraded.
+
+Re-uploading does not revisit this. A media keeps the visibility it was created
+with unless a later upload passes `--visibility` explicitly, so a screenshot
+deliberately kept team-only stays that way.
 
 It does **not** protect the file: media files are always reachable at an
 unguessable CDN URL, because GitHub fetches embedded images server-side with no


### PR DESCRIPTION
Part of ARG-501. Companion to argos-ci/argos#2487, which makes the change.

The server now infers a media's default visibility from its project — public project, public media; private project, team-only — instead of from the plan. This updates everything on the client side that described the old rule.

### What changed

- **CLI** — `--visibility` help text on `media upload`.
- **SDK** — `UploadMediaParameters.visibility` JSDoc in `@argos-ci/core`.
- **Skill** — `skills/argos-upload/SKILL.md`, including the part an agent needs to know: re-uploading keeps the visibility a media already has unless the upload passes `--visibility` itself.
- **Mock** — a comment on the msw handler's `?? "team"`, which stands in for a server default that no longer exists as a single value.

No behavior change here: the flag and the option already passed `null` through when omitted, and the server picks the default.

### About `packages/api-client/src/schema.ts`

Untouched on purpose. It is generated from the **deployed** OpenAPI document (`openapi-typescript https://api.argos-ci.com/v2/openapi.yaml`), so it picks up the new `visibility` description on the next `build-schema-types` run after the API ships. The TypeScript types themselves do not change — `visibility` stays `("team" | "public") | null`.

### Testing

`@argos-ci/cli` and `@argos-ci/core` type-check, lint and test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)