### PR TITLE
fix(core): read Buildkite builds without a SHA or a pull request

### DIFF
--- a/packages/core/src/ci-environment/services/buildkite.ts
+++ b/packages/core/src/ci-environment/services/buildkite.ts
@@ -15,6 +15,19 @@ function getRepository(context: Context): string | null {
   return null;
 }
 
+/**
+ * `BUILDKITE_COMMIT` is what the build was created with, not necessarily a
+ * SHA: a build started from the UI without a commit carries the literal
+ * `HEAD`. Only a full SHA is worth trusting over the checkout.
+ */
+function getCommit(env: Context["env"]): string | null {
+  const commit = env.BUILDKITE_COMMIT;
+  if (commit && /^[0-9a-f]{40}$/.test(commit)) {
+    return commit;
+  }
+  return head() || null;
+}
+
 const service: Service = {
   name: "Buildkite",
   key: "buildkite",
@@ -24,18 +37,19 @@ const service: Service = {
     const repository = getRepository(context);
     return {
       // Buildkite doesn't work well so we fallback to git to ensure we have commit and branch
-      commit: env.BUILDKITE_COMMIT || head() || null,
+      commit: getCommit(env),
       branch: env.BUILDKITE_BRANCH || branch() || null,
       repository,
       originalRepository: repository,
       jobId: null,
       runId: null,
       runAttempt: null,
-      prNumber: env.BUILDKITE_PULL_REQUEST
+      // The literal `false` outside a pull request.
+      prNumber: /^\d+$/.test(env.BUILDKITE_PULL_REQUEST ?? "")
         ? Number(env.BUILDKITE_PULL_REQUEST)
         : null,
       prHeadCommit: null,
-      prBaseBranch: null,
+      prBaseBranch: env.BUILDKITE_PULL_REQUEST_BASE_BRANCH || null,
       nonce: env.BUILDKITE_BUILD_ID || null,
     };
   },

--- a/packages/core/src/util/url.test.ts
+++ b/packages/core/src/util/url.test.ts
@@ -38,6 +38,19 @@ describe("getRepositoryNameFromURL", () => {
     ).toBe("team/repository");
   });
 
+  it("parses Cursor Origin clone URLs, including the legacy /git/ path", () => {
+    expect(
+      getRepositoryNameFromURL(
+        "https://origin.cursor.com/argos-ci/first-repo.git",
+      ),
+    ).toBe("argos-ci/first-repo");
+    expect(
+      getRepositoryNameFromURL(
+        "https://origin.cursor.com/git/argos-ci/first-repo.git",
+      ),
+    ).toBe("argos-ci/first-repo");
+  });
+
   it("parses valid HTTPS URLs without .git extension", () => {
     expect(getRepositoryNameFromURL("https://github.com/owner/repo")).toBe(
       "owner/repo",

--- a/packages/core/src/util/url.ts
+++ b/packages/core/src/util/url.ts
@@ -8,9 +8,10 @@ export function getRepositoryNameFromURL(url: string): string | null {
     return `${sshMatch[1]}/${sshMatch[2]}`;
   }
 
-  const httpsMatch = url.match(
-    /^(?:https?|git):\/\/[^/]+\/([^/]+)\/(.+?)(?:\.git)?$/,
-  );
+  const httpsMatch = url
+    // Cursor Origin's legacy clone path is `https://origin.cursor.com/git/{owner}/{repo}.git`.
+    .replace(/^(https?:\/\/origin\.cursor\.com)\/git\//, "$1/")
+    .match(/^(?:https?|git):\/\/[^/]+\/([^/]+)\/(.+?)(?:\.git)?$/);
   if (httpsMatch && httpsMatch[1] && httpsMatch[2]) {
     return `${httpsMatch[1]}/${httpsMatch[2]}`;
   }


### PR DESCRIPTION
## Summary

Three Buildkite fixes found while testing the [Cursor Origin integration](https://github.com/argos-ci/argos/pull/2506) on Buildkite hosted agents (Origin has no CI of its own; Buildkite is its launch CI partner). None is Origin-specific except the URL one.

- **`BUILDKITE_COMMIT` may not be a SHA.** A build started from the Buildkite UI without a commit runs with `BUILDKITE_COMMIT=HEAD` (`BUILDKITE_COMMIT_RESOLVED=false`); the CLI sent `HEAD` and the API answered `commit: Invalid commit: value was "HEAD"`. The commit is now taken from the variable only when it is a full SHA, and from `git rev-parse HEAD` otherwise.
- **`BUILDKITE_PULL_REQUEST` is the literal `false`** outside a pull request; `Number("false")` produced `NaN`. It is read only when it is digits. `BUILDKITE_PULL_REQUEST_BASE_BRANCH` now fills `prBaseBranch`.
- **Cursor Origin clone URL.** Buildkite's Origin integration sets `BUILDKITE_REPO=https://origin.cursor.com/git/{owner}/{repo}.git` (legacy path); `getRepositoryNameFromURL` returned `git/{owner}` — the `/git/` segment is stripped for that host, with tests.

Observed on a real Buildkite build for an Origin repository (`BUILDKITE_PIPELINE_PROVIDER=cursor_origin`).

## Notes

- Draft: `pnpm install` is needed locally to run the whole suite (`p-retry` missing from my checkout); the URL tests pass, `buildkite.ts` type-checks. To be run in CI here.
- No behaviour change on webhook-triggered builds, which already carry a real SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
