### PR TITLE
fix(api-client): retry rate limit responses

### DIFF
--- a/packages/api-client/src/fetch.test.ts
+++ b/packages/api-client/src/fetch.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { APIError, apiFetch } from "./fetch";
 
+function rateLimitResponse(retryAfter: string | null = "0") {
+  return new Response("rate limited", {
+    status: 429,
+    headers: retryAfter === null ? undefined : { "retry-after": retryAfter },
+  });
+}
+
 describe("apiFetch", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -54,6 +61,107 @@ describe("apiFetch", () => {
     );
 
     expect(response.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries rate limits after Retry-After plus jitter", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitResponse("2"))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    const responsePromise = apiFetch(
+      new Request("https://api.argos-ci.test/builds"),
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        minTimeout: 0,
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(2_499);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["missing", null, 60_000],
+    ["invalid", "later", 60_000],
+    ["too large", "600", 300_000],
+  ])(
+    "bounds the retry delay when Retry-After is %s",
+    async (_case, retryAfter, expectedDelay) => {
+      vi.useFakeTimers();
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(rateLimitResponse(retryAfter))
+        .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+      const responsePromise = apiFetch(
+        new Request("https://api.argos-ci.test/builds"),
+        {
+          fetch: fetchMock as unknown as typeof fetch,
+          minTimeout: 0,
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(expectedDelay - 1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("returns the final rate limit response after retries are exhausted", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const fetchMock = vi.fn(async () => rateLimitResponse());
+
+    const responsePromise = apiFetch(
+      new Request("https://api.argos-ci.test/builds"),
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        minTimeout: 0,
+        retries: 2,
+      },
+    );
+
+    await vi.runAllTimersAsync();
+    const response = await responsePromise;
+    expect(response.status).toBe(429);
+    await expect(response.text()).resolves.toBe("rate limited");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves caller cancellation during a rate limit delay", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const controller = new AbortController();
+    const reason = new Error("cancelled by caller");
+    const fetchMock = vi.fn(async () => rateLimitResponse("60"));
+
+    const promise = apiFetch(
+      new Request("https://api.argos-ci.test/builds", {
+        signal: controller.signal,
+      }),
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        minTimeout: 0,
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort(reason);
+
+    await expect(promise).rejects.toBe(reason);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/api-client/src/fetch.ts
+++ b/packages/api-client/src/fetch.ts
@@ -2,6 +2,9 @@ import pRetry from "p-retry";
 import { debug } from "./debug";
 
 const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_RETRY_AFTER_MS = 60_000;
+const MAX_RETRY_AFTER_MS = 300_000;
+const MAX_RETRY_JITTER_MS = 5_000;
 
 export class APIError extends Error {
   /**
@@ -34,6 +37,30 @@ interface APIFetchOptions {
   minTimeout?: number;
   retries?: number;
   timeout?: number;
+}
+
+function getRetryAfterMs(response: Response) {
+  const header = response.headers.get("retry-after");
+  const seconds = header === null ? Number.NaN : Number(header);
+  const retryAfterMs = Number.isFinite(seconds)
+    ? Math.max(seconds, 0) * 1_000
+    : DEFAULT_RETRY_AFTER_MS;
+  return Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
+}
+
+function waitForRetry(ms: number, signal: AbortSignal) {
+  signal.throwIfAborted();
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal.reason);
+    };
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 async function createRequestFactory(request: Request, timeout: number) {
@@ -73,10 +100,21 @@ export async function apiFetch(input: Request, options: APIFetchOptions = {}) {
     input,
     options.timeout ?? DEFAULT_TIMEOUT,
   );
+  const retries = options.retries ?? 3;
 
   return pRetry(
     async (attemptNumber) => {
       const response = await fetchImpl(createRequest(attemptNumber - 1));
+      if (response.status === 429 && attemptNumber <= retries) {
+        const retryDelayMs =
+          getRetryAfterMs(response) + Math.random() * MAX_RETRY_JITTER_MS;
+        debug(
+          `API request rate limited, waiting ${Math.ceil(retryDelayMs / 1_000)}s before retry`,
+        );
+        await response.body?.cancel();
+        await waitForRetry(retryDelayMs, input.signal);
+        throw new APIError("Too Many Requests (429)", { status: 429 });
+      }
       if (response.status >= 500) {
         throw new APIError(`Internal Server Error (${response.status})`);
       }
@@ -84,7 +122,7 @@ export async function apiFetch(input: Request, options: APIFetchOptions = {}) {
     },
     {
       minTimeout: options.minTimeout,
-      retries: options.retries ?? 3,
+      retries,
       shouldRetry: () => !input.signal.aborted,
       onFailedAttempt: (context) => {
         debug("API request failed", context.error.message);


### PR DESCRIPTION
## Description

_Work in progress PR._

Retry HTTP 429 responses in `apiFetch` instead of returning the first rate-limit response immediately.

The implementation reuses the existing configurable `p-retry` budget, so the default remains four total attempts across network errors, 5xx responses, and 429 responses. For each retryable 429 it:

- honors the numeric `Retry-After` value emitted by the Argos rate limiter;
- falls back to 60 seconds for a missing or invalid value;
- caps the server delay at five minutes and adds up to five seconds of positive jitter;
- cancels the discarded response body and keeps the delay responsive to caller cancellation; and
- returns the final 429 response untouched after retries are exhausted, preserving the existing body and error-formatting path.

## Type of changes

`bug`

## Checklist

- [ ] I have read the CONTRIBUTING doc (the document referenced by this template is not present in the repository)
- [x] The commit message follows the [Conventional Commits policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

Optional checks:

- [ ] My changes require a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

n/a