### PR TITLE
fix(core): baseline PR builds against the commit GitHub merged in

### DIFF
--- a/packages/core/src/ci-environment/git.test.ts
+++ b/packages/core/src/ci-environment/git.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   branch,
+  getCommitParents,
   getMergeBaseCommitSha,
   getRepositoryURL,
   head,
@@ -267,5 +268,108 @@ describe("#getMergeBaseCommitSha (lock contention)", () => {
     } finally {
       clearTimeout(timer);
     }
+  });
+});
+
+describe("#getCommitParents", () => {
+  let cwd: string;
+  let root: string;
+  let repoDir: string;
+  let bareDir: string;
+  let rootCommitSha: string;
+  let mainSha: string;
+  let featureSha: string;
+  let mergeSha: string;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    root = mkdtempSync(join(tmpdir(), "argos-git-parents-test-"));
+    repoDir = join(root, "repo");
+
+    bareDir = join(root, "origin.git");
+    execFileSync("git", ["init", "--bare", bareDir]);
+    // Allow fetching a commit by SHA, as GitHub does.
+    execFileSync("git", [
+      "-C",
+      bareDir,
+      "config",
+      "uploadpack.allowAnySHA1InWant",
+      "true",
+    ]);
+    execFileSync("git", ["init", repoDir]);
+    const git = (...args: string[]) =>
+      execFileSync("git", ["-C", repoDir, ...args])
+        .toString()
+        .trim();
+    git("remote", "add", "origin", bareDir);
+    git("config", "user.email", "test@argos-ci.com");
+    git("config", "user.name", "Argos Test");
+
+    git("commit", "--allow-empty", "-m", "root");
+    git("branch", "-M", "main");
+    rootCommitSha = git("rev-parse", "HEAD");
+    git("checkout", "-b", "feature");
+    git("commit", "--allow-empty", "-m", "feature 1");
+    featureSha = git("rev-parse", "HEAD");
+    git("checkout", "main");
+    git("commit", "--allow-empty", "-m", "main 1");
+    mainSha = git("rev-parse", "HEAD");
+    git("merge", "--no-ff", "-m", "merge feature", featureSha);
+    mergeSha = git("rev-parse", "HEAD");
+    git("push", "origin", "main");
+
+    process.chdir(repoDir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns the parents of a merge commit, first parent first", async () => {
+    await expect(getCommitParents(mergeSha)).resolves.toEqual([
+      mainSha,
+      featureSha,
+    ]);
+  });
+
+  it("returns an empty array for a root commit", async () => {
+    await expect(getCommitParents(rootCommitSha)).resolves.toEqual([]);
+  });
+
+  it("returns null for an unknown commit", async () => {
+    await expect(getCommitParents("f".repeat(40))).resolves.toBe(null);
+  });
+
+  it("deepens a shallow history to read the parents", async () => {
+    // The state of a CI checkout: a shallow clone where git hides the parents
+    // of the commits at the boundary of the history.
+    const shallowDir = join(root, "shallow");
+    execFileSync("git", [
+      "clone",
+      "--depth=1",
+      `file://${bareDir}`,
+      shallowDir,
+    ]);
+    process.chdir(shallowDir);
+
+    // The parents are not available locally…
+    const raw = execFileSync("git", [
+      "rev-list",
+      "--parents",
+      "-n",
+      "1",
+      mergeSha,
+      "--",
+    ])
+      .toString()
+      .trim();
+    expect(raw).toBe(mergeSha);
+
+    // … but they are fetched.
+    await expect(getCommitParents(mergeSha)).resolves.toEqual([
+      mainSha,
+      featureSha,
+    ]);
   });
 });

--- a/packages/core/src/ci-environment/git.test.ts
+++ b/packages/core/src/ci-environment/git.test.ts
@@ -344,29 +344,31 @@ describe("#getCommitParents", () => {
   it("deepens a shallow history to read the parents", async () => {
     // The state of a CI checkout: a shallow clone where git hides the parents
     // of the commits at the boundary of the history.
+    // "--depth" implies "--single-branch", so the branch is named explicitly:
+    // it would otherwise be read from the remote HEAD, which points to another
+    // branch when git defaults to "master" for new repositories.
     const shallowDir = join(root, "shallow");
     execFileSync("git", [
       "clone",
       "--depth=1",
+      "--branch",
+      "main",
       `file://${bareDir}`,
       shallowDir,
     ]);
+    const shallowGit = (...args: string[]) =>
+      execFileSync("git", ["-C", shallowDir, ...args])
+        .toString()
+        .trim();
     process.chdir(shallowDir);
 
-    // The parents are not available locally…
-    const raw = execFileSync("git", [
-      "rev-list",
-      "--parents",
-      "-n",
-      "1",
+    // The commit is there, but its parents are not…
+    expect(shallowGit("rev-parse", "HEAD")).toBe(mergeSha);
+    expect(shallowGit("rev-list", "--parents", "-n", "1", mergeSha, "--")).toBe(
       mergeSha,
-      "--",
-    ])
-      .toString()
-      .trim();
-    expect(raw).toBe(mergeSha);
+    );
 
-    // … but they are fetched.
+    // … until they are fetched.
     await expect(getCommitParents(mergeSha)).resolves.toEqual([
       mainSha,
       featureSha,

--- a/packages/core/src/ci-environment/git.ts
+++ b/packages/core/src/ci-environment/git.ts
@@ -352,3 +352,54 @@ export async function listAncestorCommits(input: {
     return [];
   }
 }
+
+/**
+ * Read the parent commits of a commit, ordered as recorded in the commit — the
+ * first parent first. Returns `null` when the commit is unknown, and an empty
+ * array when it has no parent.
+ *
+ * The history is deepened with a shallow fetch when the parents are not
+ * available locally: in the shallow clones typically used in CI, git hides the
+ * parents of the commits at the boundary of the history.
+ */
+export async function getCommitParents(sha: string): Promise<string[] | null> {
+  const localParents = readCommitParents(sha);
+  if (localParents?.length) {
+    return localParents;
+  }
+
+  // Fetch the commit and its parents, so the parents stop being hidden by the
+  // boundary of a shallow history.
+  try {
+    await runGitFetch(["--depth=2", "origin", sha]);
+  } catch (error) {
+    debug(
+      `Failed to deepen history for ${sha}, using local history`,
+      getGitErrorOutput(error),
+    );
+    return localParents;
+  }
+
+  return readCommitParents(sha);
+}
+
+/**
+ * Read the parent commits of a commit from the local history. Returns `null`
+ * when the commit is unknown, and an empty array when it has no parent — a root
+ * commit, or a commit at the boundary of a shallow history, where git hides the
+ * parents.
+ */
+function readCommitParents(sha: string): string[] | null {
+  try {
+    const raw = execFileSync(
+      "git",
+      ["rev-list", "--parents", "-n", "1", sha, "--"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const [, ...parents] = raw.toString().trim().split(" ");
+    return parents;
+  } catch (error) {
+    debug(`Failed to read the parents of ${sha}`, getGitErrorOutput(error));
+    return null;
+  }
+}

--- a/packages/core/src/ci-environment/services/github-actions.test.ts
+++ b/packages/core/src/ci-environment/services/github-actions.test.ts
@@ -1,0 +1,140 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Context } from "../types";
+import service from "./github-actions";
+
+describe("#getMergeBaseCommitSha", () => {
+  let cwd: string;
+  let root: string;
+  let repoDir: string;
+  let eventPath: string;
+  /** Commit `feature` branched off from — the merge base of `feature` and `main`. */
+  let forkSha: string;
+  /** Tip of `main`, merged into the test-merge commit. */
+  let mainSha: string;
+  /** Tip of `feature`, the pull request head. */
+  let featureSha: string;
+  /** Test-merge commit: `feature` merged into the tip of `main`. */
+  let mergeSha: string;
+
+  function writeEventPayload(input: { baseRef: string }) {
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        pull_request: {
+          number: 1,
+          head: { ref: "feature", sha: featureSha },
+          base: { ref: input.baseRef },
+        },
+      }),
+    );
+  }
+
+  function createContext(env: Record<string, string>): Context {
+    return {
+      env: {
+        GITHUB_ACTIONS: "true",
+        GITHUB_EVENT_NAME: "pull_request",
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_SHA: mergeSha,
+        ...env,
+      },
+    };
+  }
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    root = mkdtempSync(join(tmpdir(), "argos-github-actions-test-"));
+    repoDir = join(root, "repo");
+    eventPath = join(root, "event.json");
+
+    const bareDir = join(root, "origin.git");
+    execFileSync("git", ["init", "--bare", bareDir]);
+    execFileSync("git", ["init", repoDir]);
+    const git = (...args: string[]) =>
+      execFileSync("git", ["-C", repoDir, ...args])
+        .toString()
+        .trim();
+    git("remote", "add", "origin", bareDir);
+    git("config", "user.email", "test@argos-ci.com");
+    git("config", "user.name", "Argos Test");
+
+    // `main` has two commits, `feature` branches off it with one commit, then
+    // `main` moves forward — the base branch changes the pull request does not
+    // contain yet.
+    git("commit", "--allow-empty", "-m", "base 0");
+    git("commit", "--allow-empty", "-m", "base 1");
+    git("branch", "-M", "main");
+    forkSha = git("rev-parse", "HEAD");
+    git("checkout", "-b", "feature");
+    git("commit", "--allow-empty", "-m", "feature 1");
+    featureSha = git("rev-parse", "HEAD");
+    git("checkout", "main");
+    git("commit", "--allow-empty", "-m", "base 2");
+    mainSha = git("rev-parse", "HEAD");
+    git("push", "origin", "main", "feature");
+
+    // What GitHub checks out on a "pull_request" event: `feature` merged into
+    // the tip of `main`, checked out in detached HEAD.
+    git("checkout", "--detach", mainSha);
+    git("merge", "--no-ff", "-m", "Merge feature into main", featureSha);
+    mergeSha = git("rev-parse", "HEAD");
+
+    writeEventPayload({ baseRef: "main" });
+    process.chdir(repoDir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns the base commit merged into the test-merge commit", async () => {
+    const sha = await service.getMergeBaseCommitSha(
+      { base: "main", head: "feature" },
+      createContext({}),
+    );
+    expect(sha).toBe(mainSha);
+  });
+
+  it("falls back to the merge base when the pull request head is checked out", async () => {
+    // A workflow checking out `github.event.pull_request.head.sha` instead of
+    // the test-merge commit: the screenshots don't contain the base branch
+    // changes, so the merge base is the right base commit.
+    execFileSync("git", ["-C", repoDir, "checkout", "--detach", featureSha]);
+    const sha = await service.getMergeBaseCommitSha(
+      { base: "main", head: "feature" },
+      createContext({}),
+    );
+    expect(sha).toBe(forkSha);
+  });
+
+  it("falls back to the merge base on another event", async () => {
+    const sha = await service.getMergeBaseCommitSha(
+      { base: "main", head: "feature" },
+      createContext({ GITHUB_EVENT_NAME: "push" }),
+    );
+    expect(sha).toBe(forkSha);
+  });
+
+  it("falls back to the merge base when the base is not the pull request base branch", async () => {
+    // A build with a "referenceBranch" overriding the pull request base branch.
+    writeEventPayload({ baseRef: "release" });
+    const sha = await service.getMergeBaseCommitSha(
+      { base: "main", head: "feature" },
+      createContext({}),
+    );
+    expect(sha).toBe(forkSha);
+  });
+
+  it("falls back to the merge base when the event payload is missing", async () => {
+    const sha = await service.getMergeBaseCommitSha(
+      { base: "main", head: "feature" },
+      createContext({ GITHUB_EVENT_PATH: join(root, "missing.json") }),
+    );
+    expect(sha).toBe(forkSha);
+  });
+});

--- a/packages/core/src/ci-environment/services/github-actions.ts
+++ b/packages/core/src/ci-environment/services/github-actions.ts
@@ -1,6 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { Service, Context } from "../types";
-import { getMergeBaseCommitSha, listAncestorCommits } from "../git";
+import {
+  getCommitParents,
+  getMergeBaseCommitSha as getGitMergeBaseCommitSha,
+  head as getHeadSha,
+  listAncestorCommits,
+} from "../git";
 import type * as webhooks from "@octokit/webhooks";
 import type { RepositoryDispatchContext } from "@vercel/repository-dispatch/context";
 import {
@@ -290,6 +295,85 @@ async function getPullRequest(args: {
   }
 
   return getPullRequestFromPayload(payload);
+}
+
+/**
+ * Get the commit of the base branch that GitHub merged into the pull request to
+ * run its checks.
+ *
+ * On a `pull_request` event, GitHub checks out a "test-merge" commit
+ * (`refs/pull/<n>/merge`): the pull request head merged into the tip of the base
+ * branch. The screenshots of such a build then contain the base branch changes
+ * up to that tip, so that tip — the first parent of the test-merge commit — is
+ * the commit to compare the build against. Comparing against the merge base
+ * instead reports every visual change merged into the base branch since the pull
+ * request branch was created as a change of the pull request.
+ *
+ * Returns `null` when the build does not run on a test-merge commit, in which
+ * case the merge base is used: another event, a workflow that checked out
+ * something else (e.g. the pull request head itself), a base branch overridden
+ * to another branch, or a commit whose parents can't be read.
+ */
+async function getTestMergeBaseCommitSha(
+  input: { base: string },
+  ctx: Context,
+): Promise<string | null> {
+  if (ctx.env.GITHUB_EVENT_NAME !== "pull_request") {
+    return null;
+  }
+
+  const payload = readEventPayload(ctx);
+  const pullRequest = payload ? getPullRequestFromPayload(payload) : null;
+  if (!pullRequest) {
+    return null;
+  }
+
+  // The base used to find the baseline is not the branch the test-merge commit
+  // was created from, so its tip tells nothing about the build content.
+  if (input.base !== pullRequest.base.ref) {
+    debug(
+      `Base "${input.base}" is not the pull request base branch "${pullRequest.base.ref}", ignoring the test-merge commit`,
+    );
+    return null;
+  }
+
+  // The screenshots are produced from the commit checked out, so the build must
+  // run on it for its parents to tell what the screenshots contain.
+  const sha = ctx.env.GITHUB_SHA;
+  if (!sha || getHeadSha() !== sha) {
+    debug(
+      "Not running on the checked out commit, ignoring the test-merge commit",
+    );
+    return null;
+  }
+
+  const parents = await getCommitParents(sha);
+
+  // A test-merge commit merges the pull request head (second parent) into the
+  // tip of the base branch (first parent).
+  if (parents?.length !== 2 || parents[1] !== pullRequest.head.sha) {
+    debug(`${sha} is not a test-merge commit of #${pullRequest.number}`);
+    return null;
+  }
+
+  return parents[0] ?? null;
+}
+
+/**
+ * Get the commit to compare the build against: the base commit merged into the
+ * test-merge commit when the build runs on one, else the merge base of the
+ * branch and its base branch.
+ */
+async function getMergeBaseCommitSha(
+  input: { base: string; head: string },
+  ctx: Context,
+): Promise<string | null> {
+  const testMergeBase = await getTestMergeBaseCommitSha(input, ctx);
+  if (testMergeBase) {
+    debug("Found base commit from the test-merge commit", testMergeBase);
+    return testMergeBase;
+  }
+  return getGitMergeBaseCommitSha(input);
 }
 
 const service: Service = {

--- a/packages/core/src/find-reference-commit.ts
+++ b/packages/core/src/find-reference-commit.ts
@@ -111,8 +111,10 @@ export const PARENT_COMMITS_LIMIT = 300;
 
 export interface ResolveBaselineParams {
   /**
-   * Compute the merge base commit between the build branch and its base branch,
-   * or `null` when none can be found.
+   * Compute the commit of the base branch the build content is derived from —
+   * the merge base of the build branch and its base branch, or a closer commit
+   * when the CI service builds the branch merged into its base branch. Returns
+   * `null` when no such commit can be found.
    */
   getMergeBase: () => Promise<string | null>;
 
@@ -144,8 +146,9 @@ export interface BaselineResolution {
  * Resolve the baseline for a build that has no remote content access (no Git
  * provider connected).
  *
- * 1. Find the merge base — the closest common ancestor of the build branch and
- *    its base branch. This is always the starting point.
+ * 1. Find the base commit the build content is derived from — usually the merge
+ *    base, the closest common ancestor of the build branch and its base branch.
+ *    This is always the starting point.
  * 2. From the merge base, ask the API to pick the closest commit (the merge base
  *    itself or one of its ancestors) that has an eligible baseline build, and use
  *    it as the reference commit.


### PR DESCRIPTION
## Description

On a `pull_request` event, GitHub checks out a **test-merge commit** (`refs/pull/<n>/merge`): the pull request head merged into the tip of the base branch. The screenshots therefore contain the base branch changes up to that tip — but the baseline was resolved from the **merge base**, the fork point. Every visual change merged into the base branch since the branch was created was reported as a change of the pull request.

`github-actions.ts` now resolves the base commit from the **first parent of the test-merge commit**, and falls back to the merge base when the build doesn't run on one. Four guards, each falling back to the previous behavior:

- `GITHUB_EVENT_NAME === "pull_request"` — only that event checks out the merge ref.
- `input.base === pull_request.base.ref` — a `referenceBranch` pointing elsewhere means the test-merge tip says nothing about the comparison.
- `git rev-parse HEAD === GITHUB_SHA` — workflows that check out `github.event.pull_request.head.sha` produce screenshots *without* the base changes, so they must keep using the merge base. `GITHUB_SHA` is the merge SHA either way, so comparing against local `HEAD` is the only reliable signal.
- `HEAD` has exactly 2 parents and `parents[1] === pull_request.head.sha` — positively identifies GitHub's test merge rather than a merge the author made.

`getCommitParents()` in `git.ts` reads the parents from git, deepening the history with a `--depth=2` fetch when needed.

Only affects projects **without** a Git provider connected — `upload.ts` returns early when `hasRemoteContentAccess`, so server-side baseline resolution is untouched.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

## Further comments

### Verified against the real PRs open on this repo

I ran the code against #370 and #360, reproducing `actions/checkout@v6`'s exact fetch and checkout (`--depth=1` on `refs/pull/<n>/merge`, detached HEAD) and driving it with each PR's real API data:

|                                    | #370 (fork)                        | #360 (same repo)      |
| ---------------------------------- | ---------------------------------- | --------------------- |
| test-merge commit                  | `b2ed3d14`                         | `96787f53`            |
| parents in `depth=1` checkout      | hidden                             | hidden                |
| parents after deepening            | `a441481c`, `565e3b9f`             | `a441481c`, `9a63cec9`|
| 2nd parent == API `head.sha`       | ✅                                 | ✅                    |
| **before** (merge base)            | **`null` — no baseline at all**    | `a3083087` (fork point)|
| **after** (test-merge base)        | `a441481c`                         | `a441481c`            |

Three things this proved that fixtures couldn't:

**The deepening fetch is load-bearing.** In both real checkouts the parents came back hidden — `git rev-list --parents` returned only the commit itself. Without the `--depth=2` fetch this would silently never fire on any default `actions/checkout`.

**The parents must come from git, not from the payload.** #360's `pull_request.base.sha` is `4c8577c0`, but the merge ref's actual first parent is `a441481c` — GitHub recomputed the merge ref against a newer `main` without firing a new pull request event. The payload value is **26 commits stale**; trusting it would have left most of the drift in place.

**Scale of the bug.** Those 26 commits — including `feat: support media uploads` and `feat(cli): identify the coding agent driving the CLI` — were all attributed to #360 as its own visual changes. And for fork PR #370 the old code returned `null`, so those builds got no baseline whatsoever.

### Reviewer notes

- I left the `Service.getMergeBaseCommitSha` name alone even though the GitHub implementation can now return something that isn't a merge base. Renaming it to `getBaseCommitSha` would touch all eight services — happy to do it if you'd rather have the honest name.
- Fork PRs still resolve no base commit when the workflow checks out the PR head instead of the merge ref (the guard above sends them down the merge-base path, where the fork's branch can't be fetched from origin). Fixing that means fetching `refs/pull/<n>/head`, which I left out of scope.
- The one thing local verification can't cover is whether `git fetch --depth=2 origin <sha>` authenticates inside Actions. `listAncestorCommits` already relies on the same persisted-credential fetch in production, so the only failure mode is `persist-credentials: false` on a private repo — which would equally break the existing merge-base fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
