### PR TITLE
fix(core): let the server resolve the baseline from the ancestor chain

### DIFF
--- a/packages/core/src/find-reference-commit.test.ts
+++ b/packages/core/src/find-reference-commit.test.ts
@@ -159,11 +159,12 @@ describe("#resolveBaseline", () => {
     expect(findBaseline).not.toHaveBeenCalled();
   });
 
-  it("uses the baseline commit and sends no parent commits when one is found", async () => {
-    const ancestors = Array.from({ length: 200 }, (_, i) => `anc-${i}`);
+  it("hands the server the merge base and its ancestors when a baseline is reachable", async () => {
+    const ancestors = Array.from({ length: 500 }, (_, i) => `anc-${i}`);
     const getMergeBase = vi.fn(async () => "merge-base");
     const listCommits = createMergeBaseListCommits(ancestors);
-    const findBaseline = vi.fn(async () => createBaseline("anc-3"));
+    // The closest commit that happens to have a completed build right now.
+    const findBaseline = vi.fn(async () => createBaseline("anc-42"));
 
     const result = await resolveBaseline({
       getMergeBase,
@@ -171,7 +172,16 @@ describe("#resolveBaseline", () => {
       findBaseline,
     });
 
-    expect(result).toEqual({ referenceCommit: "anc-3", parentCommits: null });
+    // The merge base, not "anc-42". Naming a commit here would freeze the
+    // baseline to the builds that are complete at this instant, and the server
+    // stops at the reference commit as soon as it has a bucket for it.
+    expect(result.referenceCommit).toBe("merge-base");
+    expect(result.parentCommits).toEqual(
+      ["merge-base", ...ancestors].slice(0, PARENT_COMMITS_LIMIT),
+    );
+    // A single request: the window the server searches on its own.
+    expect(findBaseline).toHaveBeenCalledTimes(1);
+    expect(findBaseline).toHaveBeenCalledWith(result.parentCommits);
   });
 
   it("offers the merge base itself as the first baseline candidate", async () => {
@@ -188,15 +198,35 @@ describe("#resolveBaseline", () => {
       findBaseline,
     });
 
-    expect(result).toEqual({
-      referenceCommit: "merge-base",
-      parentCommits: null,
-    });
+    expect(result.referenceCommit).toBe("merge-base");
     // The merge base is the first candidate sent to the API.
     expect(findBaseline.mock.calls[0]?.[0]?.[0]).toBe("merge-base");
   });
 
-  it("falls back to the merge base with parent commits when no baseline is found", async () => {
+  it("names the commit itself when the baseline is out of the server's reach", async () => {
+    const ancestors = Array.from({ length: 1000 }, (_, i) => `anc-${i}`);
+    const getMergeBase = vi.fn(async () => "merge-base");
+    const listCommits = createMergeBaseListCommits(ancestors);
+    const findBaseline = vi
+      .fn<(commits: string[]) => Promise<Build | null>>()
+      // Nothing within the window the server searches…
+      .mockResolvedValueOnce(null)
+      // … but there is one further back, which the server cannot walk to.
+      .mockResolvedValueOnce(createBaseline("anc-700"));
+
+    const result = await resolveBaseline({
+      getMergeBase,
+      listCommits,
+      findBaseline,
+    });
+
+    expect(result.referenceCommit).toBe("anc-700");
+    expect(result.parentCommits).toEqual(
+      ["anc-700", ...ancestors].slice(0, PARENT_COMMITS_LIMIT),
+    );
+  });
+
+  it("keeps the merge base when no baseline exists anywhere", async () => {
     const ancestors = Array.from({ length: 500 }, (_, i) => `anc-${i}`);
     const getMergeBase = vi.fn(async () => "merge-base");
     const listCommits = createMergeBaseListCommits(ancestors);
@@ -214,5 +244,20 @@ describe("#resolveBaseline", () => {
       ["merge-base", ...ancestors].slice(0, PARENT_COMMITS_LIMIT),
     );
     expect(result.parentCommits).toHaveLength(PARENT_COMMITS_LIMIT);
+  });
+
+  it("never lists a shallower history than it has already fetched", async () => {
+    const ancestors = Array.from({ length: 1000 }, (_, i) => `anc-${i}`);
+    const getMergeBase = vi.fn(async () => "merge-base");
+    const listCommits = createMergeBaseListCommits(ancestors);
+    const findBaseline = vi.fn(async () => null);
+
+    await resolveBaseline({ getMergeBase, listCommits, findBaseline });
+
+    const limits = listCommits.mock.calls.map(([, limit]) => limit);
+    // Each listing deepens the shallow clone with a fetch, so a smaller limit
+    // afterwards would shorten the history back and hide commits we have.
+    expect(limits[0]).toBe(PARENT_COMMITS_LIMIT);
+    expect(limits).toEqual([...limits].sort((a, b) => a - b));
   });
 });

--- a/packages/core/src/find-reference-commit.ts
+++ b/packages/core/src/find-reference-commit.ts
@@ -50,6 +50,13 @@ export interface FindReferenceCommitParams {
    * when none is found.
    */
   findBaseline: (commits: string[]) => Promise<Build | null>;
+
+  /**
+   * Number of leading commits the caller has already inspected. Batches at or
+   * below that size are skipped, so the search never asks for a shallower
+   * history than the caller already fetched.
+   */
+  inspectedCount?: number;
 }
 
 /**
@@ -65,9 +72,15 @@ export interface FindReferenceCommitParams {
 export async function findReferenceCommit(
   params: FindReferenceCommitParams,
 ): Promise<string | null> {
-  let inspectedCount = 0;
+  let inspectedCount = params.inspectedCount ?? 0;
 
   for (const limit of getCumulativeBatchSizes()) {
+    // Already covered by the caller or by a previous batch. Asking anyway would
+    // re-fetch the history at a shallower depth than it already has.
+    if (limit <= inspectedCount) {
+      continue;
+    }
+
     const commits = await params.listCommits(limit);
 
     // Only send the commits not already inspected in previous batches. Earlier
@@ -75,7 +88,10 @@ export async function findReferenceCommit(
     // each batch the closest commit still wins overall.
     const batch = commits.slice(inspectedCount);
 
-    // No new commits became available: the history is exhausted.
+    // The listing stopped growing, so the history is exhausted. This is the only
+    // reliable signal: a listing shorter than `limit` is normal on the shallow
+    // clones CI uses, where git stops at the boundary of the fetched history and
+    // a deeper fetch does bring more commits.
     if (batch.length === 0) {
       break;
     }
@@ -88,12 +104,6 @@ export async function findReferenceCommit(
     }
 
     inspectedCount = commits.length;
-
-    // Fewer commits than requested: the history is exhausted, so asking for more
-    // would return the same list.
-    if (commits.length < limit) {
-      break;
-    }
   }
 
   debug("No eligible baseline found among ancestor commits");
@@ -101,11 +111,9 @@ export async function findReferenceCommit(
 }
 
 /**
- * Number of commits (the merge base plus its ancestors) sent as `parentCommits`
- * when no baseline build is found yet. The baseline build may still be
- * processing on the server; sending these lets the server resolve the baseline
- * once it completes, when it processes this build. The server treats the first
- * commit as the reference commit and searches the rest.
+ * Number of commits (the reference commit plus its ancestors) sent as
+ * `parentCommits`, which is the window the server searches on its own. The
+ * server treats the first commit as the reference commit and searches the rest.
  */
 export const PARENT_COMMITS_LIMIT = 300;
 
@@ -137,7 +145,8 @@ export interface BaselineResolution {
   referenceCommit: string | null;
   /**
    * Commits sent to the server so it can resolve the baseline itself — the
-   * reference commit followed by its ancestors — or `null` when not needed.
+   * reference commit followed by its ancestors — or `null` when there is no
+   * reference commit.
    */
   parentCommits: string[] | null;
 }
@@ -149,12 +158,21 @@ export interface BaselineResolution {
  * 1. Find the base commit the build content is derived from — usually the merge
  *    base, the closest common ancestor of the build branch and its base branch.
  *    This is always the starting point.
- * 2. From the merge base, ask the API to pick the closest commit (the merge base
- *    itself or one of its ancestors) that has an eligible baseline build, and use
- *    it as the reference commit.
- * 3. If none is found, the baseline build may still be processing on the server.
- *    Fall back to the merge base as the reference commit and send its parent
- *    commits so the server can resolve the baseline once that build completes.
+ * 2. Send it as the reference commit, followed by the ancestors the server
+ *    searches on its own, and let the server pick the baseline when it
+ *    processes the build.
+ * 3. Only when no baseline is reachable from the merge base do we search deeper
+ *    and name a commit ourselves, because past {@link PARENT_COMMITS_LIMIT} the
+ *    server cannot walk back that far.
+ *
+ * Step 2 is deliberately not "resolve the baseline here and send that commit".
+ * `findBaseline` only sees builds that are already complete, so on a busy base
+ * branch the closest ones are routinely still running when this executes and
+ * the search walks straight past them. A commit named here is also final: the
+ * server stops at the reference commit as soon as it has a bucket, and for a
+ * project without remote content access there is no ancestor list to fall back
+ * on. Handing over the chain instead keeps the decision where the freshest
+ * information is.
  */
 export async function resolveBaseline(
   params: ResolveBaselineParams,
@@ -166,23 +184,38 @@ export async function resolveBaseline(
   }
   debug("Found merge base", mergeBase);
 
-  const referenceCommit = await findReferenceCommit({
-    listCommits: (limit) => params.listCommits(mergeBase, limit),
-    findBaseline: params.findBaseline,
-  });
-
-  if (referenceCommit) {
-    debug("Found reference commit from baseline", referenceCommit);
-    return { referenceCommit, parentCommits: null };
-  }
-
-  // No eligible baseline build yet — it may still be processing. Fall back to
-  // the merge base and let the server resolve the baseline from the parent
-  // commits once that build completes.
   const parentCommits = await params.listCommits(
     mergeBase,
     PARENT_COMMITS_LIMIT,
   );
-  debug("No baseline found, using merge base with parent commits", mergeBase);
-  return { referenceCommit: mergeBase, parentCommits };
+
+  // Whether a baseline exists within the server's reach — not which one, that
+  // is the server's call.
+  const reachable = await params.findBaseline(parentCommits);
+  if (reachable) {
+    debug("Baseline reachable from the merge base", mergeBase);
+    return { referenceCommit: mergeBase, parentCommits };
+  }
+
+  const referenceCommit = await findReferenceCommit({
+    listCommits: (limit) => params.listCommits(mergeBase, limit),
+    findBaseline: params.findBaseline,
+    inspectedCount: parentCommits.length,
+  });
+
+  // Nothing anywhere in the history. Keep the merge base so the build is still
+  // compared against whatever lands on it later.
+  if (!referenceCommit) {
+    debug("No baseline found, using merge base with parent commits", mergeBase);
+    return { referenceCommit: mergeBase, parentCommits };
+  }
+
+  debug("Baseline out of the server's reach, using", referenceCommit);
+  return {
+    referenceCommit,
+    parentCommits: await params.listCommits(
+      referenceCommit,
+      PARENT_COMMITS_LIMIT,
+    ),
+  };
 }


### PR DESCRIPTION
## Description

Follow-up to #372, which is working: on the production build that prompted this, the merge base was master's tip. The stale baseline comes from what happens **after** the search succeeds.

`resolveBaseline()` asked `/baseline` for the closest commit with an eligible baseline build and sent that commit alone, with `parentCommits: null`. Naming a commit there has two consequences.

**The choice is frozen to the eligibility of that instant.** `/baseline` only matches builds that are already `complete` with a `complete && valid` bucket. On a busy base branch the closest ones are routinely still running when the CLI executes, so the search walks past them. Minutes later, when the server processes the build, they are complete — but `resolveCIBase` stops at the reference commit as soon as it has a bucket for it, so the stale pick stands.

**The choice is also final.** Without remote content access there is no ancestor list to fall back on: `listParentCommitShas()` returns `[]` for a **light** installation, so a single commit is all the server ever has. That is the risk flagged in #372's reviewer notes — it turns out to fire on every build, not in an edge case.

So the CLI now sends the merge base plus the ancestors the server searches, and lets the server pick when it processes the build. `/baseline` keeps the job it is actually needed for: telling us whether a baseline is reachable at all. Only when none is do we search deeper and name a commit ourselves, because past `PARENT_COMMITS_LIMIT` the server cannot walk there.

`findReferenceCommit()` also stopped widening as soon as a listing came back shorter than the batch size. That is normal on the shallow clones CI uses, where `git log` stops at the boundary of the fetched history and a deeper fetch does bring more commits — so the search could give up early. It now widens while the listing grows, and skips the batches the caller already inspected, which also keeps the fetch depths monotonic (a smaller `--depth` afterwards re-shallows the clone).

## Evidence

Measured on a production project (light app, GitHub Actions, 24 build names in one monorepo, a push to the base branch every ~2 minutes):

- **0 of 4379** builds carried `parentCommits`, so the server never had a fallback.
- **704 of 782 (90%)** base branch builds were baselined against a commit that was not the closest eligible one for their build name — skipping 1–5 nearer baselines that had already concluded **more than 5 minutes earlier**, so this is not a race with the upload.
- The commits every build converges on are the ones where *all* build names ran: one was the baseline of **21 distinct pull requests** across 27 runs. It cannot be 21 branches' fork point — it is where the walk stops.
- In a single workflow run (one test-merge commit, therefore one merge base) the 23 build names resolved **three different** reference commits: two got a base branch commit from ~25 minutes earlier, the other 21 landed 85 minutes back.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

## Further comments

### Behaviour change worth a second opinion

The server's ancestor walk (`getBucketFromCommits`) does **not** filter on `approved`, whereas `/baseline` does. For base branch history this is the same set — those builds are `type: "reference"`, which is auto-approved — but a merged pull request's `check` build whose bucket commit is an ancestor could now be picked where the CLI would have skipped it. Rejected builds stay excluded either way. This also makes the light-app path behave like the Git-provider path, which has always walked ancestors server-side.

### Ruled out along the way

- **`git log --topo-order` does not help.** The candidate list is documented as "closest to furthest ancestor" and the server ranks by position, so committer-date order looked suspect. It is not, for ancestors: a parent only enters git's walk through a child, so a parent is never emitted first. For *incomparable* commits (a side branch merged into the base branch) the order genuinely is by date — but `--topo-order` produces the identical order there; only `--first-parent` moves the mainline commit ahead. That is a real semantic change, so it is left out of this fix rather than bundled into it.
- **`GITHUB_SHA` can go stale the same way the payload did.** `getTestMergeBaseCommitSha()` requires `getHeadSha() === GITHUB_SHA` and `getCommitParents()` deepens by fetching a bare SHA. GitHub recomputes `refs/pull/<n>/merge` whenever either branch moves, so the runner can check out a newer test-merge commit than the run was created for, and the previous one stops being advertised. Both guards then bail to the merge base — the fork point, the very outcome #372 removed. I could not show it firing on the build investigated here (the merge base was fresh), so it is worth its own change rather than an unproven one here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
