### PR TITLE
fix(core): read a commit's parents from the object, not the shallow graft

### DIFF
--- a/packages/core/src/ci-environment/git.test.ts
+++ b/packages/core/src/ci-environment/git.test.ts
@@ -326,28 +326,24 @@ describe("#getCommitParents", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it("returns the parents of a merge commit, first parent first", async () => {
-    await expect(getCommitParents(mergeSha)).resolves.toEqual([
-      mainSha,
-      featureSha,
-    ]);
+  it("returns the parents of a merge commit, first parent first", () => {
+    expect(getCommitParents(mergeSha)).toEqual([mainSha, featureSha]);
   });
 
-  it("returns an empty array for a root commit", async () => {
-    await expect(getCommitParents(rootCommitSha)).resolves.toEqual([]);
+  it("returns an empty array for a root commit", () => {
+    expect(getCommitParents(rootCommitSha)).toEqual([]);
   });
 
-  it("returns null for an unknown commit", async () => {
-    await expect(getCommitParents("f".repeat(40))).resolves.toBe(null);
+  it("returns null for an unknown commit", () => {
+    expect(getCommitParents("f".repeat(40))).toBe(null);
   });
 
-  it("deepens a shallow history to read the parents", async () => {
-    // The state of a CI checkout: a shallow clone where git hides the parents
-    // of the commits at the boundary of the history.
-    // "--depth" implies "--single-branch", so the branch is named explicitly:
-    // it would otherwise be read from the remote HEAD, which points to another
-    // branch when git defaults to "master" for new repositories.
-    const shallowDir = join(root, "shallow");
+  it("reads the parents on a shallow clone without reaching the remote", async () => {
+    // What CI has: a shallow checkout, where git grafts the boundary commit to
+    // look parentless. The parent SHAs are in the commit object either way, so
+    // no fetch is needed - and none may be relied on, since the remote can stop
+    // advertising a commit GitHub generated for the pull request.
+    const shallowDir = join(root, "shallow-offline");
     execFileSync("git", [
       "clone",
       "--depth=1",
@@ -360,18 +356,14 @@ describe("#getCommitParents", () => {
       execFileSync("git", ["-C", shallowDir, ...args])
         .toString()
         .trim();
+    // Nothing to fetch from: the answer has to come from the local object.
+    shallowGit("remote", "set-url", "origin", join(root, "does-not-exist.git"));
     process.chdir(shallowDir);
 
-    // The commit is there, but its parents are not…
-    expect(shallowGit("rev-parse", "HEAD")).toBe(mergeSha);
     expect(shallowGit("rev-list", "--parents", "-n", "1", mergeSha, "--")).toBe(
       mergeSha,
     );
 
-    // … until they are fetched.
-    await expect(getCommitParents(mergeSha)).resolves.toEqual([
-      mainSha,
-      featureSha,
-    ]);
+    expect(getCommitParents(mergeSha)).toEqual([mainSha, featureSha]);
   });
 });

--- a/packages/core/src/ci-environment/git.ts
+++ b/packages/core/src/ci-environment/git.ts
@@ -354,52 +354,44 @@ export async function listAncestorCommits(input: {
 }
 
 /**
- * Read the parent commits of a commit, ordered as recorded in the commit — the
- * first parent first. Returns `null` when the commit is unknown, and an empty
- * array when it has no parent.
+ * Read the parent commits recorded in a commit object, the first parent first.
+ * Returns `null` when the object cannot be read — it is not in the repository,
+ * or git refused to print it — and an empty array for a root commit.
  *
- * The history is deepened with a shallow fetch when the parents are not
- * available locally: in the shallow clones typically used in CI, git hides the
- * parents of the commits at the boundary of the history.
+ * Read from the object rather than with `git rev-list --parents`, which honours
+ * the shallow graft: on the shallow clones CI uses it reports every commit at
+ * the boundary of the history as having no parent, which is most of what we ask
+ * about. The object carries the parent SHAs whatever the graft says, so this
+ * answers locally, and without the remote having to still advertise the commit:
+ * GitHub stops advertising a test-merge commit as soon as it recomputes
+ * `refs/pull/<n>/merge`, and fetching it then fails with "not our ref".
+ *
+ * Only the SHAs are recovered this way. The parent *objects* can be absent, so
+ * a caller that goes on to walk from one has to be able to fetch it — see
+ * {@link listAncestorCommits}, which deepens the history before listing.
  */
-export async function getCommitParents(sha: string): Promise<string[] | null> {
-  const localParents = readCommitParents(sha);
-  if (localParents?.length) {
-    return localParents;
-  }
-
-  // Fetch the commit and its parents, so the parents stop being hidden by the
-  // boundary of a shallow history.
+export function getCommitParents(sha: string): string[] | null {
   try {
-    await runGitFetch(["--depth=2", "origin", sha]);
+    const raw = execFileSync("git", ["cat-file", "commit", sha], {
+      stdio: ["ignore", "pipe", "pipe"],
+      // The whole object is printed, message included, where a bounded
+      // `rev-list --parents` used to be enough. A generated commit message can
+      // outgrow the 1MB default, and the overflow is reported as a failure to
+      // read the commit at all.
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    // The header runs up to the first blank line, and holds one "parent <sha>"
+    // line per parent, in order.
+    const [header = ""] = raw.toString().split("\n\n", 1);
+    return header
+      .split("\n")
+      .filter((line) => line.startsWith("parent "))
+      .map((line) => line.slice("parent ".length).trim());
   } catch (error) {
     debug(
-      `Failed to deepen history for ${sha}, using local history`,
+      `Failed to read the commit object of ${sha}`,
       getGitErrorOutput(error),
     );
-    return localParents;
-  }
-
-  return readCommitParents(sha);
-}
-
-/**
- * Read the parent commits of a commit from the local history. Returns `null`
- * when the commit is unknown, and an empty array when it has no parent — a root
- * commit, or a commit at the boundary of a shallow history, where git hides the
- * parents.
- */
-function readCommitParents(sha: string): string[] | null {
-  try {
-    const raw = execFileSync(
-      "git",
-      ["rev-list", "--parents", "-n", "1", sha, "--"],
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
-    const [, ...parents] = raw.toString().trim().split(" ");
-    return parents;
-  } catch (error) {
-    debug(`Failed to read the parents of ${sha}`, getGitErrorOutput(error));
     return null;
   }
 }

--- a/packages/core/src/ci-environment/services/github-actions.ts
+++ b/packages/core/src/ci-environment/services/github-actions.ts
@@ -347,11 +347,22 @@ async function getTestMergeBaseCommitSha(
     return null;
   }
 
-  const parents = await getCommitParents(sha);
+  const mergeRef = `refs/pull/${pullRequest.number}/merge`;
+  const parents = getCommitParents(sha);
+
+  // Reported apart from the shape check below: a commit we could not read says
+  // nothing about whether it is a test merge, and blaming its shape sends
+  // anyone reading the debug output after the wrong thing.
+  if (!parents) {
+    debug(
+      `Could not read the parents of ${sha}, ignoring the test-merge commit`,
+    );
+    return null;
+  }
 
   // A test-merge commit merges the pull request head (second parent) into the
   // tip of the base branch (first parent).
-  if (parents?.length !== 2) {
+  if (parents.length !== 2) {
     debug(`${sha} is not a merge commit, ignoring the test-merge commit`);
     return null;
   }
@@ -368,7 +379,7 @@ async function getTestMergeBaseCommitSha(
   // genuine test-merge build, and the fallback baselines it against the fork
   // point — reporting every change merged into the base branch since as a
   // change of the pull request.
-  if (ctx.env.GITHUB_REF === `refs/pull/${pullRequest.number}/merge`) {
+  if (ctx.env.GITHUB_REF === mergeRef) {
     return parents[0] ?? null;
   }
 


### PR DESCRIPTION
## Description

`getCommitParents()` read the parents with `git rev-list --parents`, which honours the shallow graft: on the shallow clones CI uses, every commit at the boundary of the fetched history is reported as parentless. That is exactly the commit we ask about — the test-merge commit `HEAD` sits on — so the answer came from a `git fetch --depth=2 origin <sha>` instead: once per build, over the network, for a commit the remote has to still be willing to serve.

```
rev-list --parents  →  751bad91                    (parents hidden by the graft)
cat-file commit     →  parent 46f42167 / 569a5f52  (both there)
```

The object carries the parent SHAs whatever the graft says, so reading it answers locally. Only the SHAs come back this way — the parent *objects* can still be absent — which is all the one caller needs, and is now written down in the JSDoc.

With the fetch gone the function is synchronous, and the deepening path it existed for is unreachable anyway: `getTestMergeBaseCommitSha` only calls it after establishing the commit is `HEAD`, so its object is always present. An explicit `maxBuffer` replaces the bound the old command got for free from printing nothing but SHAs.

Reading the object and failing to read it are now reported apart. Both used to log `is not a merge commit`, which blames the commit's shape for a commit we never managed to look at.

The existing tests build a full local repository, where the parents are readable whatever git is asked, so none of them covered the shallow checkout CI actually uses. The new one does, with the remote pointed at a path that does not exist; it fails without the change.

**This is a robustness fix, not the fix for the "older baseline" reports.** See below.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

## Further comments

### A `console.warn` was here and has been dropped

An earlier revision warned when a run on a merge ref could not identify its test merge. A review of it found the trigger was wrong in a way that made it net-negative, so it is gone:

- `checkRunsOnMergeRef` inspected `GITHUB_REF`, which the runner sets from the *trigger*, not from what `actions/checkout` checked out. On a `pull_request` event that is always `refs/pull/<n>/merge`, so the predicate reduced to `GITHUB_EVENT_NAME === "pull_request"` and fired on two fallbacks this file documents as **correct**: a `ref: ${{ github.event.pull_request.head.sha }}` checkout, and a configured `referenceBranch`. The existing tests at `github-actions.test.ts:103` and `:123` assert those configs are right; they only stayed silent because `createContext` leaves `GITHUB_REF` unset, an env real Actions never produces.
- It was written to stderr while `ora` owns stderr in `cli/src/commands/upload.ts`, so it was partially overwritten by the next spinner frame.
- It printed once per build name (`playwright/src/reporter.ts` loops `upload()`), so three times for a three-browser matrix.

The diagnostic intent survives in the `debug` channel, which is where the per-guard detail already lives. Doing this properly means giving `Service.getMergeBaseCommitSha` a way to say "this answer is a guess" — its `Promise<string | null>` cannot — and warning once centrally, which also covers the shared `git.ts` path that degrades *worse* (no baseline at all) and silently. That touches `types.ts` and seven services, so it belongs in its own change.

### What the investigation ruled out

Chasing a reported build on a light-app project (GitHub Actions, 24 build names in one monorepo, a push to `master` every ~2 minutes), against the production database and real runners in argos-ci/argos-test-repository#22:

- **"The closest base branch builds were still running when `/baseline` was called."** No — they had concluded more than five minutes before.
- **"A base-branch push orphans the test-merge commit."** No — GitHub does not recompute `refs/pull/<n>/merge` when the base branch moves. `main` was advanced and the merge ref was unchanged 15 minutes later.
- **"…and then the SHA can no longer be fetched."** No — moving the pull request *head* does recompute the ref, but GitHub keeps serving the orphaned merge commit: `git fetch --depth=2 origin $GITHUB_SHA` returned 0 and the resolver still resolved correctly at `fetch-depth: 1`. **`fetch-depth` is a red herring.**
- **Version skew across packages.** No — all 23 jobs of the failing run reported `@argos-ci/core@6.8.3`, with identical `baseBranch` and `baseBranchResolvedFrom`.
- **Eligibility flapping.** No — zero `build_reviews` rows on any of the skipped baselines.

The baseline **walk is correct**: run `34122664365` is textbook, with `design-system-kit` — the one build name without a build at the nearer commit — correctly falling back further.

### The one thing that would settle it

In the failing run, two jobs resolved `400f4496`/`0344ca3e` and the other 21 resolved `65ec16f2`, 85 minutes older. Whether that is a bug turns on a single fact the database cannot answer:

```sh
git merge-base --is-ancestor a59619df 400f4496
```

- **Ancestor** → those 21 build names had a nearer eligible baseline in their candidate list and should have used it, so `getMergeBase()` is returning different values for identical inputs in one run.
- **Not an ancestor** → `65ec16f2` was the correct answer, and the complaint is really that in a monorepo a package untouched for 90 minutes legitimately gets a 90-minute-old baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
