### PR TITLE
test(cli): give the e2e suite a realistic timeout

### DIFF
--- a/packages/cli/e2e/comment.test.ts
+++ b/packages/cli/e2e/comment.test.ts
@@ -100,5 +100,5 @@ describe("argos comment", () => {
       runAs(["comment", "delete", buildUrl, id]).stdout,
     );
     expect(deleted.id).toBe(id);
-  }, 30000);
+  });
 });

--- a/packages/cli/e2e/deploy.test.ts
+++ b/packages/cli/e2e/deploy.test.ts
@@ -12,4 +12,4 @@ test("deploys a static site with HTML and CSS assets", () => {
 
   expect(deployResult.combined).toContain("Deployed:");
   expect(deployResult.combined).toMatch(/https?:\/\/\S+/);
-}, 10000);
+});

--- a/packages/cli/e2e/skip.test.ts
+++ b/packages/cli/e2e/skip.test.ts
@@ -4,7 +4,7 @@ import { getRequiredEnv, run } from "./utils";
 
 getRequiredEnv("ARGOS_TOKEN");
 
-test("skip returns a build URL", { timeout: 20_000 }, () => {
+test("skip returns a build URL", () => {
   const buildName = `argos-cli-e2e-skipped-node-${process.env.NODE_VERSION}-${process.env.OS}`;
   const skipResult = run(["skip", "--build-name", buildName]);
 

--- a/packages/cli/e2e/upload-oidc.test.ts
+++ b/packages/cli/e2e/upload-oidc.test.ts
@@ -5,7 +5,7 @@ import { run } from "./utils";
 // No ARGOS_TOKEN — authentication is handled via GitHub Actions OIDC.
 test(
   "upload returns a full build URL using OIDC authentication",
-  { tags: ["oidc"], timeout: 20_000 },
+  { tags: ["oidc"] },
   () => {
     const buildName = `argos-cli-e2e-oidc-node-${process.env.NODE_VERSION}-${process.env.OS}`;
     const uploadResult = run([

--- a/packages/cli/e2e/upload-tokenless.test.ts
+++ b/packages/cli/e2e/upload-tokenless.test.ts
@@ -8,7 +8,7 @@ import { run } from "./utils";
 // eslint-disable-next-line vitest/no-disabled-tests
 test.skip(
   "upload returns a full build URL using tokenless authentication",
-  { tags: ["tokenless"], timeout: 20_000 },
+  { tags: ["tokenless"] },
   () => {
     const buildName = `argos-cli-e2e-tokenless-node-${process.env.NODE_VERSION}-${process.env.OS}`;
     const uploadResult = run([

--- a/packages/cli/e2e/upload.test.ts
+++ b/packages/cli/e2e/upload.test.ts
@@ -6,8 +6,9 @@ getRequiredEnv("ARGOS_TOKEN");
 
 // This test uploads the full __fixtures__ directory, which includes a 10MB PNG
 // stress fixture. That file is sharp-optimized, hashed, and uploaded to S3 over
-// a real network connection, so a generous timeout is required to avoid flakes.
-test("upload returns a full build URL", { timeout: 30_000 }, () => {
+// a real network connection. It relies on the generous e2e timeout configured
+// in vitest.config.ts.
+test("upload returns a full build URL", () => {
   const buildName = `argos-cli-e2e-node-${process.env.NODE_VERSION}-${process.env.OS}`;
   const uploadResult = run([
     "upload",

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,7 +1,18 @@
-export default {
+import { defineConfig } from "vitest/config";
+
+/**
+ * The e2e suite spawns the built CLI and talks to the live Argos API, so every
+ * test is bound by network latency rather than by local compute. Vitest's
+ * default 5s budget is routinely too tight on a loaded CI runner, which shows
+ * up as a single matrix cell failing on a timeout while the others pass.
+ *
+ * Applied as a project-level default so individual tests and hooks don't have
+ * to carry hand-written timeouts.
+ */
+const E2E_TIMEOUT = 30_000;
+
+export default defineConfig({
   test: {
-    environment: "node",
-    include: ["src/**/*.test.ts", "e2e/**/*.test.ts"],
     tags: [
       {
         name: "oidc",
@@ -12,5 +23,27 @@ export default {
         description: "Tokenless exchange tests.",
       },
     ],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          environment: "node",
+          include: ["src/**/*.test.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "e2e",
+          environment: "node",
+          include: ["e2e/**/*.test.ts"],
+          testTimeout: E2E_TIMEOUT,
+          // Several e2e files seed state from the API in `beforeAll`, which is
+          // subject to the same latency (default hook budget is 10s).
+          hookTimeout: E2E_TIMEOUT,
+        },
+      },
+    ],
   },
-};
+});


### PR DESCRIPTION
## Description

The CLI e2e tests spawn the built CLI and call the live Argos API, so they are bound by network latency rather than local compute. Most of them ran on vitest's 5s default, which is too tight on a loaded runner.

In [CI run 34607908169](https://github.com/argos-ci/argos-javascript/actions/runs/34607908169) the `e2e-core (24, macos-latest)` cell failed because `argos build get 999999` timed out at 5000ms, while the other 8 matrix cells passed. That is runner and API latency, not a code defect.

`packages/cli/vitest.config.ts` is now split into two vitest projects so only the e2e files get a generous budget:

| Setting | `unit` (`src`) | `e2e` (`e2e`) |
| --- | --- | --- |
| `testTimeout` | 5000ms (default) | 30000ms |
| `hookTimeout` | 10000ms (default) | 30000ms |

`hookTimeout` is raised too: six e2e files seed state from the live API inside `beforeAll`, and that hook runs on its own 10s budget that the same latency would blow.

Centralizing the timeout makes the hand-written per-test timeouts redundant, so they are removed from `comment`, `deploy`, `skip`, `upload`, `upload-oidc` and `upload-tokenless`. Three of those were set *below* 30s, so leaving them would have made those tests stricter than the rest of the suite.

## Type of changes

`bug`

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

### What a reviewer should know

**The three e2e scripts still work.** `e2e`, `e2e-oidc` and `e2e-tokenless` pass path and tag filters, which vitest applies across projects. `tags` stays declared at the root and both projects inherit it via `extends: true`. Only `tagsFilter` is a root-only option in vitest; `tags`, `testTimeout` and `hookTimeout` are all project-level.

**Verification.** `check-types`, `lint`, `check-format` and the unit suite (84 tests) all pass. The live e2e suite was not run, as no API token was available locally. Instead:

- `vitest list` (collects without executing, so no API calls) confirms all three scripts resolve their files, and that the tag filter yields 63 tests vs 64 unfiltered, correctly dropping the OIDC one.
- Throwaway probe tests confirm the config actually applies, since a config that silently fails to apply would look identical to one that works. A 6s e2e test passes where the old 5s default would have failed it; an 11s `beforeAll` passes where the 10s default would have failed it; and the same 6s test placed in `src` still fails at 5000ms, confirming the split does not leak into unit tests.

**`packages/core/e2e` needed nothing.** It is plain node scripts with no vitest involved.

**One thing worth a second opinion:** the `e2e-core` jobs in `.github/workflows/ci.yml` set `timeout-minutes: 5`. A pathological run that now burns 30s per failing test could hit the job ceiling and report as a cancelled job rather than a clean test timeout. Left untouched here as it is out of scope, but happy to bump it in this PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)