### PR TITLE
feat(storybook): support Storybook 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,3 +364,46 @@ jobs:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
           NODE_VERSION: ${{ matrix.node-version }}
           OS: ${{ matrix.os }}
+
+  # `@argos-ci/storybook` supports Storybook 8 through 11. The workspace is
+  # pinned to 10, so this job moves the package to the newest 11 pre-release and
+  # re-runs the Vitest suite against it, under its own build name. The Test
+  # Runner suite is left out for now: Storybook 11's config loader registers a
+  # Node module hook (`module.register()`), which Jest refuses, so
+  # `@storybook/test-runner` cannot load its config on 11 yet.
+  e2e-storybook-next:
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [lts/*]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup deps
+        uses: ./.github/actions/setup-deps
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Upgrade to the Storybook 11 pre-release
+        run: >-
+          pnpm --filter=@argos-ci/storybook up
+          "storybook@>=11.0.0-0 <12.0.0-0"
+          "@storybook/react-vite@>=11.0.0-0 <12.0.0-0"
+          "@storybook/addon-docs@>=11.0.0-0 <12.0.0-0"
+          "@storybook/addon-links@>=11.0.0-0 <12.0.0-0"
+          "@storybook/addon-themes@>=11.0.0-0 <12.0.0-0"
+          "@storybook/addon-vitest@>=11.0.0-0 <12.0.0-0"
+          "storybook-addon-pseudo-states@>=11.0.0-0 <12.0.0-0"
+
+      - name: Run integration tests
+        run: pnpm exec -- turbo run e2e-next --filter=@argos-ci/storybook
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+          NODE_VERSION: ${{ matrix.node-version }}
+          OS: ${{ matrix.os }}

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -54,7 +54,7 @@
     "debug": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.62.1",
+    "@playwright/test": "^1.63.0",
     "@types/debug": "^4.1.13",
     "@types/node": "catalog:",
     "vitest": "catalog:"

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -28,7 +28,7 @@ const preview: Preview = {
       },
     },
     viewport: {
-      viewports: INITIAL_VIEWPORTS,
+      options: INITIAL_VIEWPORTS,
     },
   },
 };

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -59,6 +59,10 @@ export const Example: Story = {
 
 > Using the [Storybook Test Runner](https://storybook.js.org/docs/writing-tests/integrations/test-runner) instead? Import `argosScreenshot` from `@argos-ci/storybook/test-runner` and call it from the `postVisit` hook. See the [Test Runner quickstart](https://argos-ci.com/docs/quickstart/storybook-quickstart/storybook-test-runner-quickstart).
 
+## Compatibility
+
+`@argos-ci/storybook` supports Storybook 8 through 11, including the 11 pre-releases. Screenshots can be taken with the [Vitest addon](https://storybook.js.org/docs/writing-tests/integrations/vitest-addon) (Storybook 9 or later, Vitest 4 or 5) or with the [Storybook Test Runner](https://storybook.js.org/docs/writing-tests/integrations/test-runner) (Storybook 8 or later).
+
 ## Links
 
 - [Official SDK Docs](https://argos-ci.com/docs/reference/storybook)

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -55,6 +55,9 @@
     "@argos-ci/util": "workspace:*",
     "@argos-ci/vitest": "workspace:*"
   },
+  "peerDependencies": {
+    "storybook": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0-0"
+  },
   "devDependencies": {
     "@argos-ci/cli": "workspace:*",
     "@argos-ci/util": "workspace:*",
@@ -63,7 +66,7 @@
     "@storybook/addon-themes": "^10.5.5",
     "@storybook/addon-vitest": "^10.5.5",
     "@storybook/react-vite": "^10.5.5",
-    "@storybook/test-runner": "^0.24.4",
+    "@storybook/test-runner": "^0.24.5",
     "@types/node": "catalog:",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
@@ -72,7 +75,7 @@
     "@vitest/coverage-v8": "^5.0.0",
     "@vitest/ui": "^5.0.0",
     "http-server": "^14.1.1",
-    "playwright": "^1.62.1",
+    "playwright": "^1.63.0",
     "prop-types": "^15.8.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
@@ -98,6 +101,7 @@
     "e2e-runner": "pnpm dlx concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"pnpm run serve-storybook\" \"pnpm run wait-storybook && pnpm run test-e2e-runner\"",
     "e2e-vitest": "cross-env BUILD_NAME=\"argos-storybook-vitest-e2e-node-$NODE_VERSION-$OS\" UPLOAD_TO_ARGOS=true pnpm run test-e2e-vitest",
     "e2e-compat": "cross-env BUILD_NAME=\"argos-storybook-vitest4-e2e-node-$NODE_VERSION-$OS\" UPLOAD_TO_ARGOS=true pnpm run test-e2e-vitest",
+    "e2e-next": "cross-env BUILD_NAME=\"argos-storybook-next-e2e-node-$NODE_VERSION-$OS\" UPLOAD_TO_ARGOS=true pnpm run test-e2e-vitest",
     "e2e": "pnpm run e2e-runner && rm -rf ./screenshots && pnpm run e2e-vitest",
     "check-types": "tsc",
     "check-format": "prettier --check --ignore-unknown --ignore-path=./.gitignore --ignore-path=../../.gitignore --ignore-path=../../.prettierignore .",

--- a/packages/storybook/src/utils/parameters.test.ts
+++ b/packages/storybook/src/utils/parameters.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultViewport, getViewport } from "./parameters";
+
+const definitions = {
+  compact: {
+    name: "Compact",
+    styles: { width: "600px", height: "900px" },
+  },
+  widescreen: {
+    name: "Widescreen",
+    styles: { width: "1440px", height: "900px" },
+  },
+};
+
+describe("getViewport", () => {
+  it("resolves a viewport name from `viewport.options` (Storybook 9+)", () => {
+    expect(
+      getViewport({ viewport: { options: definitions } }, "compact"),
+    ).toEqual({ width: 600, height: 900 });
+  });
+
+  it("resolves a viewport name from the legacy `viewport.viewports`", () => {
+    expect(
+      getViewport({ viewport: { viewports: definitions } }, "compact"),
+    ).toEqual({ width: 600, height: 900 });
+  });
+
+  it("prefers `options` over `viewports` when both are defined", () => {
+    const parameters = {
+      viewport: {
+        options: definitions,
+        viewports: {
+          compact: { name: "Old", styles: { width: "1px", height: "1px" } },
+        },
+      },
+    };
+    expect(getViewport(parameters, "compact")).toEqual({
+      width: 600,
+      height: 900,
+    });
+  });
+
+  it("accepts the Storybook 9+ `{ value, isRotated }` global", () => {
+    const parameters = { viewport: { options: definitions } };
+    expect(getViewport(parameters, { value: "compact" })).toEqual({
+      width: 600,
+      height: 900,
+    });
+    expect(
+      getViewport(parameters, { value: "compact", isRotated: true }),
+    ).toEqual({ width: 900, height: 600 });
+  });
+
+  it("uses a number as the viewport width", () => {
+    expect(getViewport({}, 800)).toEqual({ width: 800, height: 720 });
+    expect(getViewport({}, { value: 800 })).toEqual({
+      width: 800,
+      height: 720,
+    });
+  });
+
+  it("returns null for the responsive viewport, unknown names or no global", () => {
+    const parameters = { viewport: { options: definitions } };
+    expect(getViewport(parameters, { value: undefined })).toBeNull();
+    expect(getViewport(parameters, "unknown")).toBeNull();
+    expect(getViewport(parameters, undefined)).toBeNull();
+    expect(getViewport(parameters, null)).toBeNull();
+    expect(getViewport({}, "compact")).toBeNull();
+  });
+});
+
+describe("getDefaultViewport", () => {
+  it("reads the legacy `viewport.defaultViewport` parameter", () => {
+    expect(
+      getDefaultViewport({
+        viewport: { viewports: definitions, defaultViewport: "widescreen" },
+      }),
+    ).toEqual({ width: 1440, height: 900 });
+  });
+
+  it("rotates the legacy default when `defaultOrientation` is landscape", () => {
+    expect(
+      getDefaultViewport({
+        viewport: {
+          options: definitions,
+          defaultViewport: "compact",
+          defaultOrientation: "landscape",
+        },
+      }),
+    ).toEqual({ width: 900, height: 600 });
+  });
+
+  it("returns null without a legacy default", () => {
+    expect(
+      getDefaultViewport({ viewport: { options: definitions } }),
+    ).toBeNull();
+    expect(getDefaultViewport({})).toBeNull();
+  });
+});

--- a/packages/storybook/src/utils/parameters.ts
+++ b/packages/storybook/src/utils/parameters.ts
@@ -2,6 +2,19 @@ import type { ViewportSize } from "playwright";
 
 export type StorybookGlobals = Record<string, any>;
 
+/**
+ * Value of the Storybook `viewport` global.
+ *
+ * Storybook 9+ stores it as `{ value, isRotated }`. Argos modes and older
+ * Storybook versions use the bare viewport name; a number is used as a width.
+ */
+export type StorybookViewportGlobal =
+  | string
+  | number
+  | { value?: string | number | null; isRotated?: boolean }
+  | null
+  | undefined;
+
 export type FitToContent = {
   /**
    * Padding around the content in pixels.
@@ -33,40 +46,77 @@ export interface ArgosStorybookParameters {
 
 export type StoryParameters = Record<string, any>;
 
+type ViewportDefinitions = Record<
+  string,
+  { styles?: { width?: string; height?: string } | null } | undefined
+>;
+
+/**
+ * Get the viewports defined in the Storybook `viewport` parameter.
+ * Storybook 9+ lists them under `options`, older versions under `viewports`.
+ */
+function getViewportDefinitions(
+  parameters: StoryParameters,
+): ViewportDefinitions | null {
+  const viewport = parameters?.viewport;
+  if (!viewport || typeof viewport !== "object") {
+    return null;
+  }
+  const definitions = viewport.options ?? viewport.viewports;
+  return definitions && typeof definitions === "object" ? definitions : null;
+}
+
 /**
  * Get the default viewport size from the Storybook parameters.
+ *
+ * `viewport.defaultViewport` (and `defaultOrientation`) were replaced by the
+ * `viewport` global in Storybook 9 and removed in Storybook 10. The global is
+ * resolved with `getViewport`; this only covers the legacy parameter.
  */
 export function getDefaultViewport(
   parameters: StoryParameters,
 ): ViewportSize | null {
   const defaultViewport = parameters?.viewport?.defaultViewport;
   if (defaultViewport) {
-    return getViewport(parameters, defaultViewport);
+    return getViewport(parameters, {
+      value: defaultViewport,
+      isRotated: parameters.viewport.defaultOrientation === "landscape",
+    });
   }
   return null;
 }
 
 /**
- * Get the viewport size from the Storybook parameters.
+ * Get the viewport size matching a `viewport` global.
  */
 export function getViewport(
   parameters: StoryParameters,
-  viewportName: string,
+  viewport: StorybookViewportGlobal,
 ): ViewportSize | null {
-  if (typeof viewportName === "number") {
-    return { width: viewportName, height: 720 };
+  const { value, isRotated } =
+    viewport && typeof viewport === "object"
+      ? {
+          value: viewport.value ?? null,
+          isRotated: Boolean(viewport.isRotated),
+        }
+      : { value: viewport ?? null, isRotated: false };
+
+  if (typeof value === "number") {
+    return { width: value, height: 720 };
   }
-  const viewports = parameters?.viewport?.viewports;
-  if (viewports && viewportName in viewports) {
-    if ("styles" in viewports[viewportName] && viewports[viewportName].styles) {
-      const width = parseInt(viewports[viewportName].styles.width, 10);
-      const height = parseInt(viewports[viewportName].styles.height, 10);
-      if (!isNaN(width) && !isNaN(height)) {
-        return { width, height };
-      }
-    }
+  if (!value) {
+    return null;
   }
-  return null;
+  const styles = getViewportDefinitions(parameters)?.[value]?.styles;
+  if (!styles) {
+    return null;
+  }
+  const width = parseInt(String(styles.width), 10);
+  const height = parseInt(String(styles.height), 10);
+  if (isNaN(width) || isNaN(height)) {
+    return null;
+  }
+  return isRotated ? { width: height, height: width } : { width, height };
 }
 
 /**

--- a/packages/storybook/src/utils/screenshot.ts
+++ b/packages/storybook/src/utils/screenshot.ts
@@ -290,10 +290,11 @@ async function runHooksAndScreenshot<Handler extends Page | Frame>(args: {
 
   await runStory({ handler, globals, storyId: context.story.id });
 
-  // Get the viewport from globals set on the mode.
-  const viewportFromGlobals = globals.viewport
-    ? getViewport(context.story.parameters, globals.viewport)
-    : null;
+  // Get the viewport from the globals (set by the Argos mode or the story).
+  const viewportFromGlobals = getViewport(
+    context.story.parameters,
+    globals.viewport,
+  );
 
   const viewport =
     viewportFromGlobals ??

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -67,7 +67,7 @@
     "@vitest/browser": "^5.0.0",
     "@vitest/browser-playwright": "^5.0.0",
     "@vitest/pretty-format": "^5.0.0",
-    "playwright": "^1.62.1",
+    "playwright": "^1.63.0",
     "vitest": "catalog:"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
         version: 4.4.3(supports-color@10.2.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.62.1
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
       '@types/debug':
         specifier: ^4.1.13
         version: 4.1.13
@@ -325,8 +325,8 @@ importers:
         specifier: ^10.5.5
         version: 10.5.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.25.12)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@storybook/test-runner':
-        specifier: ^0.24.4
-        version: 0.24.4(@types/node@22.20.1)(debug@4.4.3(supports-color@10.2.2))(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(supports-color@10.2.2)
+        specifier: ^0.24.5
+        version: 0.24.5(@types/node@22.20.1)(debug@4.4.3(supports-color@10.2.2))(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(supports-color@10.2.2)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -341,7 +341,7 @@ importers:
         version: 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/browser-playwright':
         specifier: ^5.0.0
-        version: 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.62.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
+        version: 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.63.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/coverage-v8':
         specifier: ^5.0.0
         version: 5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0)
@@ -352,8 +352,8 @@ importers:
         specifier: ^14.1.1
         version: 14.1.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       playwright:
-        specifier: ^1.62.1
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -408,13 +408,13 @@ importers:
         version: 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/browser-playwright':
         specifier: ^5.0.0
-        version: 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.62.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
+        version: 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.63.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/pretty-format':
         specifier: ^5.0.0
         version: 5.0.0
       playwright:
-        specifier: ^1.62.1
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
       vitest:
         specifier: 'catalog:'
         version: 5.0.0(@types/node@22.20.1)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -2070,8 +2070,8 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.62.1':
-    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2564,12 +2564,12 @@ packages:
       typescript:
         optional: true
 
-  '@storybook/test-runner@0.24.4':
-    resolution: {integrity: sha512-xm04bba5N7QyHHc+wD4xmPZx0vKK/PIpmTFypy445HrWOj0nFK4pYg5dE6H4ppqMt7qZAnb5GfHTvBwJtywJ4A==}
+  '@storybook/test-runner@0.24.5':
+    resolution: {integrity: sha512-U8ib6parBD+wA4z5ZW/JnsR3KkEXoP+sHP8WJdDZeh0GwfTlcWjhbeR6Ij/gxNFEA1bdpBa/P8qYTOs+LKIN1g==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
-      storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0
+      storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0 || ^11.0.0-0
 
   '@swc/core-darwin-arm64@1.15.47':
     resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
@@ -4798,11 +4798,6 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6393,10 +6388,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.7:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
@@ -6413,13 +6404,13 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.62.1:
-    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
     engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.62.1:
-    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -7187,10 +7178,6 @@ packages:
     resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
     engines: {node: '>=20.0.0'}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -7735,18 +7722,6 @@ packages:
     resolution: {integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  ws@8.21.1:
-    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -8103,7 +8078,7 @@ snapshots:
       '@commitlint/load': 21.2.0(@types/node@26.1.2)(typescript@6.0.3)
       '@commitlint/read': 21.2.1(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.2)
       '@commitlint/types': 21.2.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       yargs: 18.1.0
     transitivePeerDependencies:
       - '@types/node'
@@ -8173,7 +8148,7 @@ snapshots:
       '@commitlint/top-level': 21.2.0
       '@commitlint/types': 21.2.0
       '@conventional-changelog/git-client': 3.1.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.2)
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
@@ -9586,9 +9561,9 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@playwright/test@1.62.1':
+  '@playwright/test@1.63.0':
     dependencies:
-      playwright: 1.62.1
+      playwright: 1.63.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -9700,7 +9675,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.5
+      picomatch: 4.0.7
     optionalDependencies:
       rollup: 4.62.2
 
@@ -9913,7 +9888,7 @@ snapshots:
       storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
     optionalDependencies:
       '@vitest/browser': 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
-      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.62.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
+      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.63.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/runner': 4.1.10
       vitest: 5.0.0(@types/node@22.20.1)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -9995,7 +9970,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.4(@types/node@22.20.1)(debug@4.4.3(supports-color@10.2.2))(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(supports-color@10.2.2)':
+  '@storybook/test-runner@0.24.5(@types/node@22.20.1)(debug@4.4.3(supports-color@10.2.2))(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.8
@@ -10014,8 +9989,8 @@ snapshots:
       jest-serializer-html: 7.1.0
       jest-watch-typeahead: 3.0.1(jest@30.4.2(@types/node@22.20.1)(supports-color@10.2.2))
       nyc: 15.1.0(supports-color@10.2.2)
-      playwright: 1.62.1
-      playwright-core: 1.62.1
+      playwright: 1.63.0
+      playwright-core: 1.63.0
       rimraf: 3.0.2
       storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
       uuid: 8.3.2
@@ -10500,11 +10475,11 @@ snapshots:
     dependencies:
       '@actions/github': 6.0.1
 
-  '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.62.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)':
+  '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.63.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)':
     dependencies:
       '@vitest/browser': 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-      playwright: 1.62.1
+      playwright: 1.63.0
       tinyrainbow: 3.1.1
       vitest: 5.0.0(@types/node@22.20.1)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -10513,11 +10488,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)':
+  '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.63.0)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)':
     dependencies:
       '@vitest/browser': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-      playwright: 1.62.1
+      playwright: 1.63.0
       tinyrainbow: 3.1.1
       vitest: 5.0.0(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -12404,9 +12379,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.5):
+  fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
-      picomatch: 4.0.5
+      picomatch: 4.0.7
 
   fflate@0.8.3: {}
 
@@ -12527,9 +12502,6 @@ snapshots:
       minipass: 7.1.3
 
   fs.realpath@1.0.0: {}
-
-  fsevents@2.3.2:
-    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -13307,7 +13279,7 @@ snapshots:
       jest-regex-util: 30.4.0
       jest-util: 30.4.1
       jest-worker: 30.4.1
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -13366,7 +13338,7 @@ snapshots:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       jest-util: 30.4.1
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -13533,7 +13505,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.5
+      picomatch: 4.0.7
 
   jest-validate@30.4.1:
     dependencies:
@@ -14841,8 +14813,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.5: {}
-
   picomatch@4.0.7: {}
 
   pify@2.3.0: {}
@@ -14853,13 +14823,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.62.1: {}
+  playwright-core@1.63.0: {}
 
-  playwright@1.62.1:
+  playwright@1.63.0:
     dependencies:
-      playwright-core: 1.62.1
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright-core: 1.63.0
 
   pluralize@8.0.0: {}
 
@@ -14991,7 +14959,7 @@ snapshots:
       devtools-protocol: 0.0.1653615
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.2
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - proxy-agent
@@ -15594,7 +15562,7 @@ snapshots:
       recast: 0.23.19
       semver: 7.8.5
       use-sync-external-store: 1.6.0(react@19.2.8)
-      ws: 8.21.1
+      ws: 8.21.3
     optionalDependencies:
       '@types/react': 19.2.18
       prettier: 3.9.6
@@ -15772,19 +15740,17 @@ snapshots:
 
   tinybench@6.1.4: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.12:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
   tinypool@2.1.0: {}
 
@@ -15851,10 +15817,10 @@ snapshots:
       hookable: 6.1.1
       import-without-cache: 0.4.0
       obug: 2.1.4
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       rolldown: 1.2.1
       rolldown-plugin-dts: 0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.1)(typescript@6.0.3)
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
@@ -15983,7 +15949,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.18.0
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.12.2:
@@ -16069,8 +16035,8 @@ snapshots:
   vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
       postcss: 8.5.15
       rollup: 4.62.2
       tinyglobby: 0.2.17
@@ -16084,8 +16050,8 @@ snapshots:
   vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
       postcss: 8.5.15
       rollup: 4.62.2
       tinyglobby: 0.2.17
@@ -16114,7 +16080,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
-      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.62.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
+      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(playwright@1.63.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/coverage-v8': 5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0)
       '@vitest/ui': 5.0.0(vitest@5.0.0)
     transitivePeerDependencies:
@@ -16138,7 +16104,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.2
-      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
+      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.63.0)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@5.0.0)
       '@vitest/coverage-v8': 5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0)
       '@vitest/ui': 5.0.0(vitest@5.0.0)
     transitivePeerDependencies:
@@ -16217,7 +16183,7 @@ snapshots:
       deepmerge-ts: 7.1.5
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
       undici: 8.9.0
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -16350,8 +16316,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
-
-  ws@8.21.1: {}
 
   ws@8.21.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ catalog:
   vitest: ^5.0.0
 
 allowBuilds:
+  '@parcel/watcher': false
   '@swc/core': true
   chromedriver: true
   cypress: true

--- a/turbo.json
+++ b/turbo.json
@@ -75,6 +75,19 @@
       ],
       "dependsOn": ["build-e2e"],
       "outputs": []
+    },
+    "e2e-next": {
+      "cache": false,
+      "env": [
+        "ARGOS_TOKEN",
+        "USER_ACCESS_TOKEN",
+        "ARGOS_BUILD_NUMBER",
+        "NODE_VERSION",
+        "OS",
+        "GITHUB_*"
+      ],
+      "dependsOn": ["build-e2e"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
Makes `@argos-ci/storybook` compatible with Storybook 11, checked point by point against the [addon migration guide](https://storybook.js.org/docs/11/addons/addon-migration-guide) and the [10 → 11 migration notes](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-10x-to-1100).

Storybook 11 is only available as `11.0.0-alpha.0` (`next` tag) today. The package has no manager or preview code, so most of the guide does not apply (no `definePreviewAddon`, `setConfig` layout options, `TAB` addon type, `useThemeParameters`, icons, or index parsing). What did apply is below.

## Changes

- **Peer range.** The package never declared `storybook` as a peer dependency. It now declares `^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0-0`. 8 is included because the Test Runner flow has no runtime dependency on the `storybook` package and the docs list Storybook 8+ for it; the Vitest flow needs 9+ (`@storybook/addon-vitest` and `storybook/preview-api` only exist from 9). `^11.0.0-0` keeps the 11 pre-releases in range, as `@storybook/test-runner` does.
- **Viewport parameters.** Storybook 9 renamed `viewport.viewports` to `viewport.options` and turned the `viewport` global into `{ value, isRotated }`; Storybook 10 removed `defaultViewport`. `getViewport` only understood the legacy shapes, so an Argos mode such as `{ viewport: "ipad" }` silently kept the default size on a current config. It now reads `options` first and falls back to `viewports`, accepts string, number and `{ value, isRotated }` globals, and honors rotation (including the legacy `defaultOrientation: "landscape"`). Unit tests added. The fixture preview moved to `options`, and the mode screenshots' metadata confirms the sizes (mobile 428×926, tablet 768×1024).
- **CI.** New `e2e-storybook-next` job: upgrades the package to the newest Storybook 11 pre-release (`>=11.0.0-0 <12.0.0-0` ranges, so `minimumReleaseAge` still applies) and runs the Vitest suite under its own build name, mirroring the Vitest 4 compat job. Backed by an `e2e-next` script and Turborepo task.
- **Dependencies.** `@storybook/test-runner` 0.24.4 → 0.24.5, the first release declaring `^11.0.0-0`. When its Jest dependencies are re-resolved (as `pnpm up` did locally), Jest 30.5 pulls in `@parcel/watcher`, whose install script pnpm 11 refuses (`ERR_PNPM_IGNORED_BUILDS`) and fails the install; it is denied in `allowBuilds` so neither the workspace nor the Storybook 11 job trips on it. Playwright 1.62.1 → 1.63.0 across the three packages so the workspace and the test runner resolve one `playwright-core` (otherwise `tsc` fails on two incompatible `Page` types).
- **README.** Short compatibility section.

## Verification

| Check | Storybook 10.5.5 | Storybook 11.0.0-alpha.0 |
|---|---|---|
| build, tsc, lint, unit tests | ✅ | ✅ |
| `storybook build` | ✅ | ✅ |
| Vitest e2e (15 stories, 28 screenshots) | ✅ | ✅ |
| Test Runner e2e (15 stories, 26 screenshots) | ✅ | ❌ upstream |

Every internal the package touches still exists in 11: `addons.hasChannel`/`setChannel`, `storybook/internal/channels`, `ComposedStoryFn`, the `__STORYBOOK_PREVIEW__` and `__STORYBOOK_ADDONS_PREVIEW` globals, `channel.last`, the `globalsUpdated` payload's `initialGlobals`, and `context.story` in the Vitest addon.

The Test Runner failure on 11 is not ours: Storybook 11's `importModule` (used by `serverRequire` to load `.storybook/test-runner.ts`) now calls `module.register()`, which jest-runtime 30 rejects ("module.register() is not supported in Jest") before any Argos code loads. No upstream issue exists yet. The new CI job therefore covers the Vitest flow only, with a comment saying why.

## Review notes

- Behavior change: a story or preview that sets the modern `globals.viewport` (for example `{ value: "mobile1" }`) is now screenshotted at that size instead of the default. This matches what Storybook renders and how the legacy `defaultViewport` was already honored, but it can move baselines for users who relied on the global being ignored.
- Companion docs PR: argos-ci/docs#255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
